### PR TITLE
Make applyForceAtPoint actually accumulate force

### DIFF
--- a/n64/engine/src/collision/rigid_body.cpp
+++ b/n64/engine/src/collision/rigid_body.cpp
@@ -443,11 +443,11 @@ namespace P64::Coll {
 
   void RigidBody::applyForceAtPoint(const fm_vec3_t &force, const fm_vec3_t &worldPoint) {
     if(isKinematic_) return;
-    applyLinearImpulse(force);
+    accelerate(force * inverseMass_);
     fm_vec3_t r = worldPoint - worldCenterOfMass_;
     fm_vec3_t torque;
     fm_vec3_cross(&torque, &r, &force);
-    applyAngularImpulse(torque);
+    applyTorque(torque);
   }
 
   void RigidBody::updateWorldInertia() {


### PR DESCRIPTION
This was just applying instantaneous impulses but it should be accumulating force which gets integrated later at the physics tick and scaled according to the timestep.

I am not an expert on the math here but I am _pretty_ sure this is right because I am migrating some existing car physics code from qu3e to this cool new built-in system and this change fixes some behavior that was super wrong...also full disclosure I asked some LLMs and they said this change is right so :shrug: 