### PR TITLE
Decouple physics scale from visual scale

### DIFF
--- a/n64/engine/include/collision/collide.h
+++ b/n64/engine/include/collision/collide.h
@@ -14,9 +14,9 @@ namespace P64::Coll {
   struct CollisionScene; // forward declare
   struct ColliderProxy; // forward declare
 
-  bool collideDetectObjectToObject(Collider *colliderA, RigidBody *rigidBodyA, Collider *colliderB, RigidBody *rigidBodyB);
-  bool collideDetectObjectToMesh(Collider *collider, RigidBody *rigidBody, const MeshCollider &mesh);
-  bool collideDetectObjectToTriangle(ColliderProxy *colliderProxy, RigidBody *rigidBody, const MeshCollider &mesh, int triangleIndex);
+  bool collideDetectObjectToObject(Collider *colliderA, RigidBody *rigidBodyA, Collider *colliderB, RigidBody *rigidBodyB, bool recordConstraints);
+  bool collideDetectObjectToMesh(Collider *collider, RigidBody *rigidBody, const MeshCollider &mesh, bool recordConstraints);
+  bool collideDetectObjectToTriangle(ColliderProxy *colliderProxy, RigidBody *rigidBody, const MeshCollider &mesh, int triangleIndex, bool recordConstraints);
 
   ContactConstraint *collideCacheContactConstraint(
     RigidBody *rigidBodyA, Collider *colliderA, MeshCollider *meshColliderA, Object *objectA,

--- a/n64/engine/include/collision/collider_shape.h
+++ b/n64/engine/include/collision/collider_shape.h
@@ -10,6 +10,7 @@
 #include "shapes.h"
 #include "matrix3x3.h"
 #include "aabb_tree.h"
+#include "gfx_scale.h"
 
 namespace P64
 {
@@ -54,7 +55,7 @@ namespace P64::Coll {
     }
     P64::Object *ownerObject() const { return owner_; }
 
-    void setParentOffset(const fm_vec3_t &newParentOffset) { parentOffset_ = newParentOffset; }
+    void setParentOffset(const fm_vec3_t &newParentOffset) { parentOffset_ = newParentOffset * getInvGfxScale(); }
     const fm_vec3_t &parentOffset() const { return parentOffset_; }
 
     void setBounce(float newBounce) { bounce_ = newBounce; }
@@ -87,6 +88,7 @@ namespace P64::Coll {
     fm_vec3_t rotateToLocal(const fm_vec3_t &worldDir) const;
     bool hasOwnerTransformChanged() const;
     void syncOwnerTransform();
+    bool syncFromRigidBody(const fm_vec3_t& rbPosition, const fm_quat_t& rbRotation);
     bool syncWorldState();
     bool readsCollider(const Collider *other) const;
     bool readsMeshCollider(const MeshCollider *other) const;

--- a/n64/engine/include/collision/collision_scene.h
+++ b/n64/engine/include/collision/collision_scene.h
@@ -23,8 +23,7 @@
 namespace P64::Coll {
   constexpr int MAX_OBJ_COLLISION_CANDIDATES = 15;
   constexpr float DEFAULT_FIXED_DT = 1.0f / 50.0f;
-  constexpr float DEFAULT_PHYSICS_SCALE = 16.0f;
-  constexpr fm_vec3_t DEFAULT_GRAVITY = {0.0f, -9.8f, 0.0f}; //scaled with Pyrites default scale for assets
+  constexpr fm_vec3_t DEFAULT_GRAVITY = {0.0f, -9.8f, 0.0f};
   constexpr uint8_t DEFAULT_VELOCITY_SOLVER_ITERATIONS = 8;
   constexpr uint8_t DEFAULT_POSITION_SOLVER_ITERATIONS = 7;
   constexpr float WARM_STARTING_FACTOR = 0.85f; // Bullet-style warm starting scale to prevent overcorrection from stale impulses
@@ -74,12 +73,10 @@ namespace P64::Coll {
     void addMeshCollider(MeshCollider *mesh);
     void removeMeshCollider(MeshCollider *mesh);
 
-    void configureSimulation(float fixedDt, const fm_vec3_t &gravity, uint8_t velocityIterations, uint8_t positionIterations, float physicsScale);
+    void configureSimulation(float fixedDt, const fm_vec3_t &gravity, uint8_t velocityIterations, uint8_t positionIterations, float gfxScale);
     void wakeRigidBodyIsland(RigidBody *rigidBody);
 
     void step();
-
-    float getPhysicsScale() const { return physicsScale_; }
 
     int getCachedConstraintCount() const;
     ContactConstraint &getCachedConstraint(int index);
@@ -108,7 +105,6 @@ namespace P64::Coll {
     std::vector<MeshCollider *> meshColliders_{};
 
     float fixedDt_{DEFAULT_FIXED_DT};
-    float physicsScale_{DEFAULT_PHYSICS_SCALE};
     fm_vec3_t gravity_{DEFAULT_GRAVITY};
     uint8_t velocitySolverIterations_{DEFAULT_VELOCITY_SOLVER_ITERATIONS};
     uint8_t positionSolverIterations_{DEFAULT_POSITION_SOLVER_ITERATIONS};

--- a/n64/engine/include/collision/gfx_scale.h
+++ b/n64/engine/include/collision/gfx_scale.h
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace P64::Coll {
+    constexpr float DEFAULT_GFX_SCALE = 100.0f;
+
+    inline float gfxScale_{DEFAULT_GFX_SCALE};
+    inline float inverseGfxScale_{1.0f / DEFAULT_GFX_SCALE};
+
+    inline float getGfxScale() { return gfxScale_; }
+    inline float getInvGfxScale() { return inverseGfxScale_; }
+
+    inline void setGfxScale(float gfxScale) {
+        gfxScale_ = gfxScale;
+        inverseGfxScale_ = 1.0f / gfxScale;
+    }
+}

--- a/n64/engine/include/collision/gfx_scale.h
+++ b/n64/engine/include/collision/gfx_scale.h
@@ -1,16 +1,7 @@
 #pragma once
 
 namespace P64::Coll {
-    constexpr float DEFAULT_GFX_SCALE = 100.0f;
-
-    inline float gfxScale_{DEFAULT_GFX_SCALE};
-    inline float inverseGfxScale_{1.0f / DEFAULT_GFX_SCALE};
-
-    inline float getGfxScale() { return gfxScale_; }
-    inline float getInvGfxScale() { return inverseGfxScale_; }
-
-    inline void setGfxScale(float gfxScale) {
-        gfxScale_ = gfxScale;
-        inverseGfxScale_ = 1.0f / gfxScale;
-    }
+    float getGfxScale();
+    float getInvGfxScale();
+    void setGfxScale(float gfxScale);
 }

--- a/n64/engine/include/collision/rigid_body.h
+++ b/n64/engine/include/collision/rigid_body.h
@@ -19,15 +19,15 @@ namespace P64::Coll {
   class CollisionScene;
 
   // Constants
-  constexpr float TERMINAL_SPEED = 100.0f; // Units per second, scaled by physicsScale when applied
+  constexpr float TERMINAL_SPEED = 100.0f; // Units per second
   constexpr float TERMINAL_ANGULAR_SPEED = 50.0f; // Radians per second
   constexpr float TERMINAL_ANGULAR_SPEED_SQ = TERMINAL_ANGULAR_SPEED * TERMINAL_ANGULAR_SPEED;
-  constexpr float POS_SLEEP_THRESHOLD = 0.01f; // Units moved, scaled by physicsScale when used
+  constexpr float POS_SLEEP_THRESHOLD = 0.01f; // Units moved
   constexpr float POS_SLEEP_THRESHOLD_SQ = POS_SLEEP_THRESHOLD * POS_SLEEP_THRESHOLD;
-  constexpr float SPEED_SLEEP_THRESHOLD = 0.8f; // Units per second, scaled by physicsScale when used
+  constexpr float SPEED_SLEEP_THRESHOLD = 0.8f; // Units per second
   constexpr float SPEED_SLEEP_THRESHOLD_SQ = SPEED_SLEEP_THRESHOLD * SPEED_SLEEP_THRESHOLD;
   constexpr float ROT_SIMILARITY_SLEEP_THRESHOLD = 0.9999988f;
-  constexpr float ANGULAR_SLEEP_THRESHOLD = 1.0f; // Radians per second, not scaled by physicsScale
+  constexpr float ANGULAR_SLEEP_THRESHOLD = 1.0f; // Radians per second
   constexpr float ANGULAR_SLEEP_THRESHOLD_SQ = ANGULAR_SLEEP_THRESHOLD * ANGULAR_SLEEP_THRESHOLD;
   constexpr float AMPLIFY_ANG_DAMPING_THRESHOLD = 0.015f; // Radians per second, below this angular velocity, amplification is applied to damping
   constexpr float AMPLIFY_ANG_DAMPING_THRESHOLD_SQ = AMPLIFY_ANG_DAMPING_THRESHOLD * AMPLIFY_ANG_DAMPING_THRESHOLD;
@@ -62,10 +62,10 @@ namespace P64::Coll {
     void init(P64::Object *object, float m);
 
     P64::Object *ownerObject() const { return owner_; }
-    fm_vec3_t *positionPtr() { return position_; }
-    const fm_vec3_t *positionPtr() const { return position_; }
-    fm_quat_t *rotationPtr() { return rotation_; }
-    const fm_quat_t *rotationPtr() const { return rotation_; }
+    const fm_vec3_t &position() const { return position_; }
+    const fm_quat_t &rotation() const { return rotation_; }
+    void setPosition(const fm_vec3_t &pos) { position_ = pos; }
+    void setRotation(const fm_quat_t &rot) { rotation_ = rot; }
 
     const fm_vec3_t &linearVelocity() const { return linearVelocity_; }
     const fm_vec3_t &angularVelocity() const { return angularVelocity_; }
@@ -96,7 +96,7 @@ namespace P64::Coll {
 
     bool hasLinearConstraints() const { return hasLinearConstraints_; }
     bool hasAngularConstraints() const { return hasAngularConstraints_; }
-    bool canApplyAngularResponse() const { return !isKinematic_ && rotation_ && !hasFlag(constraints_, Constraint::FreezeRotAll); }
+    bool canApplyAngularResponse() const { return !isKinematic_ && !hasFlag(constraints_, Constraint::FreezeRotAll); }
     bool isKinematic() const { return isKinematic_; }
     bool isSleeping() const { return isSleeping_; }
 
@@ -157,8 +157,8 @@ namespace P64::Coll {
     friend class CollisionScene;
 
     P64::Object *owner_{nullptr};
-    fm_vec3_t *position_{nullptr};
-    fm_quat_t *rotation_{nullptr};
+    fm_vec3_t position_{};
+    fm_quat_t rotation_{};
     Matrix3x3 invWorldInertiaTensor_{};
     Matrix3x3 rotationMatrix_{};
     Matrix3x3 inverseRotationMatrix_{};

--- a/n64/engine/include/scene/scene.h
+++ b/n64/engine/include/scene/scene.h
@@ -61,7 +61,7 @@ namespace P64
     uint16_t physicsTickRate{};
 
     fm_vec3_t gravity{};
-    float physicsScale{};
+    float visualUnitsPerMeter{};
 
     uint8_t velocitySolverIterations{};
     uint8_t positionSolverIterations{};

--- a/n64/engine/src/collision/collide.cpp
+++ b/n64/engine/src/collision/collide.cpp
@@ -1146,7 +1146,7 @@ namespace P64::Coll {
   /// @param mesh Reference to the mesh collider.
   /// @param triangleIndex Index of the triangle within the mesh to test against.
   /// @return True if a collision is detected, false otherwise.
-  bool collideDetectObjectToTriangle(ColliderProxy *colliderProxyMeshSpace, RigidBody *rigidBody, const MeshCollider &mesh, int triangleIndex) {
+  bool collideDetectObjectToTriangle(ColliderProxy *colliderProxyMeshSpace, RigidBody *rigidBody, const MeshCollider &mesh, int triangleIndex, bool recordConstraints) {
     const bool isTriggerContact = colliderProxyMeshSpace->collider->isTrigger();
     const bool colliderRespondsToMesh = colliderProxyMeshSpace->collider->readsMeshCollider(&mesh);
 
@@ -1179,11 +1179,13 @@ namespace P64::Coll {
         for(int i = 0; i < satCount; ++i) {
           mesh.localResultToWorld(satResults[i]);
         }
-        collideCacheSatContactConstraint(
-            rigidBody, colliderProxyMeshSpace->collider, objectA,
-            const_cast<MeshCollider *>(&mesh), objectB,
-            satResults, satCount,
-            combinedFriction, combinedBounce, colliderRespondsToMesh, triangleIndex);
+        if(recordConstraints) {
+          collideCacheSatContactConstraint(
+              rigidBody, colliderProxyMeshSpace->collider, objectA,
+              const_cast<MeshCollider *>(&mesh), objectB,
+              satResults, satCount,
+              combinedFriction, combinedBounce, colliderRespondsToMesh, triangleIndex);
+        }
         return true;
       }
       return false;
@@ -1201,10 +1203,12 @@ namespace P64::Coll {
       if(analyticalSphereTriangle(*colliderProxyMeshSpace, sphere, v0, v1, v2, tri.normal, sphereResult)) {
         mesh.localResultToWorld(sphereResult);
 
-        collideCacheContactConstraint(
-            rigidBody, colliderProxyMeshSpace->collider, nullptr, objectA,
-            nullptr, nullptr, const_cast<MeshCollider *>(&mesh), objectB,
-            sphereResult, combinedFriction, combinedBounce, isTriggerContact, colliderRespondsToMesh, false, triangleIndex);
+        if(recordConstraints) {
+          collideCacheContactConstraint(
+              rigidBody, colliderProxyMeshSpace->collider, nullptr, objectA,
+              nullptr, nullptr, const_cast<MeshCollider *>(&mesh), objectB,
+              sphereResult, combinedFriction, combinedBounce, isTriggerContact, colliderRespondsToMesh, false, triangleIndex);
+        }
         return true;
       }
       return false;
@@ -1237,10 +1241,12 @@ namespace P64::Coll {
       dummyResult.contactA = colliderProxyMeshSpace->collider->worldCenter();
       dummyResult.contactB = triCenter;
 
-      collideCacheContactConstraint(
-          rigidBody, colliderProxyMeshSpace->collider, nullptr, objectA,
-          nullptr, nullptr, const_cast<MeshCollider *>(&mesh), objectB,
-          dummyResult, 0.0f, 0.0f, true, false, false, triangleIndex);
+      if(recordConstraints) {
+        collideCacheContactConstraint(
+            rigidBody, colliderProxyMeshSpace->collider, nullptr, objectA,
+            nullptr, nullptr, const_cast<MeshCollider *>(&mesh), objectB,
+            dummyResult, 0.0f, 0.0f, true, false, false, triangleIndex);
+      }
 
       return true;
     }
@@ -1256,10 +1262,12 @@ namespace P64::Coll {
     {
       mesh.localResultToWorld(epaResult);
 
-      collideCacheContactConstraint(
-          rigidBody, colliderProxyMeshSpace->collider, nullptr, objectA,
-          nullptr, nullptr, const_cast<MeshCollider *>(&mesh), objectB,
-          epaResult, combinedFriction, combinedBounce, isTriggerContact, colliderRespondsToMesh, false, triangleIndex);
+      if (recordConstraints) {
+        collideCacheContactConstraint(
+            rigidBody, colliderProxyMeshSpace->collider, nullptr, objectA,
+            nullptr, nullptr, const_cast<MeshCollider *>(&mesh), objectB,
+            epaResult, combinedFriction, combinedBounce, isTriggerContact, colliderRespondsToMesh, false, triangleIndex);
+      }
 
       return true;
     }
@@ -1272,8 +1280,7 @@ namespace P64::Coll {
   /// @param collider The collider to test against the mesh.
   /// @param rigidBody The rigid body associated with the collider.
   /// @param mesh The mesh collider to test against.
-  bool collideDetectObjectToMesh(Collider *collider, RigidBody *rigidBody, const MeshCollider &mesh) {
-
+  bool collideDetectObjectToMesh(Collider *collider, RigidBody *rigidBody, const MeshCollider &mesh, bool recordConstraints) {
     // Transform the collider's world AABB into the mesh's local space for tree query
     AABB queryAABB = mesh.hasTransform()
       ? mesh.worldAabbToLocal(collider->worldAabb())
@@ -1327,9 +1334,9 @@ namespace P64::Coll {
       // If there is a collision between the collider and the current triangle and the collider is a Trigger
       // we can skip the rest of the candidates since triggers just need to report that a collision happened
       // and don't need detailed contact information for each triangle.
-      if(collideDetectObjectToTriangle(&colliderInMeshSpace, rigidBody, mesh, triIndex)) {
+      if(collideDetectObjectToTriangle(&colliderInMeshSpace, rigidBody, mesh, triIndex, recordConstraints)) {
         detected = true;
-        if(collider->isTrigger()) return true;
+        if(collider->isTrigger() || !recordConstraints) return true;
       }
     }
     return detected;
@@ -1341,7 +1348,7 @@ namespace P64::Coll {
   /// @param rbA The rigid body associated with the first collider.
   /// @param colliderB The second collider.
   /// @param rbB The rigid body associated with the second collider.
-  bool collideDetectObjectToObject(Collider *colliderA, RigidBody *rbA, Collider *colliderB, RigidBody *rbB) {
+  bool collideDetectObjectToObject(Collider *colliderA, RigidBody *rbA, Collider *colliderB, RigidBody *rbB, bool recordConstraints) {
     if(!colliderA || !colliderB) return false;
 
     CollisionScene *scene = collisionSceneGetInstance();
@@ -1467,14 +1474,16 @@ namespace P64::Coll {
       dummyResult.contactA = colliderA->worldCenter();
       dummyResult.contactB = colliderB->worldCenter();
 
-      collideCacheContactConstraint(
-        rbA, colliderA, nullptr, colliderA->ownerObject(),
-        rbB, colliderB, nullptr, colliderB->ownerObject(),
-        dummyResult,
-        0.0f, 0.0f,
-        true,
-        false, false
-      );
+      if (recordConstraints) {
+        collideCacheContactConstraint(
+          rbA, colliderA, nullptr, colliderA->ownerObject(),
+          rbB, colliderB, nullptr, colliderB->ownerObject(),
+          dummyResult,
+          0.0f, 0.0f,
+          true,
+          false, false
+        );
+      }
       return true;
     }
 
@@ -1498,11 +1507,14 @@ namespace P64::Coll {
     float combinedFriction = fmin(colliderA->friction(), colliderB->friction());
     float combinedBounce = fmaxf(colliderA->bounce(), colliderB->bounce());
 
-    // Cache the constraint
-    collideCacheContactConstraint(
-      rbA, colliderA, nullptr, colliderA->ownerObject(),
-      rbB, colliderB, nullptr, colliderB->ownerObject(),
-      result, combinedFriction, combinedBounce, false, aReadsB, bReadsA);
+    if (recordConstraints) {
+      // Cache the constraint
+      collideCacheContactConstraint(
+        rbA, colliderA, nullptr, colliderA->ownerObject(),
+        rbB, colliderB, nullptr, colliderB->ownerObject(),
+        result, combinedFriction, combinedBounce, false, aReadsB, bReadsA);
+    }
+
     return true;
   }
 

--- a/n64/engine/src/collision/collide.cpp
+++ b/n64/engine/src/collision/collide.cpp
@@ -915,7 +915,7 @@ namespace P64::Coll {
       }
 
       // Try to match new contact to an existing point by proximity
-      float MATCH_DIST_SQ = 0.02f * scene->getPhysicsScale() * scene->getPhysicsScale(); // 2cm threshold (scaled)
+      float MATCH_DIST_SQ = 0.02f; // 2cm threshold (scaled)
       int matchedIdx = -1;
       float bestDistSq = MATCH_DIST_SQ;
       for(int i = 0; i < existing->pointCount; ++i) {
@@ -967,7 +967,7 @@ namespace P64::Coll {
       }
 
       // Force all non-target points through current-frame revalidation.
-      const float revalidationSeparationLimit = -0.05f * scene->getPhysicsScale();
+      const float revalidationSeparationLimit = -0.05f;
       for(int i = 0; i < existing->pointCount; ++i) {
         ContactPoint &cp = existing->points[i];
         if(i == targetIdx) continue;
@@ -1093,7 +1093,7 @@ namespace P64::Coll {
     cc->respondsB = false;
 
     int newCount = resultCount < MAX_CONTACT_POINTS_PER_PAIR ? resultCount : MAX_CONTACT_POINTS_PER_PAIR;
-    float MATCH_DIST_SQ = 0.02f * scene->getPhysicsScale() * scene->getPhysicsScale();
+    float MATCH_DIST_SQ = 0.02f;
     bool oldClaimed[MAX_CONTACT_POINTS_PER_PAIR] = {};
 
     for(int i = 0; i < newCount; ++i) {

--- a/n64/engine/src/collision/collider_shape.cpp
+++ b/n64/engine/src/collision/collider_shape.cpp
@@ -4,6 +4,7 @@
  * @brief Defines the Basic (non-mesh) Colliders (see collider_shape.h)
  */
 #include "collision/collider_shape.h"
+#include "collision/gfx_scale.h"
 #include "collision/mesh_collider.h"
 #include "scene/object.h"
 
@@ -65,8 +66,9 @@ bool Collider::hasOwnerTransformChanged() const {
   if(!owner_) return false;
   if(!hasCachedOwnerTransform_) return true;
 
-  if(fm_vec3_distance2(&owner_->pos, &lastOwnerPosition_) > FM_EPSILON * FM_EPSILON) return true;
-  if(fm_vec3_distance2(&owner_->scale, &lastOwnerScale_) > FM_EPSILON * FM_EPSILON) return true;
+  fm_vec3_t ownerPhysicsPos = owner_->pos * getInvGfxScale();
+  if(fm_vec3_distance2(&ownerPhysicsPos, &lastOwnerPosition_) > FM_EPSILON * FM_EPSILON ) return true;
+  if(fm_vec3_distance2(&owner_->scale, &lastOwnerScale_) > FM_EPSILON * FM_EPSILON ) return true;
 
   const float rotSim = fabsf(quatDot(owner_->rot, lastOwnerRotation_));
   return rotSim < (1.0f - FM_EPSILON);
@@ -78,7 +80,7 @@ void Collider::syncOwnerTransform() {
     lastOwnerRotation_ = QUAT_IDENTITY;
     lastOwnerScale_ = fm_vec3_t{{1.0f, 1.0f, 1.0f}};
   } else {
-    lastOwnerPosition_ = owner_->pos;
+    lastOwnerPosition_ = owner_->pos * getInvGfxScale();
     lastOwnerRotation_ = owner_->rot;
     lastOwnerScale_ = owner_->scale;
   }
@@ -86,6 +88,32 @@ void Collider::syncOwnerTransform() {
   rotationMatrix_ = quatToMatrix3(lastOwnerRotation_);
   inverseRotationMatrix_ = quatToMatrix3(quatConjugate(lastOwnerRotation_));
   hasCachedOwnerTransform_ = true;
+}
+
+bool Collider::syncFromRigidBody(const fm_vec3_t& rbPosition, const fm_quat_t& rbRotation) {
+  if(hasCachedOwnerTransform_) {
+    const float posDeltaSq = fm_vec3_distance2(&rbPosition, &lastOwnerPosition_);
+    const float rotSim = fabsf(quatDot(rbRotation, lastOwnerRotation_));
+    if(posDeltaSq <= FM_EPSILON * FM_EPSILON && rotSim >= 1.0f - FM_EPSILON) {
+      return false;
+    }
+  }
+
+  lastOwnerPosition_ = rbPosition;
+  lastOwnerRotation_ = rbRotation;
+  lastOwnerScale_ = owner_ ? owner_->scale : fm_vec3_t{{1,1,1}};
+  rotationMatrix_ = quatToMatrix3(lastOwnerRotation_);
+  inverseRotationMatrix_ = quatToMatrix3(quatConjugate(lastOwnerRotation_));
+  hasCachedOwnerTransform_ = true;
+
+  worldCenter_ = lastOwnerPosition_ + matrix3Vec3Mul(rotationMatrix_, parentOffset_ * lastOwnerScale_);
+
+  const AABB local = boundingBox(&lastOwnerRotation_);
+  worldAabb_.min = local.min + worldCenter_;
+  worldAabb_.max = local.max + worldCenter_;
+  ++worldStateVersion_;
+
+  return true;
 }
 
 bool Collider::syncWorldState() {

--- a/n64/engine/src/collision/collision_scene.cpp
+++ b/n64/engine/src/collision/collision_scene.cpp
@@ -1732,7 +1732,7 @@ namespace P64::Coll {
           {
             scaled = rot * scaled;
           }
-          return scaled + pos;
+          return (scaled + pos) * getGfxScale();
         };
 
         for (uint16_t t = 0; t < meshCollider->triangleCount_; ++t)
@@ -1772,46 +1772,46 @@ namespace P64::Coll {
           {
           case ShapeType::Sphere:
             if (!isSleepingBody) col = color_t{0xFF, 0x00, 0x00, 0xFF};
-            Debug::drawSphere(collider->worldCenter_, collider->sphere_.radius, col);
+            Debug::drawSphere(collider->worldCenter_ * getGfxScale(), collider->sphere_.radius * getGfxScale(), col);
             break;
           case ShapeType::Box:
             if (!isSleepingBody) col = color_t{0x00, 0xFF, 0xFF, 0xFF};
-            Debug::drawOBB(collider->worldCenter_, collider->box_.halfSize, collider->owner_->rot, col);
+            Debug::drawOBB(collider->worldCenter_ * getGfxScale(), collider->box_.halfSize * getGfxScale(), collider->owner_->rot, col);
             break;
           case ShapeType::Capsule:
             if (!isSleepingBody) col = color_t{0x00, 0x80, 0xFF, 0xFF};
             Debug::drawCapsule(
-                collider->worldCenter_,
-                collider->capsule_.radius,
-                collider->capsule_.innerHalfHeight,
+                collider->worldCenter_ * getGfxScale(),
+                collider->capsule_.radius * getGfxScale(),
+                collider->capsule_.innerHalfHeight * getGfxScale(),
                 collider->owner_->rot,
                 col);
             break;
           case ShapeType::Cylinder:
             if (!isSleepingBody) col = color_t{0xFF, 0x80, 0x00, 0xFF};
             Debug::drawCylinder(
-                collider->worldCenter_,
-                collider->cylinder_.radius,
-                collider->cylinder_.halfHeight,
+                collider->worldCenter_ * getGfxScale(),
+                collider->cylinder_.radius * getGfxScale(),
+                collider->cylinder_.halfHeight * getGfxScale(),
                 collider->owner_->rot,
                 col);
             break;
           case ShapeType::Cone:
             if (!isSleepingBody) col = color_t{0xFF, 0x40, 0xA0, 0xFF};
             Debug::drawCone(
-                collider->worldCenter_,
-                collider->cone_.radius,
-                collider->cone_.halfHeight,
+                collider->worldCenter_ * getGfxScale(),
+                collider->cone_.radius * getGfxScale(),
+                collider->cone_.halfHeight * getGfxScale(),
                 collider->owner_->rot,
                 col);
             break;
           case ShapeType::Pyramid:
             if (!isSleepingBody) col = color_t{0xB0, 0xFF, 0x40, 0xFF};
             Debug::drawPyramid(
-                collider->worldCenter_,
-                collider->pyramid_.baseHalfWidthX,
-                collider->pyramid_.baseHalfWidthZ,
-                collider->pyramid_.halfHeight,
+                collider->worldCenter_ * getGfxScale(),
+                collider->pyramid_.baseHalfWidthX * getGfxScale(),
+                collider->pyramid_.baseHalfWidthZ * getGfxScale(),
+                collider->pyramid_.halfHeight * getGfxScale(),
                 collider->owner_->rot,
                 col);
             break;

--- a/n64/engine/src/collision/collision_scene.cpp
+++ b/n64/engine/src/collision/collision_scene.cpp
@@ -6,6 +6,7 @@
 #include "collision/collision_scene.h"
 #include "collision/collide.h"
 #include "collision/contact_utils.h"
+#include "collision/gfx_scale.h"
 #include "collision/gjk.h"
 #include "scene/scene.h"
 
@@ -95,14 +96,14 @@ namespace P64::Coll {
   }
 
   bool CollisionScene::shouldTrackSleepState(const RigidBody *rigidBody) {
-    return rigidBody && !rigidBody->isKinematic_ && rigidBody->position_;
+    return rigidBody && !rigidBody->isKinematic_;
   }
 
   bool CollisionScene::rigidBodyVelocitiesExceededSleepThreshold(const RigidBody *rigidBody) {
     if(!shouldTrackSleepState(rigidBody)) return false;
 
     const float speedSq = fm_vec3_len2(&rigidBody->linearVelocity_);
-    if(speedSq > SPEED_SLEEP_THRESHOLD_SQ * (g_scene.physicsScale_ * g_scene.physicsScale_)) return true;
+    if(speedSq > SPEED_SLEEP_THRESHOLD_SQ) return true;
 
     const float angSpeedSq = fm_vec3_len2(&rigidBody->angularVelocity_);
     return angSpeedSq > ANGULAR_SLEEP_THRESHOLD_SQ;
@@ -111,17 +112,15 @@ namespace P64::Coll {
   bool CollisionScene::rigidBodyTransformExceededSleepThreshold(const RigidBody *rigidBody) {
     if(!shouldTrackSleepState(rigidBody)) return false;
 
-    const float posDeltaSq = fm_vec3_distance2(rigidBody->position_, &rigidBody->previousStepPosition_);
-    if(posDeltaSq > POS_SLEEP_THRESHOLD_SQ * (g_scene.physicsScale_ * g_scene.physicsScale_)) return true;
+    const float posDeltaSq = fm_vec3_distance2(&rigidBody->position_, &rigidBody->previousStepPosition_);
+    if(posDeltaSq > POS_SLEEP_THRESHOLD_SQ) return true;
 
-    if(rigidBody->rotation_) {
-      const float rotSim = fabsf(quatDot(*rigidBody->rotation_, rigidBody->previousStepRotation_));
-      if(rotSim < ROT_SIMILARITY_SLEEP_THRESHOLD) return true;
-    }
+    const float rotSim = fabsf(quatDot(rigidBody->rotation_, rigidBody->previousStepRotation_));
+    if(rotSim < ROT_SIMILARITY_SLEEP_THRESHOLD) return true;
 
     if(rigidBody->owner_) {
       const float scaleDeltaSq = fm_vec3_distance2(&rigidBody->owner_->scale, &rigidBody->previousStepScale_);
-      if(scaleDeltaSq > POS_SLEEP_THRESHOLD_SQ * (g_scene.physicsScale_ * g_scene.physicsScale_)) return true;
+      if(scaleDeltaSq > POS_SLEEP_THRESHOLD_SQ) return true;
     }
 
     return false;
@@ -191,7 +190,7 @@ namespace P64::Coll {
   }
 
   void CollisionScene::updateCompoundProperties(RigidBody *rigidBody) const {
-    if(!rigidBody || !rigidBody->owner_ || !rigidBody->position_) return;
+    if(!rigidBody || !rigidBody->owner_) return;
 
     const fm_vec3_t fallbackInertia = rigidBody->getDefaultLocalInertiaTensor();
 
@@ -217,10 +216,8 @@ namespace P64::Coll {
     const float invCount = 1.0f / static_cast<float>(count);
     const fm_vec3_t worldCenter = worldCenterSum * invCount;
 
-    fm_vec3_t localCenterOffset = worldCenter - *rigidBody->position_;
-    if(rigidBody->rotation_) {
-      localCenterOffset = quatConjugate(*rigidBody->rotation_) * localCenterOffset;
-    }
+    fm_vec3_t localCenterOffset = worldCenter - rigidBody->position_;
+    localCenterOffset = quatConjugate(rigidBody->rotation_) * localCenterOffset;
 
     if(rigidBody->getMass() <= FM_EPSILON) {
       rigidBody->applyCompoundProperties(localCenterOffset, fallbackInertia, rigidBody->owner_->scale);
@@ -235,9 +232,7 @@ namespace P64::Coll {
 
       fm_vec3_t colliderInertia = collider->inertiaTensor(massPerCollider);
       fm_vec3_t r = collider->worldCenter_ - worldCenter;
-      if(rigidBody->rotation_) {
-        r = quatConjugate(*rigidBody->rotation_) * r;
-      }
+      r = quatConjugate(rigidBody->rotation_) * r;
 
       const float x2 = r.x * r.x;
       const float y2 = r.y * r.y;
@@ -270,7 +265,7 @@ namespace P64::Coll {
 
     rigidBody->markCompoundPropertiesDirty();
     syncCompoundProperties(rigidBody);
-    const fm_vec3_t worldPos = rigidBody->position_ ? *rigidBody->position_ : VEC3_ZERO;
+    const fm_vec3_t worldPos = rigidBody->position_;
     rigidBody->worldAabb_ = AABB{worldPos, worldPos};
   }
 
@@ -399,10 +394,10 @@ namespace P64::Coll {
     }
   }
 
-  void CollisionScene::configureSimulation(float fixedDt, const fm_vec3_t &gravity, uint8_t velocityIterations, uint8_t positionIterations, float physicsScale) {
+  void CollisionScene::configureSimulation(float fixedDt, const fm_vec3_t &gravity, uint8_t velocityIterations, uint8_t positionIterations, float gfxScale) {
     fixedDt_ = fixedDt > 0.0f ? fixedDt : DEFAULT_FIXED_DT;
-    physicsScale_ = physicsScale > FM_EPSILON ? physicsScale : DEFAULT_PHYSICS_SCALE;
-    gravity_ = gravity * physicsScale;
+    setGfxScale(gfxScale);
+    gravity_ = gravity;
     velocitySolverIterations_ = std::max<uint8_t>(1, velocityIterations);
     positionSolverIterations_ = std::max<uint8_t>(1, positionIterations);
   }
@@ -774,7 +769,7 @@ namespace P64::Coll {
         refreshContactPointWorldState(cp, cc);
 
         // Deactivate if too separated
-        if(cp.penetration < -(0.1f * physicsScale_)) {
+        if(cp.penetration < -0.001f) {
           cp.active = false;
         }
       }
@@ -824,7 +819,7 @@ namespace P64::Coll {
     candidates.resize(colliders_.size());
 
     for(RigidBody *body : rigidBodies_) {
-      if(!body || body->isSleeping_ || body->isKinematic_ || !body->position_) continue;
+      if(!body || body->isSleeping_ || body->isKinematic_) continue;
 
       const float dt = fixedDt_ * body->timeScale_;
       if(dt <= 0.0f) continue;
@@ -857,19 +852,19 @@ namespace P64::Coll {
         MAX_CCD_SUBSTEPS);
       if(substeps <= 1) continue;
 
-      const fm_vec3_t originalPos = *body->position_;
+      const fm_vec3_t originalPos = body->position_;
 
       // Test at intermediate substep positions along the predicted trajectory.
       // k=0 is the current position (handled by normal detection afterwards).
       for(int k = 1; k < substeps; ++k) {
         const float fraction = static_cast<float>(k) / static_cast<float>(substeps);
-        *body->position_ = originalPos + (displacement * fraction);
+        body->position_ = originalPos + (displacement * fraction);
 
         // Sync this body's colliders at the substep position
         for(Collider *collider : *ownerColliders) {
           if(!collider) continue;
           const fm_vec3_t prevCenter = collider->worldCenter_;
-          if(!collider->syncWorldState()) continue;
+          if(!collider->syncFromRigidBody(body->position_, body->rotation_)) continue;
           const fm_vec3_t disp = collider->worldCenter_ - prevCenter;
           if(collider->aabbTreeNodeId_ != NULL_NODE) {
             colliderAABBTree.moveNode(collider->aabbTreeNodeId_, collider->worldAabb_, disp);
@@ -914,11 +909,11 @@ namespace P64::Coll {
       }
 
       // Restore original position and sync colliders back
-      *body->position_ = originalPos;
+      body->position_ = originalPos;
       for(Collider *collider : *ownerColliders) {
         if(!collider) continue;
         const fm_vec3_t prevCenter = collider->worldCenter_;
-        if(!collider->syncWorldState()) continue;
+        if(!collider->syncFromRigidBody(body->position_, body->rotation_)) continue;
         const fm_vec3_t disp = collider->worldCenter_ - prevCenter;
         if(collider->aabbTreeNodeId_ != NULL_NODE) {
           colliderAABBTree.moveNode(collider->aabbTreeNodeId_, collider->worldAabb_, disp);
@@ -1040,7 +1035,7 @@ namespace P64::Coll {
   // ── Pre-solve ─────────────────────────────────────────────────────
 
   void CollisionScene::preSolveContacts() {
-    const float restitutionSlop = 0.5f * physicsScale_;
+    const float restitutionSlop = 0.5f;
 
     for(ContactConstraint *constraint : solverConstraints_) {
       ContactConstraint &cc = *constraint;
@@ -1215,7 +1210,7 @@ namespace P64::Coll {
     constexpr float VELOCITY_SOLVER_EARLY_OUT_THRESHOLD = 1e-4f;
     constexpr float VELOCITY_SOLVER_NORMAL_ERROR_THRESHOLD_PER_SCALE = 1e-3f;
     constexpr uint8_t MIN_NORMAL_SOLVER_ITERATIONS = 6;
-    const float velocitySolverNormalErrorThreshold = VELOCITY_SOLVER_NORMAL_ERROR_THRESHOLD_PER_SCALE * physicsScale_;
+    const float velocitySolverNormalErrorThreshold = VELOCITY_SOLVER_NORMAL_ERROR_THRESHOLD_PER_SCALE;
 
     const auto solveFrictionPass = [&]() {
       for(ContactConstraint *constraint : solverConstraints_) {
@@ -1360,9 +1355,9 @@ namespace P64::Coll {
   // ── Position constraint solver ────────────────────────────────────
 
   bool CollisionScene::solvePositionConstraints() {
-    const float slop = 0.01f * physicsScale_;
-    const float steering = 0.3f;
-    const float maxCorrection = 0.04f * physicsScale_;
+    const float slop = 0.005f;
+    const float steering = 0.2f;
+    const float maxCorrection = 0.2f;
     bool appliedCorrection = false;
 
     for(ContactConstraint *constraint : solverConstraints_) {
@@ -1409,10 +1404,10 @@ namespace P64::Coll {
         appliedCorrection = true;
 
         // Apply linear + angular corrections to A
-        if(a && !a->isKinematic_ && a->position_) {
+        if(a && !a->isKinematic_) {
           if(invMassA > 0.0f) {
             fm_vec3_t corrA = constrainLinearWorld(a, cc.normal * (correctionMag * invMassA));
-            *a->position_ = *a->position_ + corrA;
+            a->position_ += corrA;
           }
           if(aCanRotate) {
             fm_vec3_t angImpulse;
@@ -1423,17 +1418,17 @@ namespace P64::Coll {
               fm_vec3_t axis = rotChange / angle;
               fm_quat_t dq;
               fm_quat_from_axis_angle(&dq, &axis, angle);
-              *a->rotation_ = dq * *a->rotation_;
-              fm_quat_norm(a->rotation_, a->rotation_);
+              a->rotation_ = dq * a->rotation_;
+              fm_quat_norm(&a->rotation_, &a->rotation_);
             }
           }
         }
 
         // Apply linear + angular corrections to B
-        if(b && !b->isKinematic_ && b->position_) {
+        if(b && !b->isKinematic_) {
           if(invMassB > 0.0f) {
             fm_vec3_t corrB = constrainLinearWorld(b, cc.normal * (correctionMag * invMassB));
-            *b->position_ = *b->position_ - corrB;
+            b->position_ -= corrB;
           }
           if(bCanRotate) {
             fm_vec3_t angImpulse;
@@ -1445,8 +1440,8 @@ namespace P64::Coll {
               fm_vec3_t axis = rotChange / angle;
               fm_quat_t dq;
               fm_quat_from_axis_angle(&dq, &axis, angle);
-              *b->rotation_ = dq * *b->rotation_;
-              fm_quat_norm(b->rotation_, b->rotation_);
+              b->rotation_ = dq * b->rotation_;
+              fm_quat_norm(&b->rotation_, &b->rotation_);
             }
           }
         }
@@ -1579,7 +1574,12 @@ namespace P64::Coll {
       if(!collider) continue;
 
       const fm_vec3_t previousCenter = collider->worldCenter_;
-      if(!collider->syncWorldState() || collider->aabbTreeNodeId_ == NULL_NODE) continue;
+
+      RigidBody *rb = findRigidBodyByOwner(collider->owner_);
+      const bool changed = rb ? collider->syncFromRigidBody(rb->position_, rb->rotation_)
+                              : collider->syncWorldState();
+
+      if(!changed || collider->aabbTreeNodeId_ == NULL_NODE) continue;
 
       const fm_vec3_t displacement = collider->worldCenter_ - previousCenter;
       colliderAABBTree.moveNode(collider->aabbTreeNodeId_, collider->worldAabb_, displacement);
@@ -1667,21 +1667,31 @@ namespace P64::Coll {
       if(!ownerColliders || ownerColliders->empty()) continue;
 
       body->worldAabb_ = AABB {.min = body->worldCenterOfMass_, .max = body->worldCenterOfMass_};
-      fm_vec3_t displacement = *body->position_ - body->previousStepPosition_;
       for (Collider *collider : *ownerColliders)
       {
         if (!collider) continue;
+
+        const fm_vec3_t previousCenter = collider->worldCenter_;
+
+        if (collider->syncFromRigidBody(body->position_, body->rotation_)) {
+          const fm_vec3_t displacement = collider->worldCenter_ - previousCenter;
+          colliderAABBTree.moveNode(collider->aabbTreeNodeId_, collider->worldAabb_, displacement);
+        }
+
         body->worldAabb_ = aabbUnion(body->worldAabb_, collider->worldAabb_);
-        colliderAABBTree.moveNode(collider->aabbTreeNodeId_, collider->worldAabb_, displacement);
       }
 
       // Snapshot the fully-corrected transform for sleep evaluation.
       // This must happen AFTER the position solver and split impulse push so that
       // solver corrections (penetration resolution) do not register as "movement"
       // in the sleep threshold check.
-      if(body->position_) body->previousStepPosition_ = *body->position_;
-      if(body->rotation_) body->previousStepRotation_ = *body->rotation_;
-      if(body->owner_)    body->previousStepScale_ = body->owner_->scale;
+      body->previousStepPosition_ = body->position_;
+      body->previousStepRotation_ = body->rotation_;
+      body->previousStepScale_ = body->owner_->scale;
+
+      // Sync visual object with physics position
+      body->owner_->pos = body->position_ * gfxScale_;
+      body->owner_->rot = body->rotation_;
     }
 
     // Update RigidBody sleep states

--- a/n64/engine/src/collision/collision_scene.cpp
+++ b/n64/engine/src/collision/collision_scene.cpp
@@ -1703,7 +1703,7 @@ namespace P64::Coll {
       body->previousStepScale_ = body->owner_->scale;
 
       // Sync visual object with physics position
-      body->owner_->pos = body->position_ * gfxScale_;
+      body->owner_->pos = body->position_ * getGfxScale();
       body->owner_->rot = body->rotation_;
     }
 

--- a/n64/engine/src/collision/collision_scene.cpp
+++ b/n64/engine/src/collision/collision_scene.cpp
@@ -853,6 +853,7 @@ namespace P64::Coll {
       if(substeps <= 1) continue;
 
       const fm_vec3_t originalPos = body->position_;
+      bool hit = false;
 
       // Test at intermediate substep positions along the predicted trajectory.
       // k=0 is the current position (handled by normal detection afterwards).
@@ -888,11 +889,15 @@ namespace P64::Coll {
             if(!collider->readsCollider(collB) && !collB->readsCollider(collider)) continue;
 
             RigidBody *rbB = findRigidBodyByOwner(collB->owner_);
-            if(collideDetectObjectToObject(collider, body, collB, rbB)) {
+            if(collideDetectObjectToObject(collider, body, collB, rbB, false)) {
               debugf("CCD substep %d/%d: body %u hit body %u", k, substeps, collider->owner_->id, collB->owner_->id);
+              hit = true;
+              break;
             }
           }
+          if (hit) break;
         }
+        if (hit) break;
 
         // Broadphase + narrowphase against mesh colliders
         for(MeshCollider *mesh : meshColliders_) {
@@ -901,22 +906,30 @@ namespace P64::Coll {
             if(!collider || !collider->owner_) continue;
             if(!collider->readsMeshCollider(mesh) && !mesh->readsCollider(collider)) continue;
             if(!aabbOverlap(collider->worldAabb_, mesh->worldAabb_)) continue;
-            if(collideDetectObjectToMesh(collider, body, *mesh)) {
+            if(collideDetectObjectToMesh(collider, body, *mesh, false)) {
               debugf("CCD substep %d/%d: body %u hit mesh %u", k, substeps, collider->owner_->id, mesh->owner_ ? static_cast<unsigned>(mesh->owner_->id) : 0u);
+              hit = true;
+              break;
             }
           }
+          if (hit) break;
         }
+        if (hit) break;
       }
 
-      // Restore original position and sync colliders back
-      body->position_ = originalPos;
-      for(Collider *collider : *ownerColliders) {
-        if(!collider) continue;
-        const fm_vec3_t prevCenter = collider->worldCenter_;
-        if(!collider->syncFromRigidBody(body->position_, body->rotation_)) continue;
-        const fm_vec3_t disp = collider->worldCenter_ - prevCenter;
-        if(collider->aabbTreeNodeId_ != NULL_NODE) {
-          colliderAABBTree.moveNode(collider->aabbTreeNodeId_, collider->worldAabb_, disp);
+      if (hit) {
+        body->setVelocity(VEC3_ZERO);
+      } else {
+        // Restore original position and sync colliders back
+        body->position_ = originalPos;
+        for(Collider *collider : *ownerColliders) {
+          if(!collider) continue;
+          const fm_vec3_t prevCenter = collider->worldCenter_;
+          if(!collider->syncFromRigidBody(body->position_, body->rotation_)) continue;
+          const fm_vec3_t disp = collider->worldCenter_ - prevCenter;
+          if(collider->aabbTreeNodeId_ != NULL_NODE) {
+            colliderAABBTree.moveNode(collider->aabbTreeNodeId_, collider->worldAabb_, disp);
+          }
         }
       }
     }
@@ -985,7 +998,7 @@ namespace P64::Coll {
               continue;
             }
           }
-          collideDetectObjectToObject(collider, rbA, collB, rbB);
+          collideDetectObjectToObject(collider, rbA, collB, rbB, true);
         }
       }
     }
@@ -1022,7 +1035,7 @@ namespace P64::Coll {
         //prevent perpetural collision checks of sleeping objects with meshes
         if(!mesh->transformChanged_ && rigidBodyA && rigidBodyA->isSleeping_ && !collA->isTrigger_)
           continue;
-        collideDetectObjectToMesh(collA, rigidBodyA, *mesh);
+        collideDetectObjectToMesh(collA, rigidBodyA, *mesh, true);
       }
 
     }

--- a/n64/engine/src/collision/epa.cpp
+++ b/n64/engine/src/collision/epa.cpp
@@ -368,7 +368,7 @@ bool P64::Coll::epaSolve(
 
   SimplexTriangle *closest = nullptr;
   float projection = 0.0f;
-  float epaTolerance = EPA_CONVERGENCE_TOLERANCE * collisionSceneGetInstance()->getPhysicsScale();
+  float epaTolerance = EPA_CONVERGENCE_TOLERANCE;
 
   for(int i = 0; i < EPA_MAX_ITERATIONS; ++i) {
     closest = &closestFace(es);

--- a/n64/engine/src/collision/gfx_scale.cpp
+++ b/n64/engine/src/collision/gfx_scale.cpp
@@ -1,0 +1,16 @@
+#include "collision/gfx_scale.h"
+
+namespace P64::Coll {
+    constexpr float DEFAULT_GFX_SCALE = 100.0f;
+
+    static float gfxScale_{DEFAULT_GFX_SCALE};
+    static float inverseGfxScale_{1.0f / DEFAULT_GFX_SCALE};
+
+    float getGfxScale() { return gfxScale_; }
+    float getInvGfxScale() { return inverseGfxScale_; }
+
+    void setGfxScale(float gfxScale) {
+        gfxScale_ = gfxScale;
+        inverseGfxScale_ = 1.0f / gfxScale;
+    }
+}

--- a/n64/engine/src/collision/mesh_collider.cpp
+++ b/n64/engine/src/collision/mesh_collider.cpp
@@ -3,6 +3,7 @@
  * @author Kevin Reier <https://github.com/Byterset>
  * @brief Mesh Collider definitions and functions (see mesh_collider.h)
  */
+#include "collision/gfx_scale.h"
 #include "collision/mesh_collider.h"
 #include "collision/collider_shape.h"
 #include "scene/object.h"
@@ -103,7 +104,7 @@ namespace P64::Coll {
   // ── MeshCollider transform ────────────────────────────────────────
 
   fm_vec3_t MeshCollider::toWorldSpace(const fm_vec3_t &localPoint) const {
-    fm_vec3_t position = owner_ ? owner_->pos : VEC3_ZERO;
+    fm_vec3_t position = owner_ ? owner_->pos * getInvGfxScale() : VEC3_ZERO;
     fm_quat_t rotation = owner_ ? owner_->rot : QUAT_IDENTITY;
     fm_vec3_t scale = owner_ ? owner_->scale : fm_vec3_t{{1.0f, 1.0f, 1.0f}};
     fm_vec3_t scaled = localPoint * scale;
@@ -120,7 +121,7 @@ namespace P64::Coll {
     fm_vec3_t p = worldPoint;
     fm_vec3_t scale = owner_ ? owner_->scale : fm_vec3_t{{1.0f, 1.0f, 1.0f}};
     if(hasPosition()) {
-      p = p - owner_->pos;
+      p = p - owner_->pos * getInvGfxScale();
     }
     if(hasRotation()) {
       p = quatConjugate(owner_->rot) * p;
@@ -163,7 +164,8 @@ namespace P64::Coll {
 
   bool MeshCollider::hasPosition() const {
     if(!owner_) return false;
-    return fm_vec3_len2(&owner_->pos) > FM_EPSILON * FM_EPSILON;
+    fm_vec3_t ownerPhysicsPos = owner_->pos * getInvGfxScale();
+    return fm_vec3_len2(&ownerPhysicsPos) > FM_EPSILON * FM_EPSILON;
   }
 
   bool MeshCollider::hasScale() const {
@@ -183,7 +185,8 @@ namespace P64::Coll {
     if(!owner_) return false;
     if(!hasCachedOwnerTransform_) return true;
 
-    if(fm_vec3_distance2(&owner_->pos, &lastOwnerPosition_) > FM_EPSILON * FM_EPSILON) return true;
+  fm_vec3_t ownerPhysicsPos = owner_->pos * getInvGfxScale();
+    if(fm_vec3_distance2(&ownerPhysicsPos, &lastOwnerPosition_) > FM_EPSILON * FM_EPSILON) return true;
     if(fm_vec3_distance2(&owner_->scale, &lastOwnerScale_) > FM_EPSILON * FM_EPSILON) return true;
 
     const float rotSim = fabsf(quatDot(owner_->rot, lastOwnerRotation_));
@@ -196,7 +199,7 @@ namespace P64::Coll {
       lastOwnerRotation_ = QUAT_IDENTITY;
       lastOwnerScale_ = fm_vec3_t{{1.0f, 1.0f, 1.0f}};
     } else {
-      lastOwnerPosition_ = owner_->pos;
+      lastOwnerPosition_ = owner_->pos * getInvGfxScale();
       lastOwnerRotation_ = owner_->rot;
       lastOwnerScale_ = owner_->scale;
     }
@@ -300,7 +303,7 @@ namespace P64::Coll {
     // Copy vertex data
     collider->vertices_ = new fm_vec3_t[header->vertCount];
     for(uint32_t i = 0; i < header->vertCount; ++i) {
-      collider->vertices_[i] = vertexData[i];
+      collider->vertices_[i] = vertexData[i] * getInvGfxScale();
     }
 
     // Copy triangle indices

--- a/n64/engine/src/collision/rigid_body.cpp
+++ b/n64/engine/src/collision/rigid_body.cpp
@@ -3,6 +3,7 @@
  * @author Kevin Reier <https://github.com/Byterset>
  * @brief Contains the rigidBody definition, constants and related functions (see rigid_body.h)
  */
+#include "collision/gfx_scale.h"
 #include "collision/rigid_body.h"
 #include "collision/collision_scene.h"
 #include <cassert>
@@ -139,8 +140,8 @@ namespace P64::Coll {
     assertf(object, "RigidBody must be initialized with a valid owner object");
 
     owner_ = object;
-    position_ = &object->pos;
-    rotation_ = &object->rot;
+    position_ = object->pos * getInvGfxScale();
+    rotation_ = object->rot;
     aabbTreeNodeId_ = NULL_NODE;
     constraints_ = Constraint::None;
     sleepCounter_ = 0;
@@ -162,12 +163,8 @@ namespace P64::Coll {
 
     setMass(m);
 
-    if(rotation_) {
-      previousStepRotation_ = *rotation_;
-    }
-    if(position_) {
-      previousStepPosition_ = *position_;
-    }
+    previousStepRotation_ = rotation_;
+    previousStepPosition_ = position_;
     previousStepScale_ = object->scale;
   }
 
@@ -304,13 +301,10 @@ namespace P64::Coll {
     // Apply position constraints
     linearVelocity_ = constrainLinearWorld(linearVelocity_);
 
-    CollisionScene *scene = collisionSceneGetInstance();
-    float physicsScale = scene->getPhysicsScale();
-
     // Clamp to terminal speed
     float speedSq = fm_vec3_len2(&linearVelocity_);
-    if(speedSq > TERMINAL_SPEED * TERMINAL_SPEED * (physicsScale * physicsScale)) {
-      linearVelocity_ = linearVelocity_ * ((TERMINAL_SPEED * physicsScale) / sqrtf(speedSq));
+    if(speedSq > TERMINAL_SPEED * TERMINAL_SPEED) {
+      linearVelocity_ = linearVelocity_ * (TERMINAL_SPEED / sqrtf(speedSq));
     }
   }
 
@@ -365,32 +359,30 @@ namespace P64::Coll {
 
   void RigidBody::integratePosition(float fixedDt) {
     if(isKinematic_ || isSleeping_) return;
-    if(!position_) return;
 
     float dt = fixedDt * timeScale_;
-    previousStepPosition_ = *position_;
-    *position_ = *position_ + (linearVelocity_ * dt);
+    previousStepPosition_ = position_;
+    position_ += (linearVelocity_ * dt);
   }
 
   void RigidBody::integrateRotation(float fixedDt) {
     if(isKinematic_ || isSleeping_) return;
-    if(!rotation_) return;
     if(vec3IsZero(angularVelocity_)) return;
 
     float dt = fixedDt * timeScale_;
 
-    previousStepRotation_ = *rotation_;
+    previousStepRotation_ = rotation_;
 
     // Store old world center of mass for offset correction
-    fm_vec3_t oldWorldCOM = *position_ + (*rotation_ * centerOffset_);
+    fm_vec3_t oldWorldCOM = position_ + (rotation_ * centerOffset_);
 
-    *rotation_ = quatApplyAngularVelocity(*rotation_, angularVelocity_, dt);
+    rotation_ = quatApplyAngularVelocity(rotation_, angularVelocity_, dt);
 
     // Correct position so that the center of mass stays in place
     if(!vec3IsZero(centerOffset_)) {
-      fm_vec3_t newWorldCOM = *position_ + (*rotation_ * centerOffset_);
+      fm_vec3_t newWorldCOM = position_ + (rotation_ * centerOffset_);
       fm_vec3_t correction = oldWorldCOM - newWorldCOM;
-      *position_ = *position_ + correction;
+      position_ += correction;
     }
   }
 
@@ -451,14 +443,14 @@ namespace P64::Coll {
   }
 
   void RigidBody::updateWorldInertia() {
-    Matrix3x3 newRotationMatrix = rotation_ ? quatToMatrix3(*rotation_) : Matrix3x3::identity();
-    Matrix3x3 newInverseRotationMatrix = rotation_ ? quatToMatrix3(quatConjugate(*rotation_)) : Matrix3x3::identity();
+    Matrix3x3 newRotationMatrix = quatToMatrix3(rotation_);
+    Matrix3x3 newInverseRotationMatrix = quatToMatrix3(quatConjugate(rotation_));
 
     const Matrix3x3 localInv = diagonalMatrix(invLocalInertiaTensor_);
     Matrix3x3 newInvWorldInertiaTensor = matrix3Mul(matrix3Mul(newRotationMatrix, localInv), matrix3Transpose(newRotationMatrix));
 
     const fm_vec3_t worldOffset = matrix3Vec3Mul(newRotationMatrix, centerOffset_);
-    const fm_vec3_t newWorldCenterOfMass = position_ ? *position_ + worldOffset : worldOffset;
+    const fm_vec3_t newWorldCenterOfMass = position_ + worldOffset;
     const bool transformChanged = !matrix3Equals(rotationMatrix_, newRotationMatrix) ||
                     !matrix3Equals(inverseRotationMatrix_, newInverseRotationMatrix) ||
                     !matrix3Equals(invWorldInertiaTensor_, newInvWorldInertiaTensor) ||
@@ -468,9 +460,6 @@ namespace P64::Coll {
     inverseRotationMatrix_ = newInverseRotationMatrix;
     invWorldInertiaTensor_ = newInvWorldInertiaTensor;
 
-    if(rotation_) {
-      rotationMatrix_ = newRotationMatrix;
-    }
     refreshAngularConstraintProjection();
     refreshConstrainedInertiaTensor();
     worldCenterOfMass_ = newWorldCenterOfMass;
@@ -480,30 +469,25 @@ namespace P64::Coll {
   }
 
   fm_vec3_t RigidBody::toWorldSpace(const fm_vec3_t &localPoint) const {
-    if(!position_) return localPoint;
-    return *position_ + rotateToWorld(localPoint);
+    return position_ + rotateToWorld(localPoint);
   }
 
   fm_vec3_t RigidBody::toLocalSpace(const fm_vec3_t &worldPoint) const {
-    if(!position_) return worldPoint;
-    return rotateToLocal(worldPoint - *position_);
+    return rotateToLocal(worldPoint - position_);
   }
 
   fm_vec3_t RigidBody::rotateToWorld(const fm_vec3_t &localDir) const {
-    if(!rotation_) return localDir;
-    return *rotation_ * localDir;
+    return rotation_ * localDir;
   }
 
   fm_vec3_t RigidBody::rotateToLocal(const fm_vec3_t &worldDir) const {
-    if(!rotation_) return worldDir;
-    return quatConjugate(*rotation_) * worldDir;
+    return quatConjugate(rotation_) * worldDir;
   }
 
   void RigidBody::applyPositionConstraints() {
-    if(!position_) return;
-    if(hasFlag(constraints_, Constraint::FreezePosX)) position_->x = previousStepPosition_.x;
-    if(hasFlag(constraints_, Constraint::FreezePosY)) position_->y = previousStepPosition_.y;
-    if(hasFlag(constraints_, Constraint::FreezePosZ)) position_->z = previousStepPosition_.z;
+    if(hasFlag(constraints_, Constraint::FreezePosX)) position_.x = previousStepPosition_.x;
+    if(hasFlag(constraints_, Constraint::FreezePosY)) position_.y = previousStepPosition_.y;
+    if(hasFlag(constraints_, Constraint::FreezePosZ)) position_.z = previousStepPosition_.z;
   }
 
 } // namespace P64::Coll

--- a/n64/engine/src/scene/components/collBody.cpp
+++ b/n64/engine/src/scene/components/collBody.cpp
@@ -2,7 +2,8 @@
 * @copyright 2025 - Max Bebök
 * @license MIT
 */
-#include "scene/object.h"
+#include "collision/gfx_scale.h"
+
 #include "scene/components/collBody.h"
 
 #include "scene/scene.h"
@@ -49,9 +50,9 @@ namespace P64::Comp
     data->collider.setParentOffset(initData->offset);
 
     fm_vec3_t scaledHalfExtend = initData->halfExtend * obj.scale;
-    scaledHalfExtend.x = fabsf(scaledHalfExtend.x);
-    scaledHalfExtend.y = fabsf(scaledHalfExtend.y);
-    scaledHalfExtend.z = fabsf(scaledHalfExtend.z);
+    scaledHalfExtend.x = fabsf(scaledHalfExtend.x) * P64::Coll::getInvGfxScale();
+    scaledHalfExtend.y = fabsf(scaledHalfExtend.y) * P64::Coll::getInvGfxScale();
+    scaledHalfExtend.z = fabsf(scaledHalfExtend.z) * P64::Coll::getInvGfxScale();
 
     data->collider.setTrigger(initData->isTrigger);
     data->collider.setCollisionMask(initData->maskRead, initData->maskWrite);
@@ -99,9 +100,9 @@ namespace P64::Comp
   void CollBody::update(Object &obj, CollBody* data, float deltaTime)
   {
     fm_vec3_t scaledHalfExtend = data->orgScale * obj.scale;
-    scaledHalfExtend.x = fabsf(scaledHalfExtend.x);
-    scaledHalfExtend.y = fabsf(scaledHalfExtend.y);
-    scaledHalfExtend.z = fabsf(scaledHalfExtend.z);
+    scaledHalfExtend.x = fabsf(scaledHalfExtend.x) * Coll::getInvGfxScale();
+    scaledHalfExtend.y = fabsf(scaledHalfExtend.y) * Coll::getInvGfxScale();
+    scaledHalfExtend.z = fabsf(scaledHalfExtend.z) * Coll::getInvGfxScale();
 
     switch(data->collider.shapeType())
     {

--- a/n64/engine/src/scene/scene.cpp
+++ b/n64/engine/src/scene/scene.cpp
@@ -122,7 +122,7 @@ P64::Scene::Scene(uint16_t sceneId, Scene** ref)
     conf.gravity,
     conf.velocitySolverIterations,
     conf.positionSolverIterations,
-    conf.physicsScale
+    conf.physicsScale // TODO: Rename to gfxScale
   );
   loadScene();
 

--- a/n64/engine/src/scene/scene.cpp
+++ b/n64/engine/src/scene/scene.cpp
@@ -122,7 +122,7 @@ P64::Scene::Scene(uint16_t sceneId, Scene** ref)
     conf.gravity,
     conf.velocitySolverIterations,
     conf.positionSolverIterations,
-    conf.physicsScale // TODO: Rename to gfxScale
+    conf.visualUnitsPerMeter
   );
   loadScene();
 

--- a/n64/examples/baked_light/data/scenes/1/scene.json
+++ b/n64/examples/baked_light/data/scenes/1/scene.json
@@ -95,11 +95,11 @@
       }
     ],
     "name": "Light+AO Glossy",
-    "physicsScale": 16.0,
     "physicsTickRate": 50,
     "positionSolverIterations": 6,
     "renderPipeline": 0,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/examples/baked_light/data/scenes/2/scene.json
+++ b/n64/examples/baked_light/data/scenes/2/scene.json
@@ -95,11 +95,11 @@
       }
     ],
     "name": "Light+AO",
-    "physicsScale": 16.0,
     "physicsTickRate": 50,
     "positionSolverIterations": 6,
     "renderPipeline": 0,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/examples/jam25/data/scenes/1/scene.json
+++ b/n64/examples/jam25/data/scenes/1/scene.json
@@ -112,11 +112,11 @@
       }
     ],
     "name": "Test-Player",
-    "physicsScale": 16.0,
     "physicsTickRate": 50,
     "positionSolverIterations": 9,
     "renderPipeline": 0,
-    "velocitySolverIterations": 9
+    "velocitySolverIterations": 9,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/examples/jam25/data/scenes/10/scene.json
+++ b/n64/examples/jam25/data/scenes/10/scene.json
@@ -78,11 +78,11 @@
       }
     ],
     "name": "Boot-Check",
-    "physicsScale": 16.0,
     "physicsTickRate": 50,
     "positionSolverIterations": 6,
     "renderPipeline": 0,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/examples/jam25/data/scenes/11/scene.json
+++ b/n64/examples/jam25/data/scenes/11/scene.json
@@ -78,11 +78,11 @@
       }
     ],
     "name": "Boot-Logos",
-    "physicsScale": 16.0,
     "physicsTickRate": 50,
     "positionSolverIterations": 6,
     "renderPipeline": 0,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/examples/jam25/data/scenes/2/scene.json
+++ b/n64/examples/jam25/data/scenes/2/scene.json
@@ -95,11 +95,11 @@
       }
     ],
     "name": "Menu",
-    "physicsScale": 16.0,
     "physicsTickRate": 50,
     "positionSolverIterations": 6,
     "renderPipeline": 2,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/examples/jam25/data/scenes/3/scene.json
+++ b/n64/examples/jam25/data/scenes/3/scene.json
@@ -95,11 +95,11 @@
       }
     ],
     "name": "Test-HDR",
-    "physicsScale": 16.0,
     "physicsTickRate": 50,
     "positionSolverIterations": 6,
     "renderPipeline": 1,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/examples/jam25/data/scenes/4/scene.json
+++ b/n64/examples/jam25/data/scenes/4/scene.json
@@ -112,11 +112,11 @@
       }
     ],
     "name": "Map-Ending",
-    "physicsScale": 16.0,
     "physicsTickRate": 50,
     "positionSolverIterations": 6,
     "renderPipeline": 2,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/examples/jam25/data/scenes/5/scene.json
+++ b/n64/examples/jam25/data/scenes/5/scene.json
@@ -95,11 +95,11 @@
       }
     ],
     "name": "Credits",
-    "physicsScale": 16.0,
     "physicsTickRate": 50,
     "positionSolverIterations": 6,
     "renderPipeline": 0,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/examples/jam25/data/scenes/6/scene.json
+++ b/n64/examples/jam25/data/scenes/6/scene.json
@@ -95,11 +95,11 @@
       }
     ],
     "name": "Map-Retro",
-    "physicsScale": 16.0,
     "physicsTickRate": 50,
     "positionSolverIterations": 6,
     "renderPipeline": 0,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/examples/jam25/data/scenes/7/scene.json
+++ b/n64/examples/jam25/data/scenes/7/scene.json
@@ -16,7 +16,7 @@
     "frameLimit": 0,
     "gravity": [
       0.0,
-      -9.8100004196167,
+      -1.5679999589920044,
       0.0
     ],
     "interpolatePhysicsTransforms": true,

--- a/n64/examples/jam25/data/scenes/7/scene.json
+++ b/n64/examples/jam25/data/scenes/7/scene.json
@@ -95,11 +95,11 @@
       }
     ],
     "name": "Map-Intro",
-    "physicsScale": 16.0,
     "physicsTickRate": 60,
     "positionSolverIterations": 6,
     "renderPipeline": 0,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/examples/jam25/data/scenes/8/scene.json
+++ b/n64/examples/jam25/data/scenes/8/scene.json
@@ -95,11 +95,11 @@
       }
     ],
     "name": "Map-Paper",
-    "physicsScale": 16.0,
     "physicsTickRate": 50,
     "positionSolverIterations": 6,
     "renderPipeline": 0,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/examples/jam25/data/scenes/9/scene.json
+++ b/n64/examples/jam25/data/scenes/9/scene.json
@@ -95,11 +95,11 @@
       }
     ],
     "name": "Test",
-    "physicsScale": 16.0,
     "physicsTickRate": 50,
     "positionSolverIterations": 6,
     "renderPipeline": 2,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/examples/jam25/src/user/Player.cpp
+++ b/n64/examples/jam25/src/user/Player.cpp
@@ -76,6 +76,7 @@ namespace P64::Script::C17EA8EAB6CF1DEB
 
     float targetAnimBlend;
 
+    Coll::RigidBody* rigidBody;
     Coll::RaycastHit floorCast;
     Coll::Attach meshAttach;
     Comp::AnimModel *anim;
@@ -93,8 +94,11 @@ namespace P64::Script::C17EA8EAB6CF1DEB
   {
     sys_hw_memset((void*)data, 0, sizeof(Data));
 
+    auto rb_comp = obj.getComponent<Comp::RigidBody>();
+    data->rigidBody = &rb_comp->rigid_body;
+
     data->camPitch = 0.31f;
-    data->lastSafePos = obj.pos;
+    data->lastSafePos = data->rigidBody->position();
 
     User::ctx.controlledId = obj.id;
     User::ctx.healthTotal = 16;
@@ -104,15 +108,11 @@ namespace P64::Script::C17EA8EAB6CF1DEB
 
   void update(Object& obj, Data *data, float deltaTime)
   {
-    auto rb_comp = obj.getComponent<Comp::RigidBody>();
     if(data->anim == nullptr) {
       data->anim = obj.getComponent<Comp::AnimModel>();
       data->anim->setMainAnim(1);
       data->anim->setBlendAnim(0);
     }
-
-    auto &rb = rb_comp->rigid_body;
-    float gfxScale = P64::Coll::getGfxScale();
 
     User::ctx.playerPos = obj.pos;
 
@@ -312,7 +312,7 @@ namespace P64::Script::C17EA8EAB6CF1DEB
     }
 
     if(onFloor && data->notMovingTime > 30.0_ms) {
-      data->lastSafePos = obj.pos;
+      data->lastSafePos = data->rigidBody->position();
     }
 
     // SFX- Hit floor impact
@@ -332,7 +332,8 @@ namespace P64::Script::C17EA8EAB6CF1DEB
     {
       data->dustTimer = 0.1f + Math::rand01() * 0.3f;
       auto seed = (uint32_t)rand();
-      spawnParticles(rb.worldCenterOfMass() * gfxScale, seed % 3 + 1, seed, 40.0f, 0.5f);
+      float gfxScale = P64::Coll::getGfxScale();
+      spawnParticles(data->rigidBody->worldCenterOfMass() * gfxScale, seed % 3 + 1, seed, 40.0f, 0.5f);
     }
 
     data->lastFramePos = obj.pos;
@@ -362,22 +363,21 @@ namespace P64::Script::C17EA8EAB6CF1DEB
 
   void fixedUpdate(Object& obj, Data *data, float fixedDeltaTime)
   {
-    auto rb_comp = obj.getComponent<Comp::RigidBody>();
-    auto &rb = rb_comp->rigid_body;
-
-    if(rb.position().y < -10)
+    if(data->rigidBody->position().y < -10)
     {
-      obj.pos = data->lastSafePos;
-      rb.setVelocity({});
+      data->rigidBody->setPosition(data->lastSafePos);
+      data->rigidBody->setVelocity({});
       data->hurtVelocity = {};
       data->meshAttach = {};
     }
 
     if(obj.id != User::ctx.controlledId) return;
 
-    obj.pos -= data->meshAttach.update(obj.pos);
+    fm_vec3_t physicsPos = data->rigidBody->position();
+    fm_vec3_t diff = data->meshAttach.update(physicsPos);
+    data->rigidBody->setPosition(physicsPos - diff);
 
-    Coll::Raycast ray = Coll::Raycast::create(rb.worldCenterOfMass(), {0.0f, -1.0f, 0.0f}, 5.0f, Coll::RaycastColliderTypeFlags::ALL, false, 0x08);
+    Coll::Raycast ray = Coll::Raycast::create(data->rigidBody->worldCenterOfMass(), {0.0f, -1.0f, 0.0f}, 5.0f, Coll::RaycastColliderTypeFlags::ALL, false, 0x08);
     SceneManager::getCurrent().getCollision().raycast(ray, data->floorCast);
     bool onFloor = data->floorCast.didHit && data->floorCast.distance < 0.3f && data->floorCast.normal.y > 0.4f;
     bool canJump = onFloor || data->inAirTime < (1.0f / 60.0f * 4);
@@ -393,7 +393,7 @@ namespace P64::Script::C17EA8EAB6CF1DEB
       data->inAirTime += fixedDeltaTime;
     }
 
-    fm_vec3_t currVel = rb.linearVelocity();
+    fm_vec3_t currVel = data->rigidBody->linearVelocity();
     fm_vec3_t nextVel = currVel;
     if(nextVel.y < 0.0f) {
       data->isJumpEnd = true;
@@ -434,7 +434,7 @@ namespace P64::Script::C17EA8EAB6CF1DEB
     data->hurtVelocity *= 0.8f;
     data->jumpRequested = 0;
     if(nextVel.x == currVel.x && nextVel.y == currVel.y && nextVel.z == currVel.z) return;
-      rb.setVelocity(nextVel);
+      data->rigidBody->setVelocity(nextVel);
   }
 
   void onEvent(Object& obj, Data *data, const ObjectEvent &event)

--- a/n64/examples/jam25/src/user/Player.cpp
+++ b/n64/examples/jam25/src/user/Player.cpp
@@ -9,11 +9,12 @@
 #include "systems/dropShadows.h"
 #include "systems/sprites.h"
 #include "collision/attach.h"
+#include "collision/gfx_scale.h"
 #include "../p64/assetTable.h"
 
 namespace
 {
-  constexpr float MOVE_SPEED = 170.0f;
+  constexpr float MOVE_SPEED = 1.7f;
   constexpr float MOVE_SPEED_SLOWDOWN = 0.4f;
   constexpr float MOVE_YAW_LERP = 0.22f;
 
@@ -111,6 +112,7 @@ namespace P64::Script::C17EA8EAB6CF1DEB
     }
 
     auto &rb = rb_comp->rigid_body;
+    float gfxScale = P64::Coll::getGfxScale();
 
     User::ctx.playerPos = obj.pos;
 
@@ -158,7 +160,7 @@ namespace P64::Script::C17EA8EAB6CF1DEB
       held = {};
     }
 
-    bool onFloor = data->floorCast.didHit && data->floorCast.distance < 26.0f && data->floorCast.normal.y > 0.4f;
+    bool onFloor = data->floorCast.didHit && data->floorCast.distance < 0.26f && data->floorCast.normal.y > 0.4f;
 
     data->jumpHeld = inp.btn.a;
     if(pressed.a) {
@@ -330,7 +332,7 @@ namespace P64::Script::C17EA8EAB6CF1DEB
     {
       data->dustTimer = 0.1f + Math::rand01() * 0.3f;
       auto seed = (uint32_t)rand();
-      spawnParticles(rb.worldCenterOfMass(), seed % 3 + 1, seed, 40.0f, 0.5f);
+      spawnParticles(rb.worldCenterOfMass() * gfxScale, seed % 3 + 1, seed, 40.0f, 0.5f);
     }
 
     data->lastFramePos = obj.pos;
@@ -363,7 +365,7 @@ namespace P64::Script::C17EA8EAB6CF1DEB
     auto rb_comp = obj.getComponent<Comp::RigidBody>();
     auto &rb = rb_comp->rigid_body;
 
-    if(rb.positionPtr()->y < -1000)
+    if(rb.position().y < -10)
     {
       obj.pos = data->lastSafePos;
       rb.setVelocity({});
@@ -375,9 +377,9 @@ namespace P64::Script::C17EA8EAB6CF1DEB
 
     obj.pos -= data->meshAttach.update(obj.pos);
 
-    Coll::Raycast ray = Coll::Raycast::create(rb.worldCenterOfMass(), {0.0f, -1.0f, 0.0f}, 500.0f, Coll::RaycastColliderTypeFlags::ALL, false, 0x08);
+    Coll::Raycast ray = Coll::Raycast::create(rb.worldCenterOfMass(), {0.0f, -1.0f, 0.0f}, 5.0f, Coll::RaycastColliderTypeFlags::ALL, false, 0x08);
     SceneManager::getCurrent().getCollision().raycast(ray, data->floorCast);
-    bool onFloor = data->floorCast.didHit && data->floorCast.distance < 30.0f && data->floorCast.normal.y > 0.4f;
+    bool onFloor = data->floorCast.didHit && data->floorCast.distance < 0.3f && data->floorCast.normal.y > 0.4f;
     bool canJump = onFloor || data->inAirTime < (1.0f / 60.0f * 4);
 
     if(onFloor) {
@@ -396,7 +398,7 @@ namespace P64::Script::C17EA8EAB6CF1DEB
     if(nextVel.y < 0.0f) {
       data->isJumpEnd = true;
     }
-    if(nextVel.y > 1.0f && !data->isJumpEnd && !data->jumpHeld) {
+    if(nextVel.y > 0.01f && !data->isJumpEnd && !data->jumpHeld) {
       data->isJumpEnd = true;
     }
 
@@ -404,11 +406,11 @@ namespace P64::Script::C17EA8EAB6CF1DEB
     nextVel.z *= MOVE_SPEED_SLOWDOWN;
 
     if(!data->isJumpEnd && data->jumpHeld) {
-      nextVel.y += 360.0f * fixedDeltaTime;
+      nextVel.y += 3.6f * fixedDeltaTime;
     }
 
     if(canJump && data->jumpRequested) {
-      nextVel.y += std::exp(1.0f / 60.0f * fixedDeltaTime) * 270.0f;
+      nextVel.y += std::exp(1.0f / 60.0f * fixedDeltaTime) * 2.7f;
       data->isJumpEnd = false;
       data->isMidJump = true;
 
@@ -473,8 +475,8 @@ namespace P64::Script::C17EA8EAB6CF1DEB
         auto posDiff = event.selfCollider->worldCenter() - event.hitCollider->worldCenter();
         fm_vec3_norm(&posDiff, &posDiff);
 
-        data->hurtVelocity = posDiff * 400.0f;
-        data->hurtVelocity.y = 40.f;
+        data->hurtVelocity = posDiff * 4.0f;
+        data->hurtVelocity.y = 0.4f;
       }
 
       hurt(obj, data, 1);
@@ -484,13 +486,14 @@ namespace P64::Script::C17EA8EAB6CF1DEB
   void draw(Object& obj, Data *data, float deltaTime)
   {
     // drop shadow
-    float shadowHeight = obj.pos.y - data->floorCast.point.y;
+    float floorY = data->floorCast.point.y * P64::Coll::getGfxScale();
+    float shadowHeight = obj.pos.y - floorY;
     shadowHeight *= 0.001f;
     shadowHeight = Math::clamp(shadowHeight, 0.0f, 1.0f);
     shadowHeight = 1.0f - shadowHeight;
     if(data->floorCast.didHit)
       User::DropShadows::addShadow(
-          {obj.pos.x, data->floorCast.point.y, obj.pos.z},
+          {obj.pos.x, floorY, obj.pos.z},
           data->floorCast.normal,
           0.55f * shadowHeight,
           1.0f);

--- a/n64/examples/material_test/data/scenes/1/scene.json
+++ b/n64/examples/material_test/data/scenes/1/scene.json
@@ -129,11 +129,11 @@
       }
     ],
     "name": "Materials",
-    "physicsScale": 16.0,
     "physicsTickRate": 50,
     "positionSolverIterations": 6,
     "renderPipeline": 0,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/examples/material_test/data/scenes/2/scene.json
+++ b/n64/examples/material_test/data/scenes/2/scene.json
@@ -95,11 +95,11 @@
       }
     ],
     "name": "Dungeon",
-    "physicsScale": 16.0,
     "physicsTickRate": 50,
     "positionSolverIterations": 6,
     "renderPipeline": 0,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/tests/test_obj_states/data/scenes/1/scene.json
+++ b/n64/tests/test_obj_states/data/scenes/1/scene.json
@@ -91,11 +91,11 @@
       }
     ],
     "name": "Flat",
-    "physicsScale": 16.0,
     "physicsTickRate": 11,
     "positionSolverIterations": 6,
     "renderPipeline": 0,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/tests/test_obj_states/data/scenes/2/scene.json
+++ b/n64/tests/test_obj_states/data/scenes/2/scene.json
@@ -91,11 +91,11 @@
       }
     ],
     "name": "Nested",
-    "physicsScale": 16.0,
     "physicsTickRate": 11,
     "positionSolverIterations": 6,
     "renderPipeline": 0,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/tests/test_obj_states/data/scenes/3/scene.json
+++ b/n64/tests/test_obj_states/data/scenes/3/scene.json
@@ -91,11 +91,11 @@
       }
     ],
     "name": "Nested Disabled",
-    "physicsScale": 16.0,
     "physicsTickRate": 11,
     "positionSolverIterations": 6,
     "renderPipeline": 0,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/n64/tests/test_obj_states/data/scenes/4/scene.json
+++ b/n64/tests/test_obj_states/data/scenes/4/scene.json
@@ -91,11 +91,11 @@
       }
     ],
     "name": "State Changes",
-    "physicsScale": 16.0,
     "physicsTickRate": 11,
     "positionSolverIterations": 6,
     "renderPipeline": 0,
-    "velocitySolverIterations": 7
+    "velocitySolverIterations": 7,
+    "visualUnitsPerMeter": 100.0
   },
   "graph": {
     "children": [

--- a/src/build/sceneBuilder.cpp
+++ b/src/build/sceneBuilder.cpp
@@ -154,7 +154,7 @@ void Build::buildScene(Project::Project &project, const Project::SceneEntry &sce
   ctx.fileScene.write<float>(gravity.x);
   ctx.fileScene.write<float>(gravity.y);
   ctx.fileScene.write<float>(gravity.z);
-  ctx.fileScene.write<float>(std::max(sc->conf.physicsScale.value, 0.001f));
+  ctx.fileScene.write<float>(std::max(sc->conf.visualUnitsPerMeter.value, 0.001f));
 
   ctx.fileScene.write<uint8_t>(std::clamp(sc->conf.velocitySolverIterations.value, 1, 32));
   ctx.fileScene.write<uint8_t>(std::clamp(sc->conf.positionSolverIterations.value, 1, 32));

--- a/src/editor/pages/parts/sceneInspector.cpp
+++ b/src/editor/pages/parts/sceneInspector.cpp
@@ -105,7 +105,7 @@ void Editor::SceneInspector::draw() {
     ImTable::add("Tick Rate", scene->conf.physicsTickRate.value);
     ImTable::add("Interpolate Transforms", scene->conf.interpolatePhysicsTransforms.value);
     ImTable::add("Gravity", scene->conf.gravity.value);
-    ImTable::add("Physics Scale", scene->conf.physicsScale.value);
+    ImTable::add("Visual Units Per Meter", scene->conf.visualUnitsPerMeter.value);
     ImTable::add("Solver Vel. Iterations", scene->conf.velocitySolverIterations.value);
     ImTable::add("Solver Pos. Iterations", scene->conf.positionSolverIterations.value);
     ImTable::end();

--- a/src/project/scene/scene.cpp
+++ b/src/project/scene/scene.cpp
@@ -73,7 +73,7 @@ nlohmann::json Project::SceneConf::serialize() const {
     .set(audioFreq)
     .set(physicsTickRate)
     .set(gravity)
-    .set(physicsScale)
+    .set(visualUnitsPerMeter)
     .set(velocitySolverIterations)
     .set(positionSolverIterations)
     .set(interpolatePhysicsTransforms)
@@ -328,7 +328,7 @@ void Project::Scene::deserialize(const std::string &data)
     Utils::JSON::readProp(docConf, conf.audioFreq, 32000);
     Utils::JSON::readProp(docConf, conf.physicsTickRate, 50);
     Utils::JSON::readProp(docConf, conf.gravity, glm::vec3{0.0f, -9.81f, 0.0f});
-    Utils::JSON::readProp(docConf, conf.physicsScale, 16.0f);
+    Utils::JSON::readProp(docConf, conf.visualUnitsPerMeter, 100.0f);
     Utils::JSON::readProp(docConf, conf.velocitySolverIterations, 7);
     Utils::JSON::readProp(docConf, conf.positionSolverIterations, 6);
     Utils::JSON::readProp(docConf, conf.interpolatePhysicsTransforms, true);

--- a/src/project/scene/scene.h
+++ b/src/project/scene/scene.h
@@ -41,7 +41,7 @@ namespace Project
     PROP_S32(audioFreq);
     PROP_S32(physicsTickRate);
     PROP_VEC3(gravity);
-    PROP_FLOAT(physicsScale);
+    PROP_FLOAT(visualUnitsPerMeter);
     PROP_S32(velocitySolverIterations);
     PROP_S32(positionSolverIterations);
     PROP_BOOL(interpolatePhysicsTransforms);


### PR DESCRIPTION
I'm not sure on 100% of the implementation details but this is a proof-of-concept for the approach discussed on Discord where the physics scale uses standard metric units (1 unit = 1 meter) and never changes, and the graphical positions are scaled at the boundary (using a user-configurable scale) to match the physics positions.

This changes the "Physics Scale" config in the UI to "Visual Units Per Meter" (with a default of 100) to try to indicate that it is purely a visual scale, but maybe there is a better display name for this.

I fixed the jam25 example (I think) and the debug drawing and cleaned things up a bit to try to make it PR-ready but this is probably still missing something; let me know or feel free to make changes here or whatever