### PR TITLE
Add ability to temporarily disable a RigidBody

### DIFF
--- a/n64/engine/include/collision/collisionScene.h
+++ b/n64/engine/include/collision/collisionScene.h
@@ -66,6 +66,16 @@ namespace P64::Coll {
     RigidBody *findRigidBodyByObjectId(uint16_t id) const;
     const std::vector<RigidBody *> &getRigidBodies() const { return rigidBodies_; }
 
+    static void enableRigidBody(RigidBody *rigidBody);
+
+    /// @brief Temporarily exclude the given RigidBody from the simulation.
+    ///
+    /// While disabled, the body will be immune to collision (allowing it to pass through objects) and will not receive
+    /// changes to force, velocity, or acceleration.
+    /// Manually moving the body (via RigidBody::setPosition()/RigidBody::setRotation()) is still allowed.
+    /// Call enableRigidBody() to re-enable the RigidBody.
+    void disableRigidBody(RigidBody *rigidBody);
+
     void addCollider(Collider *collider);
     void removeCollider(Collider *collider);
     const std::vector<Collider *> &getColliders() const { return colliders_; }

--- a/n64/engine/include/collision/rigidBody.h
+++ b/n64/engine/include/collision/rigidBody.h
@@ -102,6 +102,7 @@ namespace P64::Coll {
     bool hasLinearConstraints() const { return hasLinearConstraints_; }
     bool hasAngularConstraints() const { return hasAngularConstraints_; }
     bool canApplyAngularResponse() const { return !isKinematic_ && !hasFlag(constraints_, Constraint::FreezeRotAll); }
+    bool isEnabled() const { return isEnabled_; }
     bool isKinematic() const { return isKinematic_; }
     bool isSleeping() const { return isSleeping_; }
 
@@ -190,6 +191,7 @@ namespace P64::Coll {
     NodeProxy aabbTreeNodeId_{NULL_NODE};
     uint16_t sleepCounter_{0};
     bool hasGravity_{true};
+    bool isEnabled_{true};
     bool isKinematic_{false};
     bool isSleeping_{false};
 
@@ -218,6 +220,9 @@ namespace P64::Coll {
     void refreshConstraintCaches();
     void refreshAngularConstraintProjection();
     void refreshConstrainedInertiaTensor();
+
+    void enable();
+    void disable();
 
   };
 

--- a/n64/engine/src/collision/collide.cpp
+++ b/n64/engine/src/collision/collide.cpp
@@ -1147,6 +1147,8 @@ namespace P64::Coll {
   /// @param triangleIndex Index of the triangle within the mesh to test against.
   /// @return True if a collision is detected, false otherwise.
   bool collideDetectObjectToTriangle(ColliderProxy *colliderProxyMeshSpace, RigidBody *rigidBody, const MeshCollider &mesh, int triangleIndex, bool recordConstraints) {
+    if(rigidBody && !rigidBody->isEnabled()) return false;
+
     const bool isTriggerContact = colliderProxyMeshSpace->collider->isTrigger();
     const bool colliderRespondsToMesh = colliderProxyMeshSpace->collider->readsMeshCollider(&mesh);
 
@@ -1281,6 +1283,8 @@ namespace P64::Coll {
   /// @param rigidBody The rigid body associated with the collider.
   /// @param mesh The mesh collider to test against.
   bool collideDetectObjectToMesh(Collider *collider, RigidBody *rigidBody, const MeshCollider &mesh, bool recordConstraints) {
+    if(rigidBody && !rigidBody->isEnabled()) return false;
+
     // Transform the collider's world AABB into the mesh's local space for tree query
     AABB queryAABB = mesh.hasTransform()
       ? mesh.worldAabbToLocal(collider->worldAabb())
@@ -1355,6 +1359,8 @@ namespace P64::Coll {
     const bool aReadsB = colliderA->readsCollider(colliderB);
     const bool bReadsA = colliderB->readsCollider(colliderA);
 
+    if(rbA && !rbA->isEnabled()) return false;
+    if(rbB && !rbB->isEnabled()) return false;
     if(rbA && rbB && rbA->isSleeping() && rbB->isSleeping() && !colliderA->isTrigger() && !colliderB->isTrigger()) return false;
 
     if(colliderA && colliderB) {

--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -54,6 +54,9 @@ namespace P64::Coll {
   }
 
   static bool collisionEventMasksOverlap(const CollEvent &event) {
+    if (event.selfRigidBody && !event.selfRigidBody->isEnabled()) return false;
+    if (event.hitRigidBody && !event.hitRigidBody->isEnabled()) return false;
+
     if(event.selfCollider) {
       if(event.hitCollider) return event.selfCollider->readsCollider(event.hitCollider);
       if(event.hitMeshCollider) return event.selfCollider->readsMeshCollider(event.hitMeshCollider);
@@ -96,7 +99,7 @@ namespace P64::Coll {
   }
 
   bool CollisionScene::shouldTrackSleepState(const RigidBody *rigidBody) {
-    return rigidBody && !rigidBody->isKinematic_;
+    return rigidBody && rigidBody->isEnabled_ && !rigidBody->isKinematic_;
   }
 
   bool CollisionScene::rigidBodyVelocitiesExceededSleepThreshold(const RigidBody *rigidBody) {
@@ -274,7 +277,7 @@ namespace P64::Coll {
   void CollisionScene::removeRigidBody(RigidBody *rigidBody) {
     if(!rigidBody) return;
 
-    std::vector<RigidBody *> wakeCandidates;
+    disableRigidBody(rigidBody);
 
     if(rigidBody->owner_) {
       auto ownerIt = ownerRigidBodies_.find(rigidBody->owner_);
@@ -283,13 +286,26 @@ namespace P64::Coll {
       }
     }
 
+    rigidBodies_.erase(std::remove(rigidBodies_.begin(), rigidBodies_.end(), rigidBody), rigidBodies_.end());
+  }
+
+  void CollisionScene::enableRigidBody(RigidBody *rigidBody) {
+    if(!rigidBody || rigidBody->isEnabled_) return;
+    rigidBody->enable();
+  }
+
+  void CollisionScene::disableRigidBody(RigidBody* rigidBody) {
+    if(!rigidBody || !rigidBody->isEnabled_) return;
+
+    std::vector<RigidBody *> wakeCandidates;
+
     removeCachedConstraints([rigidBody](const ContactConstraint &cc) {
       return cc.rigidBodyA == rigidBody || cc.rigidBodyB == rigidBody;
     }, wakeCandidates, rigidBody);
 
-    // Sleeping rigidBodies overlapping the removed body are likely support-dependent and should re-evaluate.
+    // Sleeping rigidBodies overlapping the disabled body are likely support-dependent and should re-evaluate.
     const AABB removedBounds = rigidBody->worldAabb_;
-    
+
     for(RigidBody *body : rigidBodies_) {
       if(!body || body == rigidBody) continue;
       if(aabbOverlap(body->worldAabb_, removedBounds)) {
@@ -298,8 +314,7 @@ namespace P64::Coll {
     }
 
     wakeCandidateIslands(wakeCandidates);
-
-    rigidBodies_.erase(std::remove(rigidBodies_.begin(), rigidBodies_.end(), rigidBody), rigidBodies_.end());
+    rigidBody->disable();
   }
 
   RigidBody *CollisionScene::findRigidBodyByObjectId(uint16_t id) const
@@ -667,7 +682,7 @@ namespace P64::Coll {
     std::vector<RigidBody *> wakeCandidates;
 
     for(RigidBody *body : rigidBodies_) {
-      if(!body || !body->isSleeping_) continue;
+      if(!body || !body->isEnabled_ || !body->isSleeping_) continue;
       if(!rigidBodyTransformExceededSleepThreshold(body)) continue;
       wakeCandidates.push_back(body);
     }
@@ -831,7 +846,7 @@ namespace P64::Coll {
     meshCandidates.resize(meshColliders_.size());
 
     for(RigidBody *body : rigidBodies_) {
-      if(!body || body->isSleeping_ || body->isKinematic_) continue;
+      if(!body || !body->isEnabled_ || body->isSleeping_ || body->isKinematic_) continue;
 
       const float dt = fixedDt_ * body->timeScale_;
       if(dt <= 0.0f) continue;
@@ -1251,7 +1266,7 @@ namespace P64::Coll {
 
           fm_vec3_t contactVelA = VEC3_ZERO;
           fm_vec3_t contactVelB = VEC3_ZERO;
-          if(a && !a->isKinematic_) {
+          if(a && a->isEnabled_ && !a->isKinematic_) {
             contactVelA = a->linearVelocity_;
             if(aHasMotionAngular) {
               fm_vec3_t aCross;
@@ -1259,7 +1274,7 @@ namespace P64::Coll {
               contactVelA += aCross;
             }
           }
-          if(b && !b->isKinematic_) {
+          if(b && b->isEnabled_ && !b->isKinematic_) {
             contactVelB = b->linearVelocity_;
             if(bHasMotionAngular) {
               fm_vec3_t bCross;
@@ -1426,7 +1441,7 @@ namespace P64::Coll {
         appliedCorrection = true;
 
         // Apply linear + angular corrections to A
-        if(a && !a->isKinematic_) {
+        if(a && a->isEnabled_ && !a->isKinematic_) {
           if(invMassA > 0.0f) {
             fm_vec3_t corrA = constrainLinearWorld(a, cc.normal * (correctionMag * invMassA));
             a->position_ += corrA;
@@ -1447,7 +1462,7 @@ namespace P64::Coll {
         }
 
         // Apply linear + angular corrections to B
-        if(b && !b->isKinematic_) {
+        if(b && b->isEnabled_ && !b->isKinematic_) {
           if(invMassB > 0.0f) {
             fm_vec3_t corrB = constrainLinearWorld(b, cc.normal * (correctionMag * invMassB));
             b->position_ -= corrB;
@@ -1624,7 +1639,7 @@ namespace P64::Coll {
     // Update compound CoM/inertia on demand and refresh world inertia tensors.
     for (RigidBody *body : rigidBodies_){
       syncCompoundProperties(body);
-      if(body->isSleeping_) continue;
+      if(!body->isEnabled_ || body->isSleeping_) continue;
       body->updateWorldInertia();
     }
     ticksWorldUpdate = get_ticks() - stageStart;
@@ -1632,6 +1647,7 @@ namespace P64::Coll {
     stageStart = get_ticks();
     // Integrate velocities (also resets sleeping bodies — see RigidBody::integrateVelocity)
     for(RigidBody *body : rigidBodies_) {
+      if (!body->isEnabled_) continue;
       body->integrateVelocity(fixedDt_, gravity_);
       body->integrateAngularVelocity(fixedDt_);
     }
@@ -1659,7 +1675,7 @@ namespace P64::Coll {
     stageStart = get_ticks();
     // Reset push velocities for split impulse (Bullet-style)
     for(RigidBody *body : rigidBodies_) {
-      if(!body->isSleeping_) body->resetPushVelocities();
+      if(body->isEnabled_ && !body->isSleeping_) body->resetPushVelocities();
     }
     warmStart();
     ticksWarmStart = get_ticks() - stageStart;
@@ -1673,7 +1689,7 @@ namespace P64::Coll {
     // Integrate positions and rotations (including split impulse push velocities)
     stageStart = get_ticks();
     for(RigidBody *body : rigidBodies_) {
-      if(body->isSleeping_) continue;
+      if(!body->isEnabled_ || body->isSleeping_) continue;
 
       body->integratePosition(fixedDt_);
       body->integrateRotation(fixedDt_);

--- a/n64/engine/src/collision/rigidBody.cpp
+++ b/n64/engine/src/collision/rigidBody.cpp
@@ -216,7 +216,7 @@ namespace P64::Coll {
   }
 
   void RigidBody::applyConstrainedImpulseAtContact(const fm_vec3_t &impulse, const fm_vec3_t &toContact) {
-    if(isKinematic_) return;
+    if(!isEnabled_ || isKinematic_) return;
 
     applyConstrainedLinearVelocityDelta(impulse * inverseMass_);
     if(!canApplyAngularResponse()) return;
@@ -227,7 +227,7 @@ namespace P64::Coll {
   }
 
   float RigidBody::constrainedLinearInvMassAlong(const fm_vec3_t &direction) const {
-    if(isKinematic_) return 0.0f;
+    if(!isEnabled_ || isKinematic_) return 0.0f;
     if(inverseMass_ <= FM_EPSILON) return 0.0f;
     if(!hasLinearConstraints_) return inverseMass_;
 
@@ -265,7 +265,7 @@ namespace P64::Coll {
   }
 
   void RigidBody::integrateVelocity(float fixedDt, const fm_vec3_t &gravity) {
-    if(isKinematic_) return;
+    if(!isEnabled_ || isKinematic_) return;
 
     // Sleeping bodies must have their velocities explicitly zeroed each frame.
     // Although sleep() zeros them once, the warm start and velocity solver apply
@@ -310,7 +310,7 @@ namespace P64::Coll {
   }
 
   void RigidBody::integrateAngularVelocity(float fixedDt) {
-    if(isKinematic_) return;
+    if(!isEnabled_ || isKinematic_) return;
 
     // See integrateVelocity for rationale — sleeping bodies must start each step
     // with zero angular velocity so the solver treats them as effectively static.
@@ -359,7 +359,7 @@ namespace P64::Coll {
   }
 
   void RigidBody::integratePosition(float fixedDt) {
-    if(isKinematic_ || isSleeping_) return;
+    if(!isEnabled_ || isKinematic_ || isSleeping_) return;
 
     float dt = fixedDt * timeScale_;
     previousStepPosition_ = position_;
@@ -367,7 +367,7 @@ namespace P64::Coll {
   }
 
   void RigidBody::integrateRotation(float fixedDt) {
-    if(isKinematic_ || isSleeping_) return;
+    if(!isEnabled_ || isKinematic_ || isSleeping_) return;
     if(vec3IsZero(angularVelocity_)) return;
 
     float dt = fixedDt * timeScale_;
@@ -388,6 +388,7 @@ namespace P64::Coll {
   }
 
   void RigidBody::accelerate(const fm_vec3_t &accel) {
+    if(!isEnabled_ || isKinematic_) return;
     acceleration_ = acceleration_ + accel;
     if(isSleeping_) wake();
   }
@@ -398,25 +399,25 @@ namespace P64::Coll {
   }
 
   void RigidBody::applyLinearForce(const fm_vec3_t &force) {
-    if(isKinematic_) return;
+    if(!isEnabled_ || isKinematic_) return;
     accelerate(force * inverseMass_);
   }
 
   void RigidBody::applyLinearImpulse(const fm_vec3_t &impulse) {
-    if(isKinematic_) return;
+    if(!isEnabled_ || isKinematic_) return;
     fm_vec3_t deltaV = constrainLinearWorld(impulse * inverseMass_);
     linearVelocity_ = linearVelocity_ + deltaV;
     if(isSleeping_) wake();
   }
 
   void RigidBody::applyTorque(const fm_vec3_t &torque) {
-    if(isKinematic_) return;
+    if(!isEnabled_ || isKinematic_) return;
     torqueAccumulator_ = torqueAccumulator_ + torque;
     if(isSleeping_) wake();
   }
 
   void RigidBody::applyAngularImpulse(const fm_vec3_t &angImpulse) {
-    if(isKinematic_) return;
+    if(!isEnabled_ || isKinematic_) return;
     angularVelocity_ = angularVelocity_ + applyConstrainedWorldInertia(angImpulse);
     if(isSleeping_) wake();
   }
@@ -440,7 +441,7 @@ namespace P64::Coll {
   }
 
   void RigidBody::applyForceAtPoint(const fm_vec3_t &force, const fm_vec3_t &worldPoint) {
-    if(isKinematic_) return;
+    if(!isEnabled_ || isKinematic_) return;
     accelerate(force * inverseMass_);
     fm_vec3_t r = worldPoint - worldCenterOfMass_;
     fm_vec3_t torque;
@@ -494,6 +495,19 @@ namespace P64::Coll {
     if(hasFlag(constraints_, Constraint::FreezePosX)) position_.x = previousStepPosition_.x;
     if(hasFlag(constraints_, Constraint::FreezePosY)) position_.y = previousStepPosition_.y;
     if(hasFlag(constraints_, Constraint::FreezePosZ)) position_.z = previousStepPosition_.z;
+  }
+
+  void RigidBody::enable() {
+    isEnabled_ = true;
+    wake();
+  }
+
+  void RigidBody::disable() {
+    isEnabled_ = false;
+    linearVelocity_ = VEC3_ZERO;
+    angularVelocity_ = VEC3_ZERO;
+    acceleration_ = VEC3_ZERO;
+    torqueAccumulator_ = VEC3_ZERO;
   }
 
 } // namespace P64::Coll


### PR DESCRIPTION
This adds two methods to `P64::Coll::CollisionScene` that can be called by user code:

* `void enableRigidBody(RigidBody *rigidBody)`
* `void disableRigidBody(RigidBody *rigidBody)`

"Disabling" a RigidBody means it is temporarily excluded from the simulation and behaves like a ghost that can pass through objects without affecting them or being affected.

I borrowed some of the `removeRigidBody` code which wakes up neighbors who might be affected by the body "disappearing".

The use-case in my specific project is for a respawn tween where a car is moved back onto the track, but this should be useful as a generic thing in many situations and is standard functionality for lots of other physics engines.