### PR TITLE
onEnable and onDisable script functions replace EVENT_TYPE_ENABLE and EVENT_TYPE_DISABLE

### DIFF
--- a/data/scripts/defaultObject.cpp
+++ b/data/scripts/defaultObject.cpp
@@ -45,17 +45,22 @@ namespace P64::Script::__UUID__
     // Put your drawing code here
   }
 
+  void onEnable(Object& obj, Data *data)
+  {
+    // this is called when the object is enabled and active in scene
+  }
+
+  void onDisable(Object& obj, Data *data)
+  {
+    // this is called when the object is disabled and inactive in scene
+  }
+
   void onEvent(Object& obj, Data *data, const ObjectEvent &event)
   {
     // generic events an object can receive
     switch(event.type)
     {
-      case EVENT_TYPE_ENABLE: // object got enabled
-      break;
-      case EVENT_TYPE_DISABLE: // object got disabled
-      break;
-
-      // you can check for your own custom types here too
+      // you can check for your own custom types here
     }
   }
 

--- a/docs/docs/manual/script/objScript.md
+++ b/docs/docs/manual/script/objScript.md
@@ -191,6 +191,24 @@ If you do have non-trivial data types as variables, please also manually destruc
 Accessing other components of the object is not safe, as they might have been destroyed already.\
 The object itself is still valid however, this can be useful to e.g. send an event to other objects.
 
+#### onEnable
+```cpp
+void onEnable(Object& obj, Data *data)
+```
+Called every time the object is enabled and after `init` if enabled in the scene.\
+This is the place to utilize initialized varaibles from `init` and/or register into external systems
+
+Accessing other components of the object is generally safe, although they might not be enabled themselves yet.
+
+#### onDisable
+```cpp
+void onDisable(Object& obj, Data *data)
+```
+Called every time the object is disabled and before `destroy` if enabled in the scene.\
+This is the place to utilize unregister from external systems that may have been initialized in `onEnable`
+
+Accessing other components of the object is generally safe, although they might still be enabled.
+
 #### Update
 ```cpp
 void update(Object& obj, Data *data, float deltaTime)
@@ -271,8 +289,6 @@ void fixedUpdate(Object &obj, Data *data, float fixedDeltaTime)
   }
 }
 ```
-
-
 
 #### Draw
 ```cpp

--- a/docs/docs/manual/script/objScript.md
+++ b/docs/docs/manual/script/objScript.md
@@ -320,7 +320,7 @@ struct ObjectEvent
 };
 ```
 Besides the sender, you will get a type and value.\
-There are a few builtin types (e.g. object disable / enable), so it must be explicitly checked.
+There are a few builtin types, so it must be explicitly checked.
 
 The safe range for user-defined types is from `EVENT_TYPE_CUSTOM_START` to `EVENT_TYPE_CUSTOM_END`.\
 This starts from `0`, whereas builtin types reserve the end of the range. 
