### PR TITLE
editor: Fix 'Show in Explorer' not opening correct folder sometimes

### DIFF
--- a/src/editor/pages/parts/assetsBrowser.cpp
+++ b/src/editor/pages/parts/assetsBrowser.cpp
@@ -602,9 +602,10 @@ void Editor::AssetsBrowser::showContextMenu(const std::string& path) {
 
 void Editor::AssetsBrowser::showInFileBrowser(const std::string& path) {
 #if defined(_WIN32)
+  std::string explorerArgs = "/select," + path;
   const char* args[] = {
     "explorer.exe",
-    ("/select," + path).c_str(),
+    explorerArgs.c_str(),
     NULL
   };
 #elif defined(__APPLE__)


### PR DESCRIPTION
Fix #149 

Taking `c_str()` from a temporary string is a nono- sometimes the memory would get overwritten with garbage before the string reached `explorer.exe`