### PR TITLE
Don't change velocity on hit during swept substep detection

### DIFF
--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -917,9 +917,7 @@ namespace P64::Coll {
         if (hit) break;
       }
 
-      if (hit) {
-        body->setVelocity(VEC3_ZERO);
-      } else {
+      if (!hit) {
         // Restore original position and sync colliders back
         body->position_ = originalPos;
         for(Collider *collider : *ownerColliders) {


### PR DESCRIPTION
I realized I probably should not have made this change in #228 

It doesn't seem to make a difference that I have noticed in my testing, but it still seems like it doesn't belong here and it should be handled by the collision resolution.

The rest of the change (i.e. keeping track of whether there was a hit and if so, exiting early and not resetting the position of the body/colliders) still makes sense though.

CC @Byterset 
