### PR TITLE
fix: capture cursor during viewport camera drags (#8)

### DIFF
--- a/src/editor/pages/parts/viewport3D.cpp
+++ b/src/editor/pages/parts/viewport3D.cpp
@@ -472,9 +472,20 @@ void Editor::Viewport3D::draw()
 
   // mouse pos
   ImVec2 screenPos = ImGui::GetCursorScreenPos();
-  mousePos = {ImGui::GetMousePos().x, ImGui::GetMousePos().y};
-  mousePos.x -= screenPos.x;
-  mousePos.y -= vpOffsetY;
+  if (cameraDragActive) {
+    float dx = 0, dy = 0;
+    SDL_GetRelativeMouseState(&dx, &dy);
+    mousePos.x += dx;
+    mousePos.y += dy;
+    // Pin ImGui's cursor to the press position so other widgets don't see it move
+    // and the SDL3 backend warps the OS cursor back here for us.
+    io.WantSetMousePos = true;
+    io.MousePos = ImVec2(cursorLockPos.x, cursorLockPos.y);
+  } else {
+    mousePos = {ImGui::GetMousePos().x, ImGui::GetMousePos().y};
+    mousePos.x -= screenPos.x;
+    mousePos.y -= vpOffsetY;
+  }
 
   if (!ctx.prefs.mouseWheelModifiesSpeed) moveSpeedModifier = 1.0f;
   float moveSpeed = (ctx.prefs.moveSpeed * moveSpeedModifier) * deltaTime;
@@ -554,7 +565,7 @@ void Editor::Viewport3D::draw()
   if(isMouseHover)
   {
     ImGui::SetMouseCursor(
-      mouseHeldRight ? ImGuiMouseCursor_None : ImGuiMouseCursor_Arrow
+      cameraDragActive ? ImGuiMouseCursor_None : ImGuiMouseCursor_Arrow
     );
   }
 
@@ -636,6 +647,15 @@ void Editor::Viewport3D::draw()
 
     if(!isMouseDown && newMouseDown) {
       mousePosStart = mousePos;
+      bool wantCapture = (isAltDown && mouseHeldLeft) || mouseHeldMiddle || mouseHeldRight;
+      if (wantCapture && !cameraDragActive) {
+        ImVec2 absPos = ImGui::GetMousePos();
+        cursorLockPos = {absPos.x, absPos.y};
+        // Drain SDL's accumulated relative motion so the first per-frame read
+        // doesn't include any cursor movement from before the drag started.
+        SDL_GetRelativeMouseState(nullptr, nullptr);
+        cameraDragActive = true;
+      }
     }
     isMouseDown = newMouseDown;
   }
@@ -710,6 +730,7 @@ void Editor::Viewport3D::draw()
   } else {
     camera.stopRotateDelta();
     camera.stopMoveDelta();
+    cameraDragActive = false;
     mousePosStart = mousePos = {0,0};
   }
   if (!newMouseDown)isMouseDown = false;

--- a/src/editor/pages/parts/viewport3D.h
+++ b/src/editor/pages/parts/viewport3D.h
@@ -30,9 +30,11 @@ namespace Editor
       bool pickAdditive{false};
       bool selectionPending{false};
       bool selectionDragging{false};
+      bool cameraDragActive{false};
 
       float moveSpeedModifier{1.0f};
       float vpOffsetY{};
+      glm::vec2 cursorLockPos{};
       glm::vec2 mousePos{};
       glm::vec2 mousePosStart{};
       glm::vec2 mousePosClick{};


### PR DESCRIPTION
## Summary

Fixes #8.

The three viewport camera-drag controls (**right-click free look**, **middle-click pan**, and **alt + left-click orbit**)
all drove the camera by raw cursor motion.

There were at least two consequences:
1. Once the cursor hit a screen edge, the camera stopped, requiring a mouse release then starting the rotation again.
2. Releasing the button outside the editor viewport window could land the click on another button, gizmo, input box, or application.

This PR captures the cursor for the duration of any of the three camera drags, so motion is unbounded and the release always lands inside the editor.

## How it works

The new `cameraDragActive` flag [`viewport3D.h:33`](https://github.com/SeanRamey/pyrite64/blob/fix/viewport-cursor-capture/src/editor/pages/parts/viewport3D.h#L33), plus the press position `cursorLockPos` [`viewport3D.h:37`](https://github.com/SeanRamey/pyrite64/blob/fix/viewport-cursor-capture/src/editor/pages/parts/viewport3D.h#L37), drives a small set of changes in `viewport3D.cpp`:

**On press** (Alt+LMB / MMB / RMB while in editor viewport) [`viewport3D.cpp:650-657`](https://github.com/SeanRamey/pyrite64/blob/fix/viewport-cursor-capture/src/editor/pages/parts/viewport3D.cpp#L650-L657):
- record `cursorLockPos` set to `ImGui::GetMousePos()`
- drain SDL's accumulated relative mouse motion `SDL_GetRelativeMouseState(nullptr, nullptr)`
- set `cameraDragActive = true`


**Each frame while captured** [`viewport3D.cpp:475-488`](https://github.com/SeanRamey/pyrite64/blob/fix/viewport-cursor-capture/src/editor/pages/parts/viewport3D.cpp#L475-L488):
- Get the mouse movement delta from `SDL_GetRelativeMouseState`, which reports raw user motion since the last call. This delta is added to `mousePos`, so the existing `dragDelta = mousePos - mousePosStart` is unchanged.
- Lock ImGui's cursor at the press position via `io.WantSetMousePos = true; io.MousePos = cursorLockPos`. ImGui's handles warping the OS cursor back each frame, so other widgets never see the cursor move and don't register false hover.
- Hide the cursor for all three modes (previously only RMB hid it) [`viewport3D.cpp:568`](https://github.com/SeanRamey/pyrite64/blob/fix/viewport-cursor-capture/src/editor/pages/parts/viewport3D.cpp#L568).
 
**On release** [`viewport3D.cpp:733`](https://github.com/SeanRamey/pyrite64/blob/fix/viewport-cursor-capture/src/editor/pages/parts/viewport3D.cpp#L733):
- clear `cameraDragActive`. Cursor is at the press point because we kept warping it there.
