### PR TITLE
Exclude documentation from the build workflow

### DIFF
--- a/.github/workflows/editor.yml
+++ b/.github/workflows/editor.yml
@@ -3,7 +3,13 @@ name: Windows (MSYS2 UCRT64)
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
 
 jobs:
   build-windows:


### PR DESCRIPTION
This PR adjusts the GitHub workflow to exclude documentation files from triggering a build of the project.

The excluded files are:
* Any .md file
* Any file within docs/