### PR TITLE
editor: Try to use existing toolchain on Windows if it exists.

### DIFF
--- a/src/editor/pages/parts/toolchainOverlay.cpp
+++ b/src/editor/pages/parts/toolchainOverlay.cpp
@@ -143,8 +143,10 @@ bool Editor::ToolchainOverlay::draw()
       {
         if(allDone) {
           ImGui::Text(
+            "Toolchain found in: %s\n"
             "The N64 toolchain is correctly installed.\n"
-            "If you wish to update it, press the update button below."
+            "If you wish to update it, press the update button below.",
+            ctx.toolchain.getState().toolchainPath.string().c_str()
           );
         } else if(STEP_DONE[0]) {
           ImGui::Text(

--- a/src/utils/toolchain.cpp
+++ b/src/utils/toolchain.cpp
@@ -27,47 +27,41 @@ void Utils::Toolchain::scan()
       return;
     }
 
-    //printf("Mingw Path: %s\n", state.mingwPath.string().c_str());
     if(state.mingwPath.empty())return;
 
-    auto toolPath = state.mingwPath / "pyrite64-sdk";
-    if(fs::exists(toolPath / "bin" / "mips64-elf-gcc.exe")
-     && fs::exists(toolPath / "bin" / "mips64-elf-g++.exe")) {
-      state.hasToolchain = true;
-    }
+    const char* n64InstEnv = std::getenv("N64_INST");
+    // If N64_INST is defined in the system, the user probably already
+    // has a working toolchain installation so try to use it.
+    state.toolchainPath = (n64InstEnv != nullptr)?
+      fs::path{n64InstEnv} : state.mingwPath / "pyrite64-sdk";
 
-    if(fs::exists(toolPath / "bin" / "n64tool.exe")
-     && fs::exists(toolPath / "bin" / "mkdfs.exe")
-     && fs::exists(toolPath / "include" / "n64.mk")
-    ) {
-      state.hasLibdragon = true;
-    }
+    state.hasToolchain = fs::exists(state.toolchainPath / "bin" / "mips64-elf-gcc.exe")
+                       && fs::exists(state.toolchainPath / "bin" / "mips64-elf-g++.exe");
 
-    if(fs::exists(toolPath / "bin" / "gltf_to_t3d.exe")
-     && fs::exists(toolPath / "include" / "t3d.mk")
-     && fs::exists(toolPath / "mips64-elf" / "include" / "t3d")
-    ) {
-      state.hasTiny3d = true;
-    }
-    
+    state.hasLibdragon = fs::exists(state.toolchainPath / "bin" / "n64tool.exe")
+                       && fs::exists(state.toolchainPath / "bin" / "mkdfs.exe")
+                       && fs::exists(state.toolchainPath / "include" / "n64.mk");
+
+    state.hasTiny3d = fs::exists(state.toolchainPath / "bin" / "gltf_to_t3d.exe")
+                    && fs::exists(state.toolchainPath / "include" / "t3d.mk")
+                    && fs::exists(state.toolchainPath / "mips64-elf" / "include" / "t3d");
 
   #else
     char* n64InstEnv = getenv("N64_INST");
     if(n64InstEnv) {
-      state.mingwPath = fs::path{n64InstEnv};
+      state.toolchainPath = fs::path{n64InstEnv};
     }
-    if(state.mingwPath.empty())return;
+    if(state.toolchainPath.empty())return;
 
-    state.hasToolchain = fs::exists(state.mingwPath / "bin" / "mips64-elf-gcc");
+    state.hasToolchain = fs::exists(state.toolchainPath / "bin" / "mips64-elf-gcc");
     if(!state.hasToolchain)return;
 
-    fs::path n64Path{n64InstEnv};
-    state.hasLibdragon = fs::exists(n64Path / "bin" / "n64tool")
-                       && fs::exists(n64Path / "bin" / "mkdfs")
-                       && fs::exists(n64Path / "include" / "n64.mk");
-    state.hasTiny3d = fs::exists(n64Path / "bin" / "gltf_to_t3d")
-                    && fs::exists(n64Path / "include" / "t3d.mk")
-                    && fs::exists(n64Path / "mips64-elf" / "include" / "t3d");
+    state.hasLibdragon = fs::exists(state.toolchainPath / "bin" / "n64tool")
+                       && fs::exists(state.toolchainPath / "bin" / "mkdfs")
+                       && fs::exists(state.toolchainPath / "include" / "n64.mk");
+    state.hasTiny3d = fs::exists(state.toolchainPath / "bin" / "gltf_to_t3d")
+                    && fs::exists(state.toolchainPath / "include" / "t3d.mk")
+                    && fs::exists(state.toolchainPath / "mips64-elf" / "include" / "t3d");
   #endif
 }
 

--- a/src/utils/toolchain.h
+++ b/src/utils/toolchain.h
@@ -15,6 +15,7 @@ namespace Utils
       struct State
       {
         fs::path mingwPath{}; // empty if not found, always empty on linux
+        fs::path toolchainPath{}; // empty if not found
         bool hasToolchain{};
         bool hasLibdragon{};
         bool hasTiny3d{};


### PR DESCRIPTION
Work towards #15 

Adds a check for N64_INST on Windows to attempt to use that path as toolchain. Allows users to use pre-existing toolchain installation. Displays the detected toolchain installation path in the installer window to be transparent.

Not implemented in this PR: Configuration that would allow the user to choose a specific toolchain installation. Currently, it's either system's N64_INST, or pyrite-installed `pyrite64-sdk`.