### PR TITLE
editor: Use app-named subfolder in default project path

### DIFF
--- a/src/editor/pages/parts/createProjectOverlay.cpp
+++ b/src/editor/pages/parts/createProjectOverlay.cpp
@@ -63,6 +63,8 @@ void Editor::CreateProjectOverlay::open()
     projectPath = (home && *home) ? home : ".";
     projectPath = expandHomePath(projectPath);
   }
+  fs::path p = fs::path(projectPath) / "pyrite64";
+  projectPath = p.string();
 }
 
 bool Editor::CreateProjectOverlay::draw()


### PR DESCRIPTION
Windows guidelines are that an app shouldn't store user files in the root of `~\Documents` but should create an app-identified subfolder. Let's enforce this by default in the Create Project dialog.