### PR TITLE
Add a localCenterOfMassOffset property to RigidBody

### DIFF
--- a/n64/engine/include/collision/rigidBody.h
+++ b/n64/engine/include/collision/rigidBody.h
@@ -106,12 +106,12 @@ namespace P64::Coll {
     bool isSleeping() const { return isSleeping_; }
 
     bool compoundPropertiesDirty() const { return compoundPropertiesDirty_; }
-    const fm_vec3_t &getCenterOffset() const { return centerOffset_; }
+    const fm_vec3_t &getLocalCenterOfMass() const { return localCenterOfMass_; }
     const fm_vec3_t &getLocalInertiaTensor() const { return localInertiaTensor_; }
     const fm_vec3_t &getDefaultLocalInertiaTensor() const { return defaultLocalInertiaTensor_; }
     const fm_vec3_t &getCompoundScale() const { return compoundScale_; }
     void markCompoundPropertiesDirty() { compoundPropertiesDirty_ = true; }
-    void applyCompoundProperties(const fm_vec3_t &centerOffset, const fm_vec3_t &localInertiaTensor, const fm_vec3_t &compoundScale);
+    void applyCompoundProperties(const fm_vec3_t &localCenterOfMass, const fm_vec3_t &localInertiaTensor, const fm_vec3_t &compoundScale);
     void setKinematic(bool newIsKinematic) { isKinematic_ = newIsKinematic; }
 
     fm_vec3_t constrainLinearWorld(const fm_vec3_t &worldLinear) const;
@@ -190,7 +190,7 @@ namespace P64::Coll {
 
     float mass_{1.0f};
     Constraint constraints_{Constraint::None};
-    fm_vec3_t centerOffset_{};
+    fm_vec3_t localCenterOfMass_{};
     fm_vec3_t localInertiaTensor_{};
     fm_vec3_t invLocalInertiaTensor_{};
     fm_vec3_t defaultLocalInertiaTensor_{};

--- a/n64/engine/include/collision/rigidBody.h
+++ b/n64/engine/include/collision/rigidBody.h
@@ -107,6 +107,11 @@ namespace P64::Coll {
 
     bool compoundPropertiesDirty() const { return compoundPropertiesDirty_; }
     const fm_vec3_t &getLocalCenterOfMass() const { return localCenterOfMass_; }
+    const fm_vec3_t &getLocalCenterOfMassOffset() const { return localCenterOfMassOffset_; }
+    void setLocalCenterOfMassOffset(const fm_vec3_t &offset) {
+      localCenterOfMassOffset_ = offset;
+      markCompoundPropertiesDirty();
+    }
     const fm_vec3_t &getLocalInertiaTensor() const { return localInertiaTensor_; }
     const fm_vec3_t &getDefaultLocalInertiaTensor() const { return defaultLocalInertiaTensor_; }
     const fm_vec3_t &getCompoundScale() const { return compoundScale_; }
@@ -191,6 +196,7 @@ namespace P64::Coll {
     float mass_{1.0f};
     Constraint constraints_{Constraint::None};
     fm_vec3_t localCenterOfMass_{};
+    fm_vec3_t localCenterOfMassOffset_{};
     fm_vec3_t localInertiaTensor_{};
     fm_vec3_t invLocalInertiaTensor_{};
     fm_vec3_t defaultLocalInertiaTensor_{};

--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -216,11 +216,11 @@ namespace P64::Coll {
     const float invCount = 1.0f / static_cast<float>(count);
     const fm_vec3_t worldCenter = worldCenterSum * invCount;
 
-    fm_vec3_t localCenterOffset = worldCenter - rigidBody->position_;
-    localCenterOffset = quatConjugate(rigidBody->rotation_) * localCenterOffset;
+    fm_vec3_t localCenterOfMass = worldCenter - rigidBody->position_;
+    localCenterOfMass = quatConjugate(rigidBody->rotation_) * localCenterOfMass;
 
     if(rigidBody->getMass() <= FM_EPSILON) {
-      rigidBody->applyCompoundProperties(localCenterOffset, fallbackInertia, rigidBody->owner_->scale);
+      rigidBody->applyCompoundProperties(localCenterOfMass, fallbackInertia, rigidBody->owner_->scale);
       return;
     }
 
@@ -245,7 +245,7 @@ namespace P64::Coll {
       compoundInertia = compoundInertia + colliderInertia;
     }
 
-    rigidBody->applyCompoundProperties(localCenterOffset, compoundInertia, rigidBody->owner_->scale);
+    rigidBody->applyCompoundProperties(localCenterOfMass, compoundInertia, rigidBody->owner_->scale);
   }
 
   void CollisionScene::syncCompoundProperties(RigidBody *rigidBody) const {

--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -196,7 +196,7 @@ namespace P64::Coll {
 
     const std::vector<Collider *> *ownerColliders = findCollidersForOwner(rigidBody->owner_);
     if(!ownerColliders || ownerColliders->empty()) {
-      rigidBody->applyCompoundProperties(VEC3_ZERO, fallbackInertia, rigidBody->owner_->scale);
+      rigidBody->applyCompoundProperties(rigidBody->localCenterOfMassOffset_, fallbackInertia, rigidBody->owner_->scale);
       return;
     }
 
@@ -209,12 +209,12 @@ namespace P64::Coll {
     }
 
     if(count <= 0) {
-      rigidBody->applyCompoundProperties(VEC3_ZERO, fallbackInertia, rigidBody->owner_->scale);
+      rigidBody->applyCompoundProperties(rigidBody->localCenterOfMassOffset_, fallbackInertia, rigidBody->owner_->scale);
       return;
     }
 
     const float invCount = 1.0f / static_cast<float>(count);
-    const fm_vec3_t worldCenter = worldCenterSum * invCount;
+    const fm_vec3_t worldCenter = (worldCenterSum * invCount) + (rigidBody->rotation_ * rigidBody->localCenterOfMassOffset_);
 
     fm_vec3_t localCenterOfMass = worldCenter - rigidBody->position_;
     localCenterOfMass = quatConjugate(rigidBody->rotation_) * localCenterOfMass;

--- a/n64/engine/src/collision/rigidBody.cpp
+++ b/n64/engine/src/collision/rigidBody.cpp
@@ -154,6 +154,7 @@ namespace P64::Coll {
     acceleration_ = VEC3_ZERO;
     torqueAccumulator_ = VEC3_ZERO;
     localCenterOfMass_ = VEC3_ZERO;
+    localCenterOfMassOffset_ = VEC3_ZERO;
     compoundScale_ = object->scale;
     compoundPropertiesDirty_ = true;
 

--- a/n64/engine/src/collision/rigidBody.cpp
+++ b/n64/engine/src/collision/rigidBody.cpp
@@ -153,7 +153,7 @@ namespace P64::Coll {
     angularVelocity_ = VEC3_ZERO;
     acceleration_ = VEC3_ZERO;
     torqueAccumulator_ = VEC3_ZERO;
-    centerOffset_ = VEC3_ZERO;
+    localCenterOfMass_ = VEC3_ZERO;
     compoundScale_ = object->scale;
     compoundPropertiesDirty_ = true;
 
@@ -191,8 +191,8 @@ namespace P64::Coll {
     angularVelocity_ = constrainAngularWorld(angularVelocity_);
   }
 
-  void RigidBody::applyCompoundProperties(const fm_vec3_t &centerOffset, const fm_vec3_t &localInertiaTensor, const fm_vec3_t &compoundScale) {
-    centerOffset_ = centerOffset;
+  void RigidBody::applyCompoundProperties(const fm_vec3_t &localCenterOfMass, const fm_vec3_t &localInertiaTensor, const fm_vec3_t &compoundScale) {
+    localCenterOfMass_ = localCenterOfMass;
     localInertiaTensor_ = localInertiaTensor;
     invLocalInertiaTensor_ = diagonalInverse(localInertiaTensor_);
     compoundScale_ = compoundScale;
@@ -374,13 +374,13 @@ namespace P64::Coll {
     previousStepRotation_ = rotation_;
 
     // Store old world center of mass for offset correction
-    fm_vec3_t oldWorldCOM = position_ + (rotation_ * centerOffset_);
+    fm_vec3_t oldWorldCOM = position_ + (rotation_ * localCenterOfMass_);
 
     rotation_ = quatApplyAngularVelocity(rotation_, angularVelocity_, dt);
 
     // Correct position so that the center of mass stays in place
-    if(!vec3IsZero(centerOffset_)) {
-      fm_vec3_t newWorldCOM = position_ + (rotation_ * centerOffset_);
+    if(!vec3IsZero(localCenterOfMass_)) {
+      fm_vec3_t newWorldCOM = position_ + (rotation_ * localCenterOfMass_);
       fm_vec3_t correction = oldWorldCOM - newWorldCOM;
       position_ += correction;
     }
@@ -454,7 +454,7 @@ namespace P64::Coll {
     const Matrix3x3 localInv = diagonalMatrix(invLocalInertiaTensor_);
     Matrix3x3 newInvWorldInertiaTensor = matrix3Mul(matrix3Mul(newRotationMatrix, localInv), matrix3Transpose(newRotationMatrix));
 
-    const fm_vec3_t worldOffset = matrix3Vec3Mul(newRotationMatrix, centerOffset_);
+    const fm_vec3_t worldOffset = matrix3Vec3Mul(newRotationMatrix, localCenterOfMass_);
     const fm_vec3_t newWorldCenterOfMass = position_ + worldOffset;
     const bool transformChanged = !matrix3Equals(rotationMatrix_, newRotationMatrix) ||
                     !matrix3Equals(inverseRotationMatrix_, newInverseRotationMatrix) ||


### PR DESCRIPTION
This allows users to add a custom offset to whatever the automatically calculated center of mass of a RigidBody is.

The existing naming of `centerOffset_` made this really confusing, hence the rename to `localCenterOfMass` with the aim of making these two variables make sense together:

* `localCenterOfMass`: the center of mass in local space
* `localCenterOfMassOffset`: an offset applied to `localCenterOfMass`