### PR TITLE
Allow to edit the name of an object on the scene tree

### DIFF
--- a/src/editor/pages/parts/sceneGraph.cpp
+++ b/src/editor/pages/parts/sceneGraph.cpp
@@ -319,6 +319,7 @@ namespace
           auto added = scene.addObject(obj);
           if (added) {
             ctx.setObjectSelection(added->uuid);
+            startRenaming(added->uuid);
           }
           Editor::UndoRedo::getHistory().markChanged("Add Object");
         }

--- a/src/editor/pages/parts/sceneGraph.cpp
+++ b/src/editor/pages/parts/sceneGraph.cpp
@@ -51,6 +51,39 @@ namespace
       + (ImGui::GetCurrentWindow()->ScrollbarY ? 0 : style.ScrollbarSize);
   }
 
+  /**
+   * Clears the current inline renaming state.
+   */
+  void clearRenaming()
+  {
+    renameObjectUUID = 0;
+    renameBuffer.clear();
+    startingRename = false;
+  }
+
+  /**
+   * Starts inline renaming for an object.
+   *
+   * @param objectUUID UUID of the object to rename
+   * @param objectName Current name
+   */
+  void startRenaming(uint32_t objectUUID)
+  {
+    // Get the scene to look for the object
+    auto scene = ctx.project->getScenes().getLoadedScene();
+    if (!scene) return;
+
+    // Can find object with such UUID --> Start renaming
+    if (const std::shared_ptr<Project::Object> theObject = scene->getObjectByUUID(objectUUID)) {
+      renameObjectUUID = objectUUID;
+      renameBuffer = theObject->name;
+      startingRename = true;
+    // Cannot find object with such UUID (selection may have gone stale between frames) --> Cancel renaming
+    } else {
+      clearRenaming();
+    }
+  }
+
   bool DrawDropTarget(uint32_t& dragDropTarget, uint32_t uuid, float thickness = 2.0f, float hitHeight = 8.0f)
   {
     // Only show when drag-drop is active
@@ -147,8 +180,7 @@ namespace
     bool finishRename = confirmRename || ImGui::IsItemDeactivated();
     // Canceled --> Clear renaming
     if (cancelRename) {
-      renameObjectUUID = 0;
-      renameBuffer.clear();
+      clearRenaming();
     // Finished renaming --> Commit name
     } else if (finishRename) {
       // Given new name --> Apply to object
@@ -156,8 +188,7 @@ namespace
         obj.name = renameBuffer;
         Editor::UndoRedo::getHistory().markChanged("Edit object name");
       }
-      renameObjectUUID = 0;
-      renameBuffer.clear();
+      clearRenaming();
     }
 
     ImGui::SetCursorPos(oldCursorPos);
@@ -201,9 +232,17 @@ namespace
     bool nodeIsClicked = ImGui::IsItemHovered()
       && ImGui::IsMouseReleased(ImGuiMouseButton_Left)
       && !ImGui::IsMouseDragging(ImGuiMouseButton_Left);
+    bool nodeIsDoubleClicked = ImGui::IsItemHovered()
+      && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)
+      && !ImGui::IsMouseDragging(ImGuiMouseButton_Left);
     if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
       ImGui::OpenPopup("NodePopup");
     }
+
+    // Double-clicked a node --> Start renaming
+    if (nodeIsDoubleClicked)
+      startRenaming(obj.uuid);
+
     bool isRenaming = renameObjectUUID == obj.uuid;
 
     if (obj.parent && ImGui::BeginDragDropSource())
@@ -324,16 +363,8 @@ void Editor::SceneGraph::draw()
     const std::vector<uint32_t> &selectedIds = ctx.getSelectedObjectUUIDs();
     // Inline renaming only makes sense for a single target; multi-select keeps its current state
     if (selectedIds.size() == 1) {
-      renameObjectUUID = selectedIds.front();
-      if (const std::shared_ptr<Project::Object> selectedObj = scene->getObjectByUUID(renameObjectUUID)) {
-        // Seed the input with the current object name and arm the first-frame focus handoff
-        renameBuffer = selectedObj->name;
-        startingRename = true;
-      } else {
-        // The selection may have gone stale between frames, so bail out cleanly
-        renameObjectUUID = 0;
-        renameBuffer.clear();
-      }
+      // Rename the selected object
+      startRenaming(selectedIds.front());
     }
   }
 