@@ -331,11 +331,7 @@ void onEvent(Object& obj, Data *data, const ObjectEvent &event)
 {
   switch(event.type)
   {
-    case EVENT_TYPE_ENABLE: // object got enabled
-    break;
-    case EVENT_TYPE_DISABLE: // object got disabled
-    break;
-    // you can check for your own custom types here too
+    // you can check for your own custom types here
   }
 }
 ```

--- a/n64/engine/include/scene/componentTable.h
+++ b/n64/engine/include/scene/componentTable.h
@@ -17,6 +17,8 @@ namespace P64
 
   typedef uint32_t(*FuncGetAllocSize)(void*);
   typedef void(*FuncInitDel)(Object&, void*, void*);
+  typedef void(*FuncEnabled)(Object&, void*);
+  typedef void(*FuncDisabled)(Object&, void*);
   typedef void(*FuncUpdate)(Object&, void*, float deltaTime);
   typedef void(*FuncFixedUpdate)(Object&, void*, float fixedDeltaTime);
   typedef void(*FuncDraw)(Object&, void*, float deltaTime);
@@ -26,6 +28,8 @@ namespace P64
   struct ComponentDef
   {
     FuncInitDel initDel{};
+    FuncEnabled onEnable{};
+    FuncDisabled onDisable{};
     FuncUpdate update{};
     FuncFixedUpdate fixedUpdate{};
     FuncDraw draw{};

--- a/n64/engine/include/scene/components/code.h
+++ b/n64/engine/include/scene/components/code.h
@@ -4,6 +4,7 @@
 */
 #pragma once
 #include "script/scriptTable.h"
+#include "scene/object.h"
 
 namespace Coll
 {
@@ -21,6 +22,8 @@ namespace P64::Comp
     static constexpr uint32_t FN_EVENT        = 1 << 2;
     static constexpr uint32_t FN_COLL         = 1 << 3;
     static constexpr uint32_t FN_FIXED_UPDATE = 1 << 4;
+    static constexpr uint32_t FN_ON_ENABLE    = 1 << 5;
+    static constexpr uint32_t FN_ON_DISABLE   = 1 << 6;
 
     // store direct pointer to avoid lookup each time
     Script::ScriptEntry *script;
@@ -40,10 +43,13 @@ namespace P64::Comp
       return sizeof(Code) + dataSize;
     }
 
-    static void initDelete([[maybe_unused]] Object& obj, Code* data, uint16_t* initData)
-    {
+    static void initDelete(Object& obj, Code* data, uint16_t* initData) {
       if (initData == nullptr)
       {
+        if(obj.isEnabled() && (data->usedFunctions & FN_ON_DISABLE)) {
+          data->script->onDisable(obj, data->getCodeData());
+        }
+
         if(data->script->destroy) {
           data->script->destroy(obj, data->getCodeData());
         }
@@ -63,9 +69,27 @@ namespace P64::Comp
       if(data->script->onEvent) data->usedFunctions |= FN_EVENT;
       if(data->script->onColl) data->usedFunctions |= FN_COLL;
       if(data->script->fixedUpdate) data->usedFunctions |= FN_FIXED_UPDATE;
+      if(data->script->onEnable) data->usedFunctions |= FN_ON_ENABLE;
+      if(data->script->onDisable) data->usedFunctions |= FN_ON_DISABLE;
 
       if(data->script->init) {
         data->script->init(obj, data->getCodeData());
+      }
+
+      if(obj.isEnabled() && (data->usedFunctions & FN_ON_ENABLE)) {
+        data->script->onEnable(obj, data->getCodeData());
+      }
+    }
+
+    static void onEnable(Object& obj, Code* data) {
+      if(data->usedFunctions & FN_ON_ENABLE) {
+        data->script->onEnable(obj, data->getCodeData());
+      }
+    }
+
+    static void onDisable(Object& obj, Code* data) {
+      if(data->usedFunctions & FN_ON_DISABLE) {
+        data->script->onDisable(obj, data->getCodeData());
       }
     }
 

--- a/n64/engine/include/scene/components/code.h
+++ b/n64/engine/include/scene/components/code.h
@@ -44,11 +44,7 @@ namespace P64::Comp
     }
 
     static void initDelete(Object& obj, Code* data, uint16_t* initData) {
-      if (initData == nullptr)
-      {
-        if(obj.isEnabled() && (data->usedFunctions & FN_ON_DISABLE)) {
-          data->script->onDisable(obj, data->getCodeData());
-        }
+      if (initData == nullptr) {
 
         if(data->script->destroy) {
           data->script->destroy(obj, data->getCodeData());
@@ -74,10 +70,6 @@ namespace P64::Comp
 
       if(data->script->init) {
         data->script->init(obj, data->getCodeData());
-      }
-
-      if(obj.isEnabled() && (data->usedFunctions & FN_ON_ENABLE)) {
-        data->script->onEnable(obj, data->getCodeData());
       }
     }
 

--- a/n64/engine/include/scene/components/collBody.h
+++ b/n64/engine/include/scene/components/collBody.h
@@ -26,7 +26,9 @@ namespace P64::Comp
 
     static void initDelete([[maybe_unused]] Object& obj, CollBody* data, void* initData);
 
-    static void onEvent(Object& obj, CollBody* data, const ObjectEvent& event);
+    static void onEnable(Object& obj, CollBody* data);
+    
+    static void onDisable(Object& obj, CollBody* data);
 
     static void update(Object& obj, CollBody* data, float deltaTime);
   };

--- a/n64/engine/include/scene/components/collMesh.h
+++ b/n64/engine/include/scene/components/collMesh.h
@@ -21,7 +21,9 @@ namespace P64::Comp
 
     static void initDelete([[maybe_unused]] Object& obj, CollMesh* data, uint16_t* initData);
 
-    static void onEvent(Object &obj, CollMesh* data, const ObjectEvent &event);
+    static void onEnable(Object& obj, CollMesh* data);
+
+    static void onDisable(Object& obj, CollMesh* data);
 
     static void update(Object& obj, CollMesh* data, float deltaTime);
   };

--- a/n64/engine/include/scene/components/rigidBody.h
+++ b/n64/engine/include/scene/components/rigidBody.h
@@ -26,7 +26,9 @@ namespace P64::Comp
 
     static void initDelete([[maybe_unused]] Object& obj, RigidBody* data, void* initData);
 
-    static void onEvent(Object& obj, RigidBody* data, const ObjectEvent& event);
+    static void onEnable(Object& obj, RigidBody* data);
+
+    static void onDisable(Object& obj, RigidBody* data);
 
     static void update(Object& obj, RigidBody* data, float deltaTime);
   };

--- a/n64/engine/include/scene/event.h
+++ b/n64/engine/include/scene/event.h
@@ -9,9 +9,6 @@ namespace P64
 {
   constexpr uint32_t MAX_EVENT_COUNT = 128;
 
-  constexpr uint16_t EVENT_TYPE_ENABLE = 0xFFFF;
-  constexpr uint16_t EVENT_TYPE_DISABLE = 0xFFFE;
-
   // Safe ranges for user-defined custom events
   constexpr uint16_t EVENT_TYPE_CUSTOM_START = 0x0000;
   constexpr uint16_t EVENT_TYPE_CUSTOM_END   = 0xF000;

--- a/n64/engine/include/scene/object.h
+++ b/n64/engine/include/scene/object.h
@@ -123,6 +123,14 @@ namespace P64
       }
 
       /**
+       * Check if the object is pending removal.
+       * @return true enabled
+       */
+      [[nodiscard]] bool isPendingRemove() const {
+        return (flags & ObjectFlags::PENDING_REMOVE) == ObjectFlags::PENDING_REMOVE;
+      }
+
+      /**
        * Changes the state of the object to be enabled or disabled.
        * Prefer this over changing flags directly, as components may need to be notified.
        * @param isEnabled true to enable, false to disable

--- a/n64/engine/include/script/scriptTable.h
+++ b/n64/engine/include/script/scriptTable.h
@@ -20,6 +20,8 @@ namespace P64::Script
   {
     FuncObjInit init;
     FuncObjInit destroy;
+    FuncObjInit onEnable;
+    FuncObjInit onDisable;
     FuncObjDataDelta update;
     FuncObjDataDelta fixedUpdate;
     FuncObjDataDelta draw;

--- a/n64/engine/src/scene/componentTable.cpp
+++ b/n64/engine/src/scene/componentTable.cpp
@@ -34,6 +34,8 @@
 
 namespace
 {
+  HAS_FUNC_TPL(has_enable, get_on_enable,  onEnable  )
+  HAS_FUNC_TPL(has_disable,get_on_disable, onDisable )
   HAS_FUNC_TPL(has_draw,   get_draw,    draw   )
   HAS_FUNC_TPL(has_update, get_update,  update )
   HAS_FUNC_TPL(has_fixed_update, get_fixed_update, fixedUpdate)
@@ -44,6 +46,8 @@ namespace
 #define SET_COMP(NAME) \
   [Comp::NAME::ID] = { \
     .initDel = reinterpret_cast<FuncInitDel>(Comp::NAME::initDelete), \
+    .onEnable = (FuncEnabled)get_on_enable<Comp::NAME>(), \
+    .onDisable = (FuncDisabled)get_on_disable<Comp::NAME>(), \
     .update = (FuncUpdate)get_update<Comp::NAME>(), \
     .fixedUpdate = (FuncFixedUpdate)get_fixed_update<Comp::NAME>(), \
     .draw   = (FuncDraw)(get_draw<Comp::NAME>()), \

--- a/n64/engine/src/scene/components/collBody.cpp
+++ b/n64/engine/src/scene/components/collBody.cpp
@@ -81,19 +81,16 @@ namespace P64::Comp
         data->collider.pyramidShape().halfHeight = scaledHalfExtend.y;
       break;
     }
-    if (obj.isEnabled()) {
-      coll.addCollider(&data->collider);
-    }
   }
 
-  void CollBody::onEvent(Object &obj, CollBody* data, const ObjectEvent &event)
+  void CollBody::onEnable(Object& obj, CollBody* data)
   {
-    if(event.type == EVENT_TYPE_DISABLE) {
-      return obj.getScene().getCollision().removeCollider(&data->collider);
-    }
-    if(event.type == EVENT_TYPE_ENABLE) {
-      return obj.getScene().getCollision().addCollider(&data->collider);
-    }
+    return obj.getScene().getCollision().addCollider(&data->collider);
+  }
+
+  void CollBody::onDisable(Object& obj, CollBody* data)
+  {
+    return obj.getScene().getCollision().removeCollider(&data->collider);
   }
 
   void CollBody::update(Object &obj, CollBody* data, float deltaTime)

--- a/n64/engine/src/scene/components/collMesh.cpp
+++ b/n64/engine/src/scene/components/collMesh.cpp
@@ -54,23 +54,19 @@ namespace P64::Comp
     data->meshCollider = Coll::MeshCollider::createFromRawData(rawData, &obj);
 
     data->meshCollider->setCollisionMask(initData->maskRead, initData->maskWrite);
-    if(data->meshCollider && obj.isEnabled()) {
+  }
+
+  void CollMesh::onEnable(Object& obj, CollMesh* data)
+  {
+    if(data->meshCollider) {
       obj.getScene().getCollision().addMeshCollider(data->meshCollider);
     }
   }
 
-  void CollMesh::onEvent(Object &obj, CollMesh* data, const ObjectEvent &event)
+  void CollMesh::onDisable(Object& obj, CollMesh* data)
   {
-    if(event.type == EVENT_TYPE_DISABLE) {
-      if(data->meshCollider) {
-        obj.getScene().getCollision().removeMeshCollider(data->meshCollider);
-      }
-      return;
-    }
-    if(event.type == EVENT_TYPE_ENABLE) {
-      if(data->meshCollider) {
-        obj.getScene().getCollision().addMeshCollider(data->meshCollider);
-      }
+    if(data->meshCollider) {
+      obj.getScene().getCollision().removeMeshCollider(data->meshCollider);
     }
   }
 

--- a/n64/engine/src/scene/components/rigidBody.cpp
+++ b/n64/engine/src/scene/components/rigidBody.cpp
@@ -67,20 +67,16 @@ namespace P64::Comp
     if(initData->constrainRotY) constraints = constraints | Coll::Constraint::FreezeRotY;
     if(initData->constrainRotZ) constraints = constraints | Coll::Constraint::FreezeRotZ;
     data->rigid_body.setConstraints(constraints);
-
-    if(obj.isEnabled()) {
-      coll.addRigidBody(&data->rigid_body);
-    }
   }
 
-  void RigidBody::onEvent(Object &obj, RigidBody* data, const ObjectEvent &event)
+  void RigidBody::onEnable(Object& obj, RigidBody* data)
   {
-    if(event.type == EVENT_TYPE_DISABLE) {
-      return obj.getScene().getCollision().removeRigidBody(&data->rigid_body);
-    }
-    if(event.type == EVENT_TYPE_ENABLE) {
-      return obj.getScene().getCollision().addRigidBody(&data->rigid_body);
-    }
+    return obj.getScene().getCollision().addRigidBody(&data->rigid_body);
+  }
+
+  void RigidBody::onDisable(Object& obj, RigidBody* data)
+  {
+    return obj.getScene().getCollision().removeRigidBody(&data->rigid_body);
   }
 
   void RigidBody::update(Object &obj, RigidBody* data, float deltaTime)

--- a/n64/engine/src/scene/object.cpp
+++ b/n64/engine/src/scene/object.cpp
@@ -36,15 +36,10 @@ void P64::Object::setEnabled(bool isEnabled)
     auto compRefs = getCompRefs();
     for (uint32_t i=0; i<compCount; ++i) {
       const auto &compDef = COMP_TABLE[compRefs[i].type];
-      if(compDef.onEvent)
-      {
-        char* dataPtr = (char*)this + compRefs[i].offset;
-        compDef.onEvent(*this, dataPtr, {
-          .senderId = 0,
-          .type = isEnabledNow ? EVENT_TYPE_ENABLE : EVENT_TYPE_DISABLE,
-          .value = 0
-        });
-      }
+      char* dataPtr = (char*)this + compRefs[i].offset;
+      
+      if(isEnabledNow && compDef.onEnable) compDef.onEnable(*this, dataPtr);
+      else if(!isEnabledNow && compDef.onDisable) compDef.onDisable(*this, dataPtr);
     }
   }
 
@@ -55,7 +50,6 @@ void P64::Object::remove()
 {
   if(flags & ObjectFlags::PENDING_REMOVE)return;
   flags |= ObjectFlags::PENDING_REMOVE;
-  flags &= ~ObjectFlags::ACTIVE;
   SceneManager::getCurrent().removeObject(*this);
 }
 

--- a/n64/engine/src/scene/object.cpp
+++ b/n64/engine/src/scene/object.cpp
@@ -14,6 +14,11 @@ P64::Object::~Object()
   for (uint32_t i=0; i<compCount; ++i) {
     const auto &compDef = COMP_TABLE[compRefs[i].type];
     char* dataPtr = (char*)this + compRefs[i].offset;
+
+    if(isEnabled() && compDef.onDisable) {
+        compDef.onDisable(*this, dataPtr);
+    }
+
     compDef.initDel(*this, dataPtr, nullptr);
   }
 }

--- a/n64/engine/src/scene/scene.cpp
+++ b/n64/engine/src/scene/scene.cpp
@@ -242,7 +242,7 @@ void P64::Scene::update(float deltaTime)
   ticksActorUpdate = get_ticks();
   for(auto obj : objects)
   {
-    if(!obj->isEnabled())continue;
+    if(!obj->isEnabled() || obj->isPendingRemove()) continue;
 
     auto compRefs = obj->getCompRefs();
 

--- a/n64/engine/src/scene/scene.cpp
+++ b/n64/engine/src/scene/scene.cpp
@@ -44,14 +44,10 @@ namespace
     auto compRefs = obj.getCompRefs();
     for (uint32_t i=0; i<obj.compCount; ++i) {
       const auto &compDef = P64::COMP_TABLE[compRefs[i].type];
-      if(!compDef.onEvent) continue;
-
+      
       char* dataPtr = (char*)&obj + compRefs[i].offset;
-      compDef.onEvent(obj, dataPtr, {
-        .senderId = 0,
-        .type = enabled ? P64::EVENT_TYPE_ENABLE : P64::EVENT_TYPE_DISABLE,
-        .value = 0
-      });
+      if(enabled && compDef.onEnable) compDef.onEnable(obj, dataPtr);
+      else if(!enabled && compDef.onDisable) compDef.onDisable(obj, dataPtr);
     }
   }
 

--- a/n64/engine/src/scene/sceneLoader.cpp
+++ b/n64/engine/src/scene/sceneLoader.cpp
@@ -153,6 +153,10 @@ P64::Object* P64::Scene::loadObject(uint8_t* &objFile, std::function<void(Object
     else
     {
       compDef.initDel(*obj, objCompDataPtr, ptrIn + 4);
+
+      if(obj->isEnabled() && compDef.onEnable) {
+        compDef.onEnable(*obj, objCompDataPtr);
+      }
     }
 
     objCompDataPtr += Math::alignUp(compDef.getAllocSize(ptrIn + 4), 8);
@@ -181,6 +185,10 @@ void P64::Scene::runPendingComponentInit()
   {
     const auto &compDef = COMP_TABLE[pending.compId];
     compDef.initDel(*pending.obj, pending.dataPtr, pending.initData);
+
+    if(pending.obj->isEnabled() && compDef.onEnable) {
+      compDef.onEnable(*pending.obj, pending.dataPtr);
+    }
   }
   pendingCompInit.clear();
 }

--- a/n64/examples/jam25/src/user/ObjBot.cpp
+++ b/n64/examples/jam25/src/user/ObjBot.cpp
@@ -110,10 +110,6 @@ namespace P64::Script::C4F4D286D6CB0DE3
   {
     switch(event.type)
     {
-      case EVENT_TYPE_ENABLE:
-        break;
-      case EVENT_TYPE_DISABLE:
-        break;
       default: break;
     }
   }

--- a/src/build/scriptBuilder.cpp
+++ b/src/build/scriptBuilder.cpp
@@ -38,6 +38,8 @@ void Build::buildScripts(Project::Project &project, SceneCtx &sceneCtx)
 
     bool hasInit    = Utils::CPP::hasFunction(src, "void", "init");
     bool hasDestroy = Utils::CPP::hasFunction(src, "void", "destroy");
+    bool hasEnable  = Utils::CPP::hasFunction(src, "void", "onEnable");
+    bool hasDisable = Utils::CPP::hasFunction(src, "void", "onDisable");
     bool hasFixedUpdate = Utils::CPP::hasFunction(src, "void", "fixedUpdate");
     bool hasUpdate  = Utils::CPP::hasFunction(src, "void", "update");
     bool hasDraw    = Utils::CPP::hasFunction(src, "void", "draw");
@@ -52,6 +54,8 @@ void Build::buildScripts(Project::Project &project, SceneCtx &sceneCtx)
     srcDecl += " extern uint16_t DATA_SIZE;\n";
     if(hasInit)srcDecl += "void init(Object& obj, Data *data);\n";
     if(hasDestroy)srcDecl += "void destroy(Object& obj, Data *data);\n";
+    if(hasEnable)srcDecl += "void onEnable(Object& obj, Data *data);\n";
+    if(hasDisable)srcDecl += "void onDisable(Object& obj, Data *data);\n";
     if(hasUpdate)srcDecl += "void update(Object& obj, Data *data, float deltaTime);\n";
     if(hasFixedUpdate)srcDecl += "void fixedUpdate(Object& obj, Data *data, float fixedDeltaTime);\n";
     if(hasDraw)srcDecl += "void draw(Object& obj, Data *data, float deltaTime);\n";
@@ -62,6 +66,8 @@ void Build::buildScripts(Project::Project &project, SceneCtx &sceneCtx)
     srcEntries += "{\n";
     if(hasInit)srcEntries += " .init = (FuncObjInit)" + uuidStr + "::init,\n";
     if(hasDestroy)srcEntries += " .destroy = (FuncObjInit)" + uuidStr + "::destroy,\n";
+    if(hasEnable)srcEntries += " .onEnable = (FuncObjInit)" + uuidStr + "::onEnable,\n";
+    if(hasDisable)srcEntries += " .onDisable = (FuncObjInit)" + uuidStr + "::onDisable,\n";
     if(hasUpdate)srcEntries += " .update = (FuncObjDataDelta)" + uuidStr + "::update,\n";
     if(hasFixedUpdate)srcEntries += " .fixedUpdate = (FuncObjDataDelta)" + uuidStr + "::fixedUpdate,\n";
     if(hasDraw)srcEntries += " .draw = (FuncObjDataDelta)" + uuidStr + "::draw,\n";


### PR DESCRIPTION
provides an onEnable and onDisable function to components and user scripts that will also get called after init()/before destroy() if the object is enabled.
