### PR TITLE
Fix scene name not updating in the scene browser

### DIFF
--- a/src/editor/pages/parts/assetsBrowser.cpp
+++ b/src/editor/pages/parts/assetsBrowser.cpp
@@ -499,12 +499,16 @@ void Editor::AssetsBrowser::draw() {
       auto activeScene = ctx.project->getScenes().getLoadedScene();
 
       bool isSelected = activeScene && (activeScene->getId() == scene.id);
+      const auto &liveName = isSelected ? activeScene->getName() : scene.name;
+      const auto &displayName = liveName.empty() ? "(unnamed)" : liveName;
+      auto buttonLabel = displayName + "##" + std::to_string(scene.id);
+
       if(isSelected) {
         ImGui::PushStyleColor(ImGuiCol_Button, {0.5f,0.5f,0.7f,1});
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, {0.5f,0.5f,0.7f,0.8f});
       }
 
-      if (ImGui::Button(scene.name.c_str(), textBtnSize)) {
+      if (ImGui::Button(buttonLabel.c_str(), textBtnSize)) {
         ctx.project->getScenes().loadScene(scene.id);
         ctx.project->conf.sceneIdLastOpened = scene.id;
         ctx.project->saveConfig();
@@ -514,7 +518,7 @@ void Editor::AssetsBrowser::draw() {
 
       if(ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
       {
-        ImGui::SetTooltip("Scene: %s\nID: %d", scene.name.c_str(), scene.id);
+        ImGui::SetTooltip("Scene: %s\nID: %d", displayName.c_str(), scene.id);
       }
     }
   }

--- a/src/project/scene/sceneManager.cpp
+++ b/src/project/scene/sceneManager.cpp
@@ -96,6 +96,7 @@ void Project::SceneManager::loadScene(int id) {
   if (loadedScene) {
     loadedScene->save();
     delete loadedScene;
+    reload(); // ensure names are up to date in case the loaded scene was renamed
   }
   //if we load a scene we should clear the undo history
   Editor::UndoRedo::getHistory().clear();


### PR DESCRIPTION
The scene browser reads scene names from a cached entries list that is only populated on reload() (e.g. at project open or when a new scene is created). Editing a scene's name in the inspector updates the in-memory Scene object but doesn't sync back to the entries list, so the browser button continued showing the stale name until the editor was restarted.

Updates SceneManager::loadScene to call reload() if there's a outgoing scene, so the entries list reflects any name changes when switching scenes.
And updates the scene browser buttons to use the "live" name (activeScene->getName()) for the currently loaded scene's button instead of the cached entry name, so edits are reflected immediately without needing to switch away first.
