### PR TITLE
mingw: Fix libdragon installation on a clean system

### DIFF
--- a/data/scripts/mingw_create_env.sh
+++ b/data/scripts/mingw_create_env.sh
@@ -13,9 +13,16 @@ export N64_INST=$sdkpath
 
 echo "Updating MSYS2 environment..."
 
+if pacman -Qu | grep -Eq '^(msys2-runtime|bash|pacman)\s'; then
+    msysUpdate=true
+else
+    msysUpdate=false
+fi
+
 pacman -Syyu --noconfirm
-if pacman -Q pacman | grep -q "->"; then
-    echo "Core MSYS2 update occurred. Please close this window and start the installation again."
+
+if $msysUpdate; then
+    echo "Core MSYS2 components were updated. Please close this window and start the installation again."
     exit 1
 fi
 
@@ -63,7 +70,7 @@ cd libdragon
 
 git checkout preview
 git pull
-make clean && make -C tools clean && make -C examples/brew-volley clean
+make clean && make -C tools clean
 
 # Build libdragon
 if [[ ! -f "$sdkpath/bin/n64tool.exe" || "${FORCE_UPDATE:-}" == "true" ]]; then
@@ -72,6 +79,7 @@ if [[ ! -f "$sdkpath/bin/n64tool.exe" || "${FORCE_UPDATE:-}" == "true" ]]; then
     make install || sudo -E make install
     make -C tools install || sudo -C tools install
     # Build an example as sanity check
+    make -C examples/brew-volley clean
     make -C examples/brew-volley
 else
     echo "Libdragon already installed"    


### PR DESCRIPTION
Fix #52 

I was trying to clean an example even before installing for the first time which meant there was no `n64.mk` present which caused an error while parsing the example's Makefile.

I also updated the condition that checks if MSYS2 had update to packages that require restart of the shell to a new approach because it seems my previous attempt didn't work properly.