### PR TITLE
Add Tooltips to Toggle Buttons

### DIFF
--- a/src/editor/imgui/helper.h
+++ b/src/editor/imgui/helper.h
@@ -584,6 +584,7 @@ namespace ImTable
           obj->removePropOverride(prop);
         }
       }
+      ImGui::SetItemTooltip("%s Override", isOverrideLocal ? "Disable" : "Enable");
       ImGui::SameLine();
     }
 

--- a/src/editor/pages/parts/sceneGraph.cpp
+++ b/src/editor/pages/parts/sceneGraph.cpp
@@ -122,6 +122,7 @@ namespace
     if (obj.parent && ImGui::BeginDragDropSource())
     {
       ImGui::SetDragDropPayload("OBJECT", &obj.uuid, sizeof(obj.uuid));
+      ImGui::TextUnformatted(obj.name.c_str());
       ImGui::EndDragDropSource();
     }
 
@@ -149,8 +150,10 @@ namespace
 
       int clicked = 0;
       clicked |= ImGui::IconToggle(obj.selectable, ICON_MDI_CURSOR_DEFAULT, ICON_MDI_CURSOR_DEFAULT_OUTLINE, iconSize);
+      ImGui::SetItemTooltip("%s Object Selection", obj.selectable ? "Disable" : "Enable");
       ImGui::SameLine(0, spacing);
       clicked |= ImGui::IconToggle(obj.enabled, ICON_MDI_CHECKBOX_MARKED, ICON_MDI_CHECKBOX_BLANK_OUTLINE, iconSize);
+      ImGui::SetItemTooltip("%s Object", obj.enabled ? "Disable" : "Enable");
 
       if(clicked)nodeIsClicked = false;
 

--- a/src/editor/pages/parts/viewport3D.cpp
+++ b/src/editor/pages/parts/viewport3D.cpp
@@ -508,6 +508,7 @@ void Editor::Viewport3D::draw()
   //ImGui::Text("Viewport: %f | %f | %08X", mousePos.x, mousePos.y, ctx.selObjectUUID);
 
   constexpr const char* const GIZMO_LABELS[3] = {ICON_MDI_CURSOR_MOVE, ICON_MDI_ROTATE_360, ICON_MDI_ARROW_EXPAND};
+  constexpr const char* const GIZMO_TOOLTIPS[3] = {"Translate", "Rotate", "Scale"};
   for (int i=0; i<3; ++i) {
     if (ConnectedToggleButton(
       GIZMO_LABELS[i],
@@ -517,6 +518,7 @@ void Editor::Viewport3D::draw()
     )) {
       gizmoOp = i;
     }
+    ImGui::SetItemTooltip("%s", GIZMO_TOOLTIPS[i]);
   }
 
   ImGui::SameLine();
@@ -524,6 +526,7 @@ void Editor::Viewport3D::draw()
   if (ConnectedToggleButton(ICON_MDI_WEB, isTransWorld, true, true, ImVec2(32,24))) {
     isTransWorld = !isTransWorld;
   }
+  ImGui::SetItemTooltip("Show %s Space", isTransWorld ? "Local" : "World");
 
   ImGui::SameLine();
   ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 12);
@@ -531,18 +534,21 @@ void Editor::Viewport3D::draw()
   if(ConnectedToggleButton(ICON_MDI_GRID, showGrid, true, true, ImVec2(32,24))) {
     showGrid = !showGrid;
   }
+  ImGui::SetItemTooltip("%s Grid", showGrid ? "Hide" : "Show");
 
   ImGui::SameLine();
   ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 4);
   if(ConnectedToggleButton(ICON_MDI_LANDSLIDE_OUTLINE, showCollMesh, true, true, ImVec2(32,24))) {
     showCollMesh = !showCollMesh;
   }
+  ImGui::SetItemTooltip("%s Collision Mesh", showCollMesh ? "Hide" : "Show");
 
   ImGui::SameLine();
   ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 4);
   if(ConnectedToggleButton(ICON_MDI_CYLINDER, showCollObj, true, true, ImVec2(32,24))) {
     showCollObj = !showCollObj;
   }
+  ImGui::SetItemTooltip("%s Collision Bodies", showCollObj ? "Hide" : "Show");
 
   ImGui::SetCursorPosY(currPos.y + BAR_HEIGHT);
 


### PR DESCRIPTION
add tooltips to icon toggle buttons, show name of object when dragging from the scene graph

- added tooltips to the icon toggles on top of the viewport
- added tooltip for property overrides for prefab instances (lock icon)
- added tooltips for making an object in the scene graph selectable or to disable/enable it