### PR TITLE
Add an applyLinearForce method

### DIFF
--- a/n64/engine/include/collision/rigidBody.h
+++ b/n64/engine/include/collision/rigidBody.h
@@ -127,6 +127,7 @@ namespace P64::Coll {
 
     void accelerate(const fm_vec3_t &accel);
     void setVelocity(const fm_vec3_t &vel);
+    void applyLinearForce(const fm_vec3_t &force);
     void applyLinearImpulse(const fm_vec3_t &impulse);
     void applyTorque(const fm_vec3_t &torque);
     void applyAngularImpulse(const fm_vec3_t &angImpulse);

--- a/n64/engine/src/collision/rigidBody.cpp
+++ b/n64/engine/src/collision/rigidBody.cpp
@@ -396,6 +396,11 @@ namespace P64::Coll {
     if(isSleeping_) wake();
   }
 
+  void RigidBody::applyLinearForce(const fm_vec3_t &force) {
+    if(isKinematic_) return;
+    accelerate(force * inverseMass_);
+  }
+
   void RigidBody::applyLinearImpulse(const fm_vec3_t &impulse) {
     if(isKinematic_) return;
     fm_vec3_t deltaV = constrainLinearWorld(impulse * inverseMass_);


### PR DESCRIPTION
This is a common method to have in a physics engine, and I just ran into a situation where I felt the lack of it!

It's the same as applyForceAtPoint using worldCenterOfMass_ but it saves CPU cycles since it doesn't do any cross product calculation or try to apply torque.