### PR TITLE
Allow a MeshCollider to have no owner

### DIFF
--- a/n64/engine/include/collision/meshCollider.h
+++ b/n64/engine/include/collision/meshCollider.h
@@ -124,7 +124,7 @@ namespace P64::Coll {
     /// Coordinates must use internal physics scale (i.e. 1 unit = 1 meter).
     /// Ownership of the given arrays (vertices, triangleIndices) is transferred to the returned MeshCollider
     /// object; call destroyData() to free them.
-    static MeshCollider* create(fm_vec3_t* vertices, uint16_t vertexCount, MeshTriangleIndices* triangleIndices, uint16_t triangleCount, Object *owner);
+    static MeshCollider* create(fm_vec3_t* vertices, uint16_t vertexCount, MeshTriangleIndices* triangleIndices, uint16_t triangleCount, Object *owner = nullptr);
 
     static inline fm_vec3_t triangleNormalFromVertices(const fm_vec3_t &v0, const fm_vec3_t &v1, const fm_vec3_t &v2)
     {

--- a/n64/engine/include/collision/meshCollider.h
+++ b/n64/engine/include/collision/meshCollider.h
@@ -119,11 +119,12 @@ namespace P64::Coll {
     /// Call destroyData() to free them.
     static MeshCollider *createFromRawData(void *rawData, Object *obj);
 
-    /// Create a MeshCollider from manually defined geometry, binding to the given Object's transform.
+    /// Create a MeshCollider from manually defined geometry. If a non-null owner Object is given, the
+    /// MeshCollider's transform will be synced to that of the owner.
     /// Coordinates must use internal physics scale (i.e. 1 unit = 1 meter).
     /// Ownership of the given arrays (vertices, triangleIndices) is transferred to the returned MeshCollider
     /// object; call destroyData() to free them.
-    static MeshCollider* create(fm_vec3_t* vertices, uint16_t vertexCount, MeshTriangleIndices* triangleIndices, uint16_t triangleCount, Object *obj);
+    static MeshCollider* create(fm_vec3_t* vertices, uint16_t vertexCount, MeshTriangleIndices* triangleIndices, uint16_t triangleCount, Object *owner);
 
     static inline fm_vec3_t triangleNormalFromVertices(const fm_vec3_t &v0, const fm_vec3_t &v1, const fm_vec3_t &v2)
     {

--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -1489,7 +1489,7 @@ namespace P64::Coll {
     if(hasFlag(ray.collTypes, RaycastColliderTypeFlags::MESH_COLLIDERS)) {
       for(std::size_t m = 0; m < meshColliders_.size(); ++m) {
         const MeshCollider *mesh = meshColliders_[m];
-        if(!mesh || mesh->triangleCount_ == 0 || !mesh->owner_) continue;
+        if(!mesh || mesh->triangleCount_ == 0) continue;
         Raycast localRay = ray;
         if(mesh->hasScale()) {
           const fm_vec3_t &scale = mesh->owner_->scale;
@@ -1529,7 +1529,7 @@ namespace P64::Coll {
           currentHit.normal = mesh->hasTransform() ? mesh->localNormalToWorld(currentHit.normal) : currentHit.normal;
           const fm_vec3_t hitDelta = currentHit.point - ray.origin;
           currentHit.distance = fm_vec3_len(&hitDelta);
-          currentHit.hitObjectId = mesh->owner_->id;
+          currentHit.hitObjectId = mesh->owner_ ? mesh->owner_->id : 0;
 
           hit.didHit = true;
           if(currentHit.didHit && currentHit.distance < hit.distance && currentHit.distance <= ray.maxDistance) {
@@ -1735,31 +1735,15 @@ namespace P64::Coll {
 
         color_t color = Debug::paletteColor(static_cast<uint32_t>(meshIdx));
 
-        const bool useRotation = meshCollider->hasRotation();
-
-  const fm_quat_t rot = meshCollider->owner_->rot;
-  const fm_vec3_t pos = meshCollider->owner_->pos;
-  const fm_vec3_t scale = meshCollider->owner_->scale;
-
-        auto toWorldMesh = [&](const fm_vec3_t &local)
-        {
-          fm_vec3_t scaled = fm_vec3_t{{local.x * scale.x, local.y * scale.y, local.z * scale.z}};
-          if (useRotation)
-          {
-            scaled = rot * scaled;
-          }
-          return (scaled + pos) * getGfxScale();
-        };
-
         for (uint16_t t = 0; t < meshCollider->triangleCount_; ++t)
         {
           int idxA = meshCollider->triangles_[t].indices[0];
           int idxB = meshCollider->triangles_[t].indices[1];
           int idxC = meshCollider->triangles_[t].indices[2];
 
-          fm_vec3_t v0 = toWorldMesh(meshCollider->vertices_[idxA]);
-          fm_vec3_t v1 = toWorldMesh(meshCollider->vertices_[idxB]);
-          fm_vec3_t v2 = toWorldMesh(meshCollider->vertices_[idxC]);
+          fm_vec3_t v0 = meshCollider->toWorldSpace(meshCollider->vertices_[idxA]) * getGfxScale();
+          fm_vec3_t v1 = meshCollider->toWorldSpace(meshCollider->vertices_[idxB]) * getGfxScale();
+          fm_vec3_t v2 = meshCollider->toWorldSpace(meshCollider->vertices_[idxC]) * getGfxScale();
 
           Debug::drawLine(v0, v1, color);
           Debug::drawLine(v1, v2, color);

--- a/n64/engine/src/collision/meshCollider.cpp
+++ b/n64/engine/src/collision/meshCollider.cpp
@@ -357,15 +357,15 @@ namespace P64::Coll {
     collider->recalculateWorldAabb();
   }
 
-  MeshCollider* MeshCollider::create(fm_vec3_t* vertices, uint16_t vertexCount, MeshTriangleIndices* triangleIndices, uint16_t triangleCount, Object *obj) {
-    if (!vertices || vertexCount == 0 || !triangleIndices || triangleCount == 0 || !obj) return nullptr;
+  MeshCollider* MeshCollider::create(fm_vec3_t* vertices, uint16_t vertexCount, MeshTriangleIndices* triangleIndices, uint16_t triangleCount, Object *owner) {
+    if (!vertices || vertexCount == 0 || !triangleIndices || triangleCount == 0) return nullptr;
 
     auto *collider = new MeshCollider();
     collider->vertices_ = vertices;
     collider->vertexCount_ = vertexCount;
     collider->triangles_ = triangleIndices;
     collider->triangleCount_ = triangleCount;
-    collider->owner_ = obj;
+    collider->owner_ = owner;
 
     collider->normals_ = new fm_vec3_t[triangleCount];
     for (uint16_t t = 0; t < triangleCount; ++t) {


### PR DESCRIPTION
The "no owner" case was already handled in several places by MeshCollider code, but there were a few remaining places where an owner was still required/assumed. This fixes that inconsistency and simplifies the API for callers of the manual `MeshCollider::create` method in scenarios where dynamic transform-syncing is unneeded.