### PR TITLE
Add ability to toggle visibility of Object

### DIFF
--- a/n64/engine/include/scene/object.h
+++ b/n64/engine/include/scene/object.h
@@ -129,6 +129,29 @@ namespace P64
        */
       void setEnabled(bool isEnabled);
 
+      /**
+       * Check if the object itself is visible (not considering parent/group state).
+       * @return true if visible
+       */
+      [[nodiscard]] bool isSelfVisible() const {
+        return !(flags & ObjectFlags::SELF_HIDDEN);
+      }
+
+      /**
+       * Check if the object is visible, considering parent/group state.
+       * @return true if visible
+       */
+      [[nodiscard]] bool isVisible() const {
+        return !(flags & ObjectFlags::HIDDEN);
+      }
+
+      /**
+       * Changes the state of the object to be visible or hidden.
+       * Prefer this over changing flags directly, so that children properly inherit visibility from parents.
+       * @param isVisible true to show, false to hide
+       */
+      void setVisible(bool isVisible);
+
       [[nodiscard]] bool hasChildren() const {
         return (flags & ObjectFlags::HAS_CHILDREN);
       }

--- a/n64/engine/include/scene/objectFlags.h
+++ b/n64/engine/include/scene/objectFlags.h
@@ -16,8 +16,8 @@ namespace P64::ObjectFlags
   constexpr uint16_t PENDING_REMOVE     = 1 << 3; // flagged for removal at the end of the frame
   constexpr uint16_t PENDING_ACTIVE_CHG = 1 << 4; // flagged to toggle active state after all updates
   constexpr uint16_t IS_CULLED          = 1 << 5; // if true, object is not drawn this frame (usually set by culling logic)
-  constexpr uint16_t SELF_HIDDEN        = 1 << 6;
-  constexpr uint16_t PARENTS_HIDDEN     = 1 << 7;
+  constexpr uint16_t SELF_HIDDEN        = 1 << 6; // if true, object drawing is disabled
+  constexpr uint16_t PARENTS_HIDDEN     = 1 << 7; // true if all ancestors are hidden, used to determine final hidden state
 
   constexpr uint16_t ACTIVE = SELF_ACTIVE | PARENTS_ACTIVE;
   constexpr uint16_t HIDDEN = SELF_HIDDEN | PARENTS_HIDDEN;

--- a/n64/engine/include/scene/objectFlags.h
+++ b/n64/engine/include/scene/objectFlags.h
@@ -16,6 +16,9 @@ namespace P64::ObjectFlags
   constexpr uint16_t PENDING_REMOVE     = 1 << 3; // flagged for removal at the end of the frame
   constexpr uint16_t PENDING_ACTIVE_CHG = 1 << 4; // flagged to toggle active state after all updates
   constexpr uint16_t IS_CULLED          = 1 << 5; // if true, object is not drawn this frame (usually set by culling logic)
+  constexpr uint16_t SELF_HIDDEN        = 1 << 6;
+  constexpr uint16_t PARENTS_HIDDEN     = 1 << 7;
 
   constexpr uint16_t ACTIVE = SELF_ACTIVE | PARENTS_ACTIVE;
+  constexpr uint16_t HIDDEN = SELF_HIDDEN | PARENTS_HIDDEN;
 }

--- a/n64/engine/src/scene/object.cpp
+++ b/n64/engine/src/scene/object.cpp
@@ -28,6 +28,14 @@ void P64::Object::setEnabled(bool isEnabled)
   }
 }
 
+void P64::Object::setVisible(bool isVisible)
+{
+  if (isVisible != this->isSelfVisible()) {
+    setFlag(ObjectFlags::SELF_HIDDEN, !isVisible);
+    SceneManager::getCurrent().needsObjStateUpdate = true;
+  }
+}
+
 void P64::Object::remove(bool keepChildren)
 {
   if(flags & ObjectFlags::PENDING_REMOVE)return;

--- a/n64/engine/src/scene/scene.cpp
+++ b/n64/engine/src/scene/scene.cpp
@@ -309,7 +309,7 @@ void P64::Scene::draw([[maybe_unused]] float deltaTime)
 
       for (uint32_t i=0; i<obj->compCount; ++i)
       {
-        if(obj->flags & ObjectFlags::IS_CULLED)break;
+        if(obj->flags & (ObjectFlags::IS_CULLED | ObjectFlags::HIDDEN))break;
         const auto &compDef = COMP_TABLE[compRefs[i].type];
         if(compDef.draw)
         {
@@ -471,16 +471,23 @@ void P64::Scene::updateChildObjectStates(const Object* parent, Object& obj)
   }
 
   const auto wasEnabledBefore = obj.isEnabled();
-  obj.setFlag(ObjectFlags::PARENTS_ACTIVE, parent ? parent->isEnabled() : true);
-  if(!obj.performStateChange() && !parent) {
-    return; // without a parent, no cascading change can happen if the own state didn't change
-  }
+  const auto wasVisibleBefore = obj.isVisible();
 
-  if(wasEnabledBefore == obj.isEnabled()) {
+  obj.setFlag(ObjectFlags::PARENTS_ACTIVE, parent ? parent->isEnabled() : true);
+  obj.setFlag(ObjectFlags::PARENTS_HIDDEN, parent ? !parent->isVisible() : false);
+  obj.performStateChange();
+
+  const bool enabledChanged = wasEnabledBefore != obj.isEnabled();
+  const bool visibleChanged = wasVisibleBefore != obj.isVisible();
+
+  if(!enabledChanged && !visibleChanged) {
     return;
   }
 
-  sendEvent(obj.id, 0, obj.isEnabled() ? EVENT_TYPE_ENABLE : EVENT_TYPE_DISABLE, 0);
+  if (enabledChanged) {
+    sendEvent(obj.id, 0, obj.isEnabled() ? EVENT_TYPE_ENABLE : EVENT_TYPE_DISABLE, 0);
+  }
+
   iterObjectChildren(obj.id, [&](Object* child) {
     updateChildObjectStates(&obj, *child);
   });


### PR DESCRIPTION
This adds a visible/hidden state to Objects which only affects drawing and inherits from ancestors' visibility (inspired by the existing "active" flag in pyrite64 and by how visibility works in Godot)

I thought it made more sense to use `HIDDEN` for the actual flag so that the default of `0` would mean the object is visible by default, but for the public API, keeping it in positive terms of "visible" seemed more intuitive to me.