### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/editor.yml
+++ b/.github/workflows/editor.yml
@@ -27,7 +27,7 @@ jobs:
           lfs: true
 
       - name: Setup MSYS2 (UCRT64)
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@v2.30.0
         with:
           msystem: UCRT64
           update: true


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `msys2/setup-msys2` | [`v2`](https://github.com/msys2/setup-msys2/releases/tag/v2) | [`v2.30.0`](https://github.com/msys2/setup-msys2/releases/tag/v2.30.0) | [Release](https://github.com/msys2/setup-msys2/releases/tag/v2.30.0) | editor.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
