### PR TITLE
Show per-row icons in scene-graph hierarchy, remove lines for cool clean UI

### DIFF
--- a/src/editor/pages/parts/sceneGraph.cpp
+++ b/src/editor/pages/parts/sceneGraph.cpp
@@ -200,7 +200,7 @@ namespace
   )
   {
     ImGuiTreeNodeFlags flag = ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_OpenOnArrow
-      | ImGuiTreeNodeFlags_OpenOnDoubleClick | ImGuiTreeNodeFlags_DrawLinesFull
+      | ImGuiTreeNodeFlags_OpenOnDoubleClick
       | ImGuiTreeNodeFlags_FramePadding | ImGuiTreeNodeFlags_SpanAllColumns;
 
     if (obj.children.empty()) {
@@ -222,6 +222,22 @@ namespace
     std::string nameID{};
     if(obj.uuidPrefab.value) {
       nameID += ICON_MDI_PACKAGE_VARIANT_CLOSED " ";
+    }
+    bool gotComponentIcon = false;
+    if (!obj.components.empty()) {
+      const auto &compEntry = obj.components.front();
+      if (compEntry.id >= 0 && (size_t)compEntry.id < Project::Component::TABLE.size()) {
+        const auto &def = Project::Component::TABLE[compEntry.id];
+        if (def.icon) {
+          nameID += def.icon;
+          gotComponentIcon = true;
+        }
+      }
+    }
+    if (!gotComponentIcon) {
+      nameID += (obj.parent == nullptr)
+        ? ICON_MDI_MOVIE_OPEN_OUTLINE " "
+        : ICON_MDI_CUBE_OUTLINE " ";
     }
     nameID += obj.name + "##" + std::to_string(obj.uuid);
 


### PR DESCRIPTION
Each hierarchy row now leads with an icon: the first component's icon for componentized objects, with a fallback of a film-clapboard for the scene root and a cube outline for empty objects. This helps you know what kind of object you are looking at or clicking/selecting at a glance and adds some familiarity for godot/unreal/unity users.

Drops ImGuiTreeNodeFlags_DrawLinesFull as a related cleanup so the connector lines don't compete with the new icons.

**Prefab Note**
The existing prefab-instance badge stacks in front of the component icon, so a prefab instance reads as [prefab][component] Name. The badge identifies that the object is a prefab and the component icon hints at what kind of prefab it is. I wasn't sure of a better way to handle this because I wanted to identify prefabs but also know what the root component of a prefab might be.
<img width="196" height="45" alt="image" src="https://github.com/user-attachments/assets/4c0ff259-857b-4246-9547-bb17932037aa" />

Open to suggestions of course or if this is too opinionated then feel free to shoot it down!

<img width="310" height="157" alt="clean-graph" src="https://github.com/user-attachments/assets/8e49b129-21d9-48a2-b05a-5e7ce2ff1584" />
