### PR TITLE
Enable setting Prefabs in the editor / code-component arguments

### DIFF
--- a/n64/engine/include/assets/assetManager.h
+++ b/n64/engine/include/assets/assetManager.h
@@ -62,4 +62,14 @@ namespace P64
       return ptr;
     }
   };
+
+  struct PrefabRef
+  {
+    uint32_t idx;
+
+    inline uint32_t get()
+    {
+      return idx;
+    }
+  };
 }

--- a/src/project/component/types/compCode.cpp
+++ b/src/project/component/types/compCode.cpp
@@ -85,7 +85,7 @@ namespace Project::Component::Code
         ctx.fileObj.write<uint32_t>(objId);
       } else if(field.type == Utils::DataType::PREFAB){
         uint64_t uuid = Utils::parseU64(val);
-        ctx.fileObj.write<uint32_t>(0x4552434B);//ctx.assetUUIDToIdx[uuid]);
+        ctx.fileObj.write<uint32_t>(ctx.assetUUIDToIdx[uuid]);
       } else {
         ctx.fileObj.writeAs(val, field.type);
       }

--- a/src/project/component/types/compCode.cpp
+++ b/src/project/component/types/compCode.cpp
@@ -83,6 +83,9 @@ namespace Project::Component::Code
         auto refObj = ctx.scene ? ctx.scene->getObjectByUUID(uuid) : nullptr;
         uint16_t objId = refObj ? refObj->id : 0;
         ctx.fileObj.write<uint32_t>(objId);
+      } else if(field.type == Utils::DataType::PREFAB){
+        uint64_t uuid = Utils::parseU64(val);
+        ctx.fileObj.write<uint32_t>(0x4552434B);//ctx.assetUUIDToIdx[uuid]);
       } else {
         ctx.fileObj.writeAs(val, field.type);
       }
@@ -142,6 +145,12 @@ namespace Project::Component::Code
 
             uint32_t uuid = static_cast<uint32_t>(Utils::parseU64(data.args[field.name].value));
             ImTable::addObjectVecComboBox(name, objList, uuid, [&](uint32_t newId) {
+              data.args[field.name].value = std::to_string(newId);
+            });
+          } else if(field.type == Utils::DataType::PREFAB) {
+            const auto &prefabs = ctx.project->getAssets().getTypeEntries(FileType::PREFAB);
+            uint64_t uuid = Utils::parseU64(data.args[field.name].value);
+            ImTable::addAssetVecComboBox(name, prefabs, uuid, [&](uint64_t newId) {
               data.args[field.name].value = std::to_string(newId);
             });
           } else {

--- a/src/utils/binaryFile.h
+++ b/src/utils/binaryFile.h
@@ -23,7 +23,8 @@ namespace Utils
     u8, s8, u16, s16, u32, s32,
     f32, string,
     ASSET_SPRITE,
-    OBJECT_REF
+    OBJECT_REF,
+    PREFAB,
   };
 
   class BinaryFile
@@ -115,6 +116,7 @@ namespace Utils
           case u8: write<uint8_t>(std::stoul(str)); break;
           case s8: write<int8_t>(std::stol(str)); break;
           case OBJECT_REF: write<uint32_t>(std::stoul(str)); break;
+          case PREFAB: write<uint32_t>(std::stoul(str)); break;
           case string:
             for(char c : str)write<uint8_t>(c);
             write<uint8_t>(0);

--- a/src/utils/codeParser.cpp
+++ b/src/utils/codeParser.cpp
@@ -25,6 +25,7 @@ namespace
     if (str == "float") return Utils::DataType::f32;
     if (str == "char") return Utils::DataType::string;
     if (str == "AssetRef<sprite_t>") return Utils::DataType::ASSET_SPRITE;
+    if (str == "PrefabRef") return Utils::DataType::PREFAB;
     if (str == "ObjectRef" || str == "P64::ObjectRef" || str.rfind("ObjectRef<", 0) == 0 || str.find("::ObjectRef<") != std::string::npos) return Utils::DataType::OBJECT_REF;
     return Utils::DataType::s32;
   }
@@ -42,6 +43,7 @@ namespace
       case Utils::DataType::f32:
       case Utils::DataType::ASSET_SPRITE:
       case Utils::DataType::OBJECT_REF:
+      case Utils::DataType::PREFAB:
       default:
         return 4;
     }


### PR DESCRIPTION
This adds a `PrefabRef` type that can be exposed to the editor to enable linking prefabs to objects.

I tested using this script:
```
#include "script/userScript.h"
#include "scene/sceneManager.h"

#include "../p64/assetTable.h"

#include <libdragon.h>
#include <vector>

namespace
{
    // A prefab that we can use to verify the PrefabRef is working.
    constexpr uint32_t desiredPrefab = "MoverBox"_prefab;
}

namespace P64::Script::C7FE1C17E01A05A5
{
    P64_DATA(

        [[P64::Name("Prefab To Spawn")]]
        PrefabRef prefabToSpawn;

        [[P64::Name("Max Alive")]]
        uint8_t maxToLive = 1;

        std::vector<ObjectRef> objects;	
    );

    void init(Object& obj, Data *data)
    {
        data->objects = {};
        data->objects.reserve(data->maxToLive);
    }

    void destroy(Object& obj, Data *data)
    {
        for(ObjectRef& obj : data->objects)
        {
            if(obj) obj->remove();
        }
        data->objects.clear();
    }

    void spawn(Object& obj, Data *data)
    {
        if(data->objects.size() >= data->maxToLive) return;


        ObjectRef newObjIdx;
        newObjIdx.id = obj.getScene().addObject(data->prefabToSpawn.get(), obj.pos);
        if(newObjIdx)
        {
            data->objects.push_back(newObjIdx);
        }
    }
    void despawn(Object& obj, Data *data)
    {
        if(data->objects.size() == 0) return;
        data->objects[0]->remove();
        data->objects.erase(data->objects.begin());
    }

    void update(Object& obj, Data *data, float deltaTime)
    {
        joypad_buttons_t buttons_pressed = joypad_get_buttons_pressed(JOYPAD_PORT_1);
        if(buttons_pressed.a)
        {
            spawn(obj, data);
        }
        if(buttons_pressed.z)
        {
            data->prefabToSpawn.idx = desiredPrefab;
            spawn(obj, data);
        }
        if(buttons_pressed.b)
        {
            despawn(obj, data);
        }
    }

    void draw(Object& obj, Data *data, float deltaTime)
    {  
        DrawLayer::use2D();
            rdpq_text_printf(nullptr, 1, 20, 200, "Prefab: %lX  - Expected: %lX", data->prefabToSpawn.get(), desiredPrefab);  
            rdpq_text_printf(nullptr, 1, 20, 210, "Spawned: %d/%d", (uint8_t)data->objects.size(), data->maxToLive);  
        DrawLayer::useDefault();
    }
}
```

And the code in the PR gives this result in the editor:
<img width="452" height="241" alt="image" src="https://github.com/user-attachments/assets/309e95a2-5bb1-4be9-a3ce-246ead718ec8" />

<img width="435" height="285" alt="image" src="https://github.com/user-attachments/assets/cc7711d9-822a-4e83-92b9-1410a694be0c" />
