### PR TITLE
fix: destroy editorScene before renderer scene goes out of scope

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -393,10 +393,8 @@ int main(int argc, char** argv)
         }
       }
     }
+    ctx.editorScene.reset();
   }
-
-  // needs to be destroyed before GPU teardown
-  ctx.editorScene.reset();
 
   SDL_WaitForGPUIdle(ctx.gpu);
 


### PR DESCRIPTION
Hello, this fix is based on @rasky solution. I tested it on a Windows machine and it worked.

It fixes the heap corruption crash (STATUS_HEAP_CORRUPTION 0xc0000374) on exit.

`ctx.editorScene.reset()` was happening after the inner scope ended, so the stack-allocated `Renderer::Scene` had already been destroyed. Then `Viewport3D`’s destructor ran and tried to call `removeRenderPass` / `removeCopyPass` / `removePostRenderCallback` on `unordered_map`s that were already dead in memory.

moving the reset inside the scope, teardown happens while the scene is still alive, so those removals are safe.

Closes #99 