### PR TITLE
Add method for creating custom collision mesh

### DIFF
--- a/n64/engine/include/collision/meshCollider.h
+++ b/n64/engine/include/collision/meshCollider.h
@@ -121,9 +121,9 @@ namespace P64::Coll {
 
     /// Create a MeshCollider from manually defined geometry, binding to the given Object's transform.
     /// Coordinates must use internal physics scale (i.e. 1 unit = 1 meter).
-    /// The returned collider owns newly allocated arrays (vertices, triangles, normals).
-    /// Call destroyData() to free them.
-    static MeshCollider *create(const fm_vec3_t* vertices, uint16_t vertCount, const uint16_t* indices, const fm_vec3_t* normals, uint16_t triCount, Object *obj);
+    /// Ownership of the given arrays (vertices, triangleIndices) is transferred to the returned MeshCollider
+    /// object; call destroyData() to free them.
+    static MeshCollider* create(fm_vec3_t* vertices, uint16_t vertexCount, MeshTriangleIndices* triangleIndices, uint16_t triangleCount, Object *obj);
 
     static inline fm_vec3_t triangleNormalFromVertices(const fm_vec3_t &v0, const fm_vec3_t &v1, const fm_vec3_t &v2)
     {

--- a/n64/engine/include/collision/meshCollider.h
+++ b/n64/engine/include/collision/meshCollider.h
@@ -119,6 +119,12 @@ namespace P64::Coll {
     /// Call destroyData() to free them.
     static MeshCollider *createFromRawData(void *rawData, Object *obj);
 
+    /// Create a MeshCollider from manually defined geometry, binding to the given Object's transform.
+    /// Coordinates must use internal physics scale (i.e. 1 unit = 1 meter).
+    /// The returned collider owns newly allocated arrays (vertices, triangles, normals).
+    /// Call destroyData() to free them.
+    static MeshCollider *create(const fm_vec3_t* vertices, uint16_t vertCount, const uint16_t* indices, const fm_vec3_t* normals, uint16_t triCount, Object *obj);
+
     static inline fm_vec3_t triangleNormalFromVertices(const fm_vec3_t &v0, const fm_vec3_t &v1, const fm_vec3_t &v2)
     {
       const fm_vec3_t edge0 = v1 - v0;
@@ -135,6 +141,7 @@ namespace P64::Coll {
     friend class CollisionScene;
 
     AABBTree aabbTree_{};
+    static void buildAabbTree(MeshCollider* collider);
     fm_vec3_t *vertices_{nullptr};
     MeshTriangleIndices *triangles_{nullptr};
     fm_vec3_t *normals_{nullptr};

--- a/n64/engine/src/collision/meshCollider.cpp
+++ b/n64/engine/src/collision/meshCollider.cpp
@@ -326,14 +326,21 @@ namespace P64::Coll {
     }
 
     // Bind to owner object
-  collider->owner_ = obj;
+    collider->owner_ = obj;
 
-    // Build AABB tree from triangle bounding boxes
-    // Need 2*N-1 internal nodes for N leaves, plus some margin
-    int treeCapacity = static_cast<int>(header->triCount) * 2 + 1;
+    buildAabbTree(collider);
+    collider->syncOwnerTransform();
+
+    return collider;
+  }
+
+  // Build AABB tree from triangle bounding boxes
+  // Need 2*N-1 internal nodes for N leaves, plus some margin
+  void MeshCollider::buildAabbTree(MeshCollider* collider) {
+    int treeCapacity = static_cast<int>(collider->triangleCount_) * 2 + 1;
     collider->aabbTree_.init(treeCapacity);
 
-    for(uint32_t t = 0; t < header->triCount; ++t) {
+    for(uint32_t t = 0; t < collider->triangleCount_; ++t) {
       const fm_vec3_t &v0 = collider->vertices_[collider->triangles_[t].indices[0]];
       const fm_vec3_t &v1 = collider->vertices_[collider->triangles_[t].indices[1]];
       const fm_vec3_t &v2 = collider->vertices_[collider->triangles_[t].indices[2]];
@@ -348,6 +355,37 @@ namespace P64::Coll {
 
     collider->computeLocalRootAabb();
     collider->recalculateWorldAabb();
+  }
+
+  MeshCollider* MeshCollider::create(const fm_vec3_t* vertices, uint16_t vertCount, const uint16_t* indices, const fm_vec3_t* normals, uint16_t triCount, Object *obj) {
+    if (!vertices || vertCount == 0 || !indices || triCount == 0 || !obj) return nullptr;
+
+    auto *collider = new MeshCollider();
+    collider->triangleCount_ = triCount;
+    collider->vertexCount_ = vertCount;
+    collider->owner_ = obj;
+
+    // Copy vertex data
+    collider->vertices_ = new fm_vec3_t[vertCount];
+    for (uint32_t i = 0; i < vertCount; ++i) {
+      collider->vertices_[i] = vertices[i];
+    }
+
+    // Copy triangle indices
+    collider->triangles_ = new MeshTriangleIndices[triCount];
+    for (uint32_t t = 0; t < triCount; ++t) {
+      collider->triangles_[t].indices[0] = indices[t * 3 + 0];
+      collider->triangles_[t].indices[1] = indices[t * 3 + 1];
+      collider->triangles_[t].indices[2] = indices[t * 3 + 2];
+    }
+
+    // Copy normals
+    collider->normals_ = new fm_vec3_t[triCount];
+    for (uint32_t t = 0; t < triCount; ++t) {
+      collider->normals_[t] = normals[t];
+    }
+
+    buildAabbTree(collider);
     collider->syncOwnerTransform();
 
     return collider;

--- a/n64/engine/src/collision/meshCollider.cpp
+++ b/n64/engine/src/collision/meshCollider.cpp
@@ -357,32 +357,23 @@ namespace P64::Coll {
     collider->recalculateWorldAabb();
   }
 
-  MeshCollider* MeshCollider::create(const fm_vec3_t* vertices, uint16_t vertCount, const uint16_t* indices, const fm_vec3_t* normals, uint16_t triCount, Object *obj) {
-    if (!vertices || vertCount == 0 || !indices || triCount == 0 || !obj) return nullptr;
+  MeshCollider* MeshCollider::create(fm_vec3_t* vertices, uint16_t vertexCount, MeshTriangleIndices* triangleIndices, uint16_t triangleCount, Object *obj) {
+    if (!vertices || vertexCount == 0 || !triangleIndices || triangleCount == 0 || !obj) return nullptr;
 
     auto *collider = new MeshCollider();
-    collider->triangleCount_ = triCount;
-    collider->vertexCount_ = vertCount;
+    collider->vertices_ = vertices;
+    collider->vertexCount_ = vertexCount;
+    collider->triangles_ = triangleIndices;
+    collider->triangleCount_ = triangleCount;
     collider->owner_ = obj;
 
-    // Copy vertex data
-    collider->vertices_ = new fm_vec3_t[vertCount];
-    for (uint32_t i = 0; i < vertCount; ++i) {
-      collider->vertices_[i] = vertices[i];
-    }
-
-    // Copy triangle indices
-    collider->triangles_ = new MeshTriangleIndices[triCount];
-    for (uint32_t t = 0; t < triCount; ++t) {
-      collider->triangles_[t].indices[0] = indices[t * 3 + 0];
-      collider->triangles_[t].indices[1] = indices[t * 3 + 1];
-      collider->triangles_[t].indices[2] = indices[t * 3 + 2];
-    }
-
-    // Copy normals
-    collider->normals_ = new fm_vec3_t[triCount];
-    for (uint32_t t = 0; t < triCount; ++t) {
-      collider->normals_[t] = normals[t];
+    collider->normals_ = new fm_vec3_t[triangleCount];
+    for (uint16_t t = 0; t < triangleCount; ++t) {
+      const auto& indices = triangleIndices[t].indices;
+      fm_vec3_t v0 = vertices[indices[0]];
+      fm_vec3_t v1 = vertices[indices[1]];
+      fm_vec3_t v2 = vertices[indices[2]];
+      collider->normals_[t] = triangleNormalFromVertices(v0, v1, v2);
     }
 
     buildAabbTree(collider);


### PR DESCRIPTION
This adds a function which can be called from user code to make a custom `MeshCollider` at runtime, without having to use a pre-existing model.

I've been using this successfully to generate collision for dynamically generated road meshes.