### PR TITLE
Consistent AABB rendering across component types

### DIFF
--- a/src/project/component/types/compAnimModel.cpp
+++ b/src/project/component/types/compAnimModel.cpp
@@ -220,8 +220,9 @@ namespace Project::Component::AnimModel
         aabbCol = {0xFF,0xAA,0x00,0xFF};
       }
 
-      Utils::Mesh::addLineBox(*vp.getLines(), center, halfExt, aabbCol);
-      Utils::Mesh::addLineBox(*vp.getLines(), center, halfExt + 0.002f, aabbCol);
+      auto rot = obj.rot.resolve(obj.propOverrides);
+      Utils::Mesh::addLineBox(*vp.getLines(), center, halfExt, aabbCol, rot);
+      Utils::Mesh::addLineBox(*vp.getLines(), center, halfExt + 0.002f, aabbCol, rot);
     }
   }
 

--- a/src/project/component/types/compCollMesh.cpp
+++ b/src/project/component/types/compCollMesh.cpp
@@ -225,8 +225,9 @@ namespace Project::Component::CollMesh
         aabbCol = {0xFF,0xAA,0x00,0xFF};
       }
 
-      Utils::Mesh::addLineBox(*vp.getLines(), center, halfExt, aabbCol);
-      Utils::Mesh::addLineBox(*vp.getLines(), center, halfExt + 0.002f, aabbCol);
+      auto rot = obj.rot.resolve(obj.propOverrides);
+      Utils::Mesh::addLineBox(*vp.getLines(), center, halfExt, aabbCol, rot);
+      Utils::Mesh::addLineBox(*vp.getLines(), center, halfExt + 0.002f, aabbCol, rot);
     }
   }
 

--- a/src/project/component/types/compCulling.cpp
+++ b/src/project/component/types/compCulling.cpp
@@ -92,13 +92,14 @@ namespace Project::Component::Culling
 
     glm::vec4 aabbCol{1.0f, 0.0f, 0.0f, 1.0f};
 
+    auto rot = obj.rot.resolve(obj.propOverrides);
     if(type == TYPE_BOX)
     {
-      Utils::Mesh::addLineBox(*vp.getLines(), center, halfExt, aabbCol);
-      Utils::Mesh::addLineBox(*vp.getLines(), center, halfExt + 0.002f, aabbCol);
+      Utils::Mesh::addLineBox(*vp.getLines(), center, halfExt, aabbCol, rot);
+      Utils::Mesh::addLineBox(*vp.getLines(), center, halfExt + 0.002f, aabbCol, rot);
     } else if(type == TYPE_SPHERE)
     {
-      Utils::Mesh::addLineSphere(*vp.getLines(), center, halfExt, aabbCol);
+      Utils::Mesh::addLineSphere(*vp.getLines(), center, halfExt, aabbCol, rot);
     }
   }
 }

--- a/src/project/component/types/compModel.cpp
+++ b/src/project/component/types/compModel.cpp
@@ -256,8 +256,9 @@ namespace Project::Component::Model
         aabbCol = {0xFF,0xAA,0x00,0xFF};
       }
 
-      Utils::Mesh::addLineBox(*vp.getLines(), center, halfExt, aabbCol);
-      Utils::Mesh::addLineBox(*vp.getLines(), center, halfExt + 0.002f, aabbCol);
+      auto rot = obj.rot.resolve(obj.propOverrides);
+      Utils::Mesh::addLineBox(*vp.getLines(), center, halfExt, aabbCol, rot);
+      Utils::Mesh::addLineBox(*vp.getLines(), center, halfExt + 0.002f, aabbCol, rot);
     }
   }
 


### PR DESCRIPTION
Hopefully, this is a small enough change. I was very confused with how my prefabs were rendering. I was getting an orange aabb box that was perpendicular to where the mesh actually was.

I tried to infer what the intended behavior was from other components.

Below on the left you can see how prefabs render before this patch, on the right after the patch is applied. This is recreated by generating a prefab, adding an instance of it to the scene, and then rotating the prefab. You can see the box collider was behaving correctly already.

Also, any discussion on parent translation vs child? I could not tell if it was a bug or a design choice. Right now if you translate a parent it does not affect the child. The child's position is absolute but I could see the argument for either.


<img width="1208" height="553" alt="bug" src="https://github.com/user-attachments/assets/3a579e5b-89b7-4ba3-8af8-e369b77c3e3c" />