--- a/src/editor/pages/parts/sceneGraph.cpp
+++ b/src/editor/pages/parts/sceneGraph.cpp
@@ -5,7 +5,9 @@
 #include "sceneGraph.h"
 
 #include <algorithm>
+#include <string>
 #include "imgui.h"
+#include "misc/cpp/imgui_stdlib.h"
 #include "../../../context.h"
 #include "../../imgui/helper.h"
 #include "IconsMaterialDesignIcons.h"
@@ -17,6 +19,9 @@ namespace
 {
   Project::Object* deleteObj{nullptr};
   bool deleteSelection{false};
+  uint32_t renameObjectUUID{0};
+  std::string renameBuffer{};
+  bool startingRename{false};
 
   struct DragDropTask {
     uint32_t sourceUUID{0};
@@ -25,6 +30,26 @@ namespace
   };
 
   DragDropTask dragDropTask{};
+
+  /**
+   * Computes the horizontal area reserved for the controls at the right side of a row.
+   *
+   * @return Width that must remain free at the right side of the row.
+   */
+  float calcRightControlAreaWidth()
+  {
+    const int iconAmount = 2;
+    const ImGuiStyle& style = ImGui::GetStyle();
+
+    // Sum the width of all the buttons
+    return ImGui::CalcTextSize(ICON_MDI_CURSOR_DEFAULT).x * iconAmount
+      // Sum the width of margins between buttons
+      + style.ItemInnerSpacing.x * (iconAmount - 1)
+      // Keep a small buffer against the window edge
+      + style.WindowPadding.x
+      // Add the width of the scrollbar if not present
+      + (ImGui::GetCurrentWindow()->ScrollbarY ? 0 : style.ScrollbarSize);
+  }
 
   bool DrawDropTarget(uint32_t& dragDropTarget, uint32_t uuid, float thickness = 2.0f, float hitHeight = 8.0f)
   {
@@ -78,6 +103,66 @@ namespace
     return res;
   }
 
+  /**
+   * Draws an inline rename text field on top of a scene-graph node label.
+   *
+   * The edit is confirmed on Enter or when the field loses focus, and cancelled with Escape.
+   *
+   * @param obj The scene object currently being renamed.
+  */
+  void drawRenameInput(Project::Object &obj, const ImVec2 &nodeRectMin)
+  {
+    const ImVec2 oldCursorPos = ImGui::GetCursorPos();
+
+    // Anchor input to the tree label position
+    ImVec2 renamePos = nodeRectMin;
+    const ImGuiStyle& style = ImGui::GetStyle();
+    renamePos.x += ImGui::GetTreeNodeToLabelSpacing() / 2 - style.FramePadding.x + 2;
+    renamePos.y -= 1;
+    ImGui::SetCursorScreenPos(renamePos);
+
+    // Clamp input width to the usable row space so it stays inside the window
+    float rightLimit = ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x - calcRightControlAreaWidth() - style.FramePadding.x;
+    float inputWidth = rightLimit - ImGui::GetCursorScreenPos().x;
+    if (inputWidth < 1_px)
+      inputWidth = 1_px;
+
+    // Is the first frame --> Focus input
+    if (startingRename) {
+      ImGui::SetKeyboardFocusHere();
+      startingRename = false;
+    }
+
+    // Place input and read value
+    ImGui::SetNextItemWidth(inputWidth);
+    bool confirmRename = ImGui::InputText(
+      ("##Rename" + std::to_string(obj.uuid)).c_str(),
+      &renameBuffer,
+      ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll
+    );
+
+    // Escape aborts rename
+    bool cancelRename = ImGui::IsItemActive() && ImGui::IsKeyPressed(ImGuiKey_Escape);
+    // Enter or losing focus commits name
+    bool finishRename = confirmRename || ImGui::IsItemDeactivated();
+    // Canceled --> Clear renaming
+    if (cancelRename) {
+      renameObjectUUID = 0;
+      renameBuffer.clear();
+    // Finished renaming --> Commit name
+    } else if (finishRename) {
+      // Given new name --> Apply to object
+      if (!renameBuffer.empty() && obj.name != renameBuffer) {
+        obj.name = renameBuffer;
+        Editor::UndoRedo::getHistory().markChanged("Edit object name");
+      }
+      renameObjectUUID = 0;
+      renameBuffer.clear();
+    }
+
+    ImGui::SetCursorPos(oldCursorPos);
+  }
+
   void drawObjectNode(
     Project::Scene &scene, Project::Object &obj, bool keyDelete,
     bool parentEnabled = true
@@ -111,6 +196,7 @@ namespace
 
     bool isOpen = ImGui::TreeNodeEx(nameID.c_str(), flag);
     ImGui::PopStyleVar(2);
+    ImVec2 nodeRectMin = ImGui::GetItemRectMin();
 
     bool nodeIsClicked = ImGui::IsItemHovered()
       && ImGui::IsMouseReleased(ImGuiMouseButton_Left)
@@ -118,6 +204,7 @@ namespace
     if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
       ImGui::OpenPopup("NodePopup");
     }
+    bool isRenaming = renameObjectUUID == obj.uuid;
 
     if (obj.parent && ImGui::BeginDragDropSource())
     {
@@ -135,6 +222,10 @@ namespace
       ImGui::EndDragDropTarget();
     }
 
+    // Is renaming the object node
+    if (isRenaming)
+      drawRenameInput(obj, nodeRectMin);
+
     if(obj.parent)
     {
       float spacing = ImGui::GetStyle().ItemInnerSpacing.x;
@@ -142,8 +233,7 @@ namespace
 
       auto oldCursorPos = ImGui::GetCursorPos();
 
-      float offsetRight = 24_px + 10.0f;
-      if(!ImGui::GetCurrentWindow()->ScrollbarY)offsetRight += 10.0f;
+      float offsetRight = calcRightControlAreaWidth();
       ImGui::SameLine(ImGui::GetWindowContentRegionMax().x - offsetRight);
 
       if(!parentEnabled)ImGui::BeginDisabled();
@@ -222,9 +312,30 @@ void Editor::SceneGraph::draw()
   deleteObj = nullptr;
   deleteSelection = false;
   bool isFocus = ImGui::IsWindowFocused();
+  // While rename is active, shortcuts stay disabled, so the text field can own the keyboard input
+  bool isRenaming = renameObjectUUID != 0;
 
   ImGui::PushStyleVar(ImGuiStyleVar_IndentSpacing, 16.0_px);
-  bool keyDelete = isFocus && (ImGui::IsKeyPressed(ImGuiKey_Delete) || ImGui::IsKeyPressed(ImGuiKey_Backspace));
+  bool keyDelete = isFocus && !isRenaming && (ImGui::IsKeyPressed(ImGuiKey_Delete) || ImGui::IsKeyPressed(ImGuiKey_Backspace));
+  // F2 starts renaming the current object, matching common scene-tree/file-explorer behavior
+  bool keyRename = isFocus && !isRenaming && ImGui::IsKeyPressed(ImGuiKey_F2);
+
+  if (keyRename) {
+    const std::vector<uint32_t> &selectedIds = ctx.getSelectedObjectUUIDs();
+    // Inline renaming only makes sense for a single target; multi-select keeps its current state
+    if (selectedIds.size() == 1) {
+      renameObjectUUID = selectedIds.front();
+      if (const std::shared_ptr<Project::Object> selectedObj = scene->getObjectByUUID(renameObjectUUID)) {
+        // Seed the input with the current object name and arm the first-frame focus handoff
+        renameBuffer = selectedObj->name;
+        startingRename = true;
+      } else {
+        // The selection may have gone stale between frames, so bail out cleanly
+        renameObjectUUID = 0;
+        renameBuffer.clear();
+      }
+    }
+  }
 
   auto &root = scene->getRootObject();
   drawObjectNode(*scene, root, keyDelete);


### PR DESCRIPTION
## Summary

Adds inline object renaming support in the scene graph.

- Start renaming with F2.
- Start renaming with double-click.
- Start renaming after "Add Object".