### PR TITLE
projectBuild: Use system N64_INST on Windows, if set

### DIFF
--- a/src/build/projectBuilder.cpp
+++ b/src/build/projectBuilder.cpp
@@ -57,19 +57,15 @@ bool Build::buildProject(const std::string &configPath)
 
   if(project.conf.pathN64Inst.empty())
   {
-    // read env
-  #if defined(_WIN32)
-    /*char* n64InstEnv = nullptr;
-    size_t envSize = 0;
-    if(_dupenv_s(&n64InstEnv, &envSize, "N64_INST") == 0 && n64InstEnv != nullptr) {
-      project.conf.pathN64Inst = n64InstEnv;
-      free(n64InstEnv);
-    }*/
-   project.conf.pathN64Inst = "/pyrite64-sdk";
-  #else
+    // read N64_INST from environment
     char* n64InstEnv = getenv("N64_INST");
     if(n64InstEnv != nullptr) {
       project.conf.pathN64Inst = n64InstEnv;
+    }
+  // On Windows, fall back to pyrite64-sdk (autoinstaller location) if not explicitly set by the user. 
+  #if defined(_WIN32)
+    else {
+      project.conf.pathN64Inst = "/pyrite64-sdk";
     }
   #endif
   } else {


### PR DESCRIPTION
Missed during #26 

N64_INST during project building was still hardcoded to `/pyrite64-sdk`. This PR reads N64_INST from the environment (like on Linux) and falls back to `/pyrite64-sdk` only if not set.