### PR TITLE
Allow to filter in the "Script" ComboBox of the "Code" component

### DIFF
--- a/src/editor/imgui/helper.h
+++ b/src/editor/imgui/helper.h
@@ -3,7 +3,11 @@
 * @license MIT
 */
 #pragma once
+#include <algorithm>
+#include <cctype>
+#include <cstring>
 #include <string>
+#include <unordered_map>
 #include "imgui.h"
 #include "misc/cpp/imgui_stdlib.h"
 #include "IconsMaterialDesignIcons.h"
@@ -209,6 +213,67 @@ namespace ImTable
     ImGui::TableSetColumnIndex(1);
   }
 
+  /**
+   * Draws a search input for an opened ComboBox popup.
+   * @param label ImGui label used to derive the combo-specific filter state.
+   * @return Pointer to the filter string owned by this helper.
+   */
+  inline std::string* drawComboSearchFilter(const char *label)
+  {
+    // Keep one filter string per combo so multiple searchable combos do not share text
+    static std::unordered_map<ImGuiID, std::string> filters;
+
+    // Use the ImGui ID so repeated labels still map to the correct popup state
+    auto *filter = &filters[ImGui::GetID(label)];
+
+    // Start each newly opened popup with a focused empty search box
+    if (ImGui::IsWindowAppearing()) {
+      filter->clear();
+      ImGui::SetKeyboardFocusHere();
+    }
+
+    // Match the filter input width to the combo popup content width
+    ImGui::SetNextItemWidth(-FLT_MIN);
+    ImGui::InputTextWithHint("##Filter", "Filter...", filter);
+
+    // Separate the filter input from the selectable rows
+    ImGui::Separator();
+
+    return filter;
+  }
+
+  /**
+   * Returns whether a label matches a filter.
+   * @param label Item text.
+   * @param filter Filter text.
+   * @return True when the item matches the filter.
+   */
+  inline bool labelMatchesFilter(const char *label, const std::string &filter)
+  {
+    if (filter.empty())return true;
+
+    const char *labelEnd = label + std::strlen(label);
+    return std::search(label, labelEnd, filter.begin(), filter.end(),
+      [](unsigned char lhs, unsigned char rhs) {
+        return std::tolower(lhs) == std::tolower(rhs);
+      }
+    ) != labelEnd;
+  }
+
+  /**
+   * Draws a ComboBox.
+   * @tparam GetLabel Callable that returns the visible label for an item index.
+   * @tparam ApplySelection Callable that applies the selected item index.
+   * @param label Internal ImGui label for the ComboBox.
+   * @param count Number of selectable items.
+   * @param current Current selected index, updated when the user selects an item.
+   * @param preview Text shown while the ComboBox is collapsed.
+   * @param snapshotLabel Undo history label used when a selection changes.
+   * @param getLabel Label resolver for each item index.
+   * @param applySelection Selection callback for each item index.
+   * @param searchable Whether to allow to filter the values.
+   * @return True when the selection changed during this draw.
+   */
   template<typename GetLabel, typename ApplySelection>
   inline bool drawComboSelection(
     const char* label,
@@ -217,33 +282,71 @@ namespace ImTable
     const char* preview,
     const std::string &snapshotLabel,
     GetLabel getLabel,
-    ApplySelection applySelection
+    ApplySelection applySelection,
+    bool searchable = false
   ) {
     bool changed = false;
+
+    // ComboBox is open --> Draw DropDown with the values
     if (ImGui::BeginCombo(label, preview)) {
+      std::string *filter = nullptr;
+      // Allow to search --> Display filter
+      if (searchable) {
+        filter = drawComboSearchFilter(label);
+      }
+
+      bool hasMatches = false; // Holds whether there are values to display in the DropDown
+
       for (int i = 0; i < count; ++i) {
+        // Resolve the label
+        const char *itemLabel = getLabel(i);
+
+        // The item doesn't match the filter --> Skip it
+        if (filter && !labelMatchesFilter(itemLabel, *filter)) continue;
+
+        hasMatches = true;
         bool selected = (i == current);
-        if (ImGui::Selectable(getLabel(i), selected)) {
+
+        // The uses has chosen the row
+        if (ImGui::Selectable(itemLabel, selected)) {
+          // Is an object-backed edit --> Add to history
           if (obj) {
             Editor::UndoRedo::getHistory().markChanged(snapshotLabel);
-            applySelection(i);
-          } else {
-            applySelection(i);
           }
+          applySelection(i);
+
+          // Keep the local index in sync with the caller-owned value
           current = i;
           changed = true;
         }
+
+        // Is the selected value --> Focus it for keyboard navigation
         if (selected) {
           ImGui::SetItemDefaultFocus();
         }
       }
+
+      // Is searchable and there are no matches --> Display info text
+      if (searchable && !hasMatches) {
+        ImGui::TextDisabled("(No results)");
+      }
+
+      // End the popup drawing scope opened by BeginCombo
       ImGui::EndCombo();
     }
+
+    // Return whether the selection changed
     return changed;
   }
 
   template<typename T, typename OnChange>
-  inline int addVecComboBox(const std::string &name, const std::vector<T> &items, auto &id, OnChange onChange)
+  inline int addVecComboBox(
+    const std::string &name,
+    const std::vector<T> &items,
+    auto &id,
+    OnChange onChange,
+    bool searchable = false
+  )
   {
     if(!name.empty())add(name);
     bool disabled  (isPrefabLocked());
@@ -268,16 +371,17 @@ namespace ImTable
       [&items, &id, &onChange](int i) {
         id = items[i].getId();
         onChange(id);
-      }
+      },
+      searchable
     );
     if(disabled)ImGui::EndDisabled();
     return idx;
   }
 
   template<typename T>
-  inline int addVecComboBox(const std::string &name, const std::vector<T> &items, auto &id)
+  inline int addVecComboBox(const std::string &name, const std::vector<T> &items, auto &id, bool searchable = false)
   {
-    return addVecComboBox(name, items, id, [](auto) {});
+    return addVecComboBox(name, items, id, [](auto) {}, searchable);
   }
 
   // addVecComboBox with drag-drop support and custom validator
@@ -288,11 +392,12 @@ namespace ImTable
     const std::vector<T>& items,
     auto& id,
     TValidator validator,
-    OnChange onChange
+    OnChange onChange,
+    bool searchable = false
   )
   {
     auto oldId = id;
-    addVecComboBox(name, items, id, onChange);
+    addVecComboBox(name, items, id, onChange, searchable);
     
     if (ImGui::HandleComboBoxDragDrop(id, validator)) {
       onChange(id);
@@ -313,7 +418,8 @@ namespace ImTable
     const std::vector<T>& items,
     auto& id,
     TAssetValidator assetValidator,
-    OnChange onChange
+    OnChange onChange,
+    bool searchable = false
   )
   {
     return addVecComboBoxWithDragDrop(name, items, id,
@@ -321,7 +427,8 @@ namespace ImTable
         if (strcmp(type, "ASSET") != 0) return false;
         return assetValidator(uuid);
       },
-      onChange
+      onChange,
+      searchable
     );
   }
 
@@ -331,7 +438,8 @@ namespace ImTable
     const std::string& name,
     const std::vector<T>& items,
     auto& id,
-    OnChange onChange
+    OnChange onChange,
+    bool searchable = false
   )
   {
     return addAssetVecComboBox(name, items, id,
@@ -341,7 +449,8 @@ namespace ImTable
         }
         return false;
       },
-      onChange
+      onChange,
+      searchable
     );
   }
 
@@ -350,10 +459,11 @@ namespace ImTable
   inline int addAssetVecComboBox(
     const std::string& name,
     const std::vector<T>& items,
-    auto& id
+    auto& id,
+    bool searchable = false
   )
   {
-    return addAssetVecComboBox(name, items, id, [](auto){});
+    return addAssetVecComboBox(name, items, id, [](auto){}, searchable);
   }
 
   // Object-only drag-drop combo box
@@ -364,7 +474,8 @@ namespace ImTable
     const std::vector<T>& items,
     auto& id,
     TObjectValidator objectValidator,
-    OnChange onChange
+    OnChange onChange,
+    bool searchable = false
   )
   {
     return addVecComboBoxWithDragDrop(name, items, id,
@@ -372,7 +483,8 @@ namespace ImTable
         if (strcmp(type, "OBJECT") != 0) return false;
         return objectValidator(static_cast<uint32_t>(uuid));
       },
-      onChange
+      onChange,
+      searchable
     );
   }
 
@@ -382,7 +494,8 @@ namespace ImTable
     const std::string& name,
     const std::vector<T>& items,
     auto& id,
-    OnChange onChange
+    OnChange onChange,
+    bool searchable = false
   )
   {
     return addObjectVecComboBox(name, items, id,
@@ -392,7 +505,8 @@ namespace ImTable
         }
         return false;
       },
-      onChange
+      onChange,
+      searchable
     );
   }
 
@@ -401,13 +515,14 @@ namespace ImTable
   inline int addObjectVecComboBox(
     const std::string& name,
     const std::vector<T>& items,
-    auto& id
+    auto& id,
+    bool searchable = false
   )
   {
-    return addObjectVecComboBox(name, items, id, [](auto){});
+    return addObjectVecComboBox(name, items, id, [](auto){}, searchable);
   }
 
-  inline bool addComboBox(const std::string &name, int &itemCurrent, const char* const items[], int itemsCount) {
+  inline bool addComboBox(const std::string &name, int &itemCurrent, const char* const items[], int itemsCount, bool searchable = false) {
     add(name);
     bool disabled  (isPrefabLocked());
     auto labelHidden = "##" + name;
@@ -420,13 +535,14 @@ namespace ImTable
       preview,
       "Edit " + name,
       [items](int i) { return items[i]; },
-      [&itemCurrent](int i) { itemCurrent = i; }
+      [&itemCurrent](int i) { itemCurrent = i; },
+      searchable
     );
     if(disabled)ImGui::EndDisabled();
     return res;
   }
 
-  inline bool addComboBox(const std::string &name, int &itemCurrent, const std::vector<const char*> &items) {
+  inline bool addComboBox(const std::string &name, int &itemCurrent, const std::vector<const char*> &items, bool searchable = false) {
     add(name);
     bool disabled  (isPrefabLocked());
     if(disabled)ImGui::BeginDisabled();
@@ -439,7 +555,8 @@ namespace ImTable
       preview,
       "Edit " + name,
       [&items](int i) { return items[i]; },
-      [&itemCurrent](int i) { itemCurrent = i; }
+      [&itemCurrent](int i) { itemCurrent = i; },
+      searchable
     );
     if(disabled)ImGui::EndDisabled();
     return res;

--- a/src/editor/imgui/helper.h
+++ b/src/editor/imgui/helper.h
@@ -243,19 +243,135 @@ namespace ImTable
   }
 
   /**
-   * Returns whether a label matches a filter.
+   * Returns whether a character starts a searchable PascalCase word.
+   * @param label Item text being searched.
+   * @param labelLength Cached label length used to inspect the next character safely
+   * @param index Character index to test.
+   * @return True when the character should be treated as a word start.
+   */
+  inline bool isPascalWordStart(const char *label, size_t labelLength, size_t index)
+  {
+    unsigned char currentChar = label[index];
+
+    // Separators are not words, but the first alphanumeric character after them is
+    if (!std::isalnum(currentChar)) return false;
+    if (index == 0) return true;
+
+    unsigned char previousChar = label[index - 1];
+
+    // Non-alphanumeric separators split words, and digit runs start only on the first digit
+    if (!std::isalnum(previousChar)) return true;
+    if (std::isdigit(currentChar)) return !std::isdigit(previousChar);
+    if (std::isdigit(previousChar)) return true;
+
+    // Uppercase letters after lowercase letters mark normal PascalCase boundaries
+    if (!std::isupper(currentChar)) return false;
+    if (std::islower(previousChar)) return true;
+
+    // Treat the last capital in an acronym as a word start. For example XMLParser -> Parser
+    bool nextIsLower = index + 1 < labelLength && std::islower((unsigned char)label[index + 1]);
+    return std::isupper(previousChar) && nextIsLower;
+  }
+
+  /**
+   * Returns whether a label word starts with a filter token, ignoring case.
+   * @param label Item text being searched.
+   * @param labelLength Cached label length used to avoid reading past the end.
+   * @param labelStart Word start index inside label.
+   * @param filter Full filter text.
+   * @param filterStart Token start index inside filter.
+   * @param filterEnd Token end index inside filter.
+   * @return True when the token matches the start of the label word.
+   */
+  inline bool labelStartsWithFilterToken(
+    const char *label,
+    size_t labelLength,
+    size_t labelStart,
+    const std::string &filter,
+    size_t filterStart,
+    size_t filterEnd
+  )
+  {
+    size_t tokenLength = filterEnd - filterStart;
+
+    // The token cannot match if it would extend past the label
+    if (labelStart + tokenLength > labelLength) return false;
+
+    // Compare the token against the label word prefix without case sensitivity
+    for (size_t i = 0; i < tokenLength; ++i) {
+      auto labelChar = (unsigned char)label[labelStart + i];
+      auto filterChar = (unsigned char)filter[filterStart + i];
+      if (std::tolower(labelChar) != std::tolower(filterChar)) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Matches a spaced filter against ordered PascalCase word starts.
+   * @param label Item text being searched.
+   * @param filter Filter text split by spaces into word-prefix tokens.
+   * @return True when every token matches a later PascalCase word start.
+   */
+  inline bool labelMatchesPascalWordFilter(const char *label, const std::string &filter)
+  {
+    size_t labelLength = std::strlen(label);
+    size_t labelStart = 0;
+    size_t filterStart = 0;
+
+    while (filterStart < filter.size()) {
+      // Collapse repeated spaces between filter tokens
+      while (filterStart < filter.size() && std::isspace((unsigned char)filter[filterStart])) {
+        ++filterStart;
+      }
+      if (filterStart >= filter.size()) return true;
+
+      // Read one token from the spaced filter
+      size_t filterEnd = filterStart;
+      while (filterEnd < filter.size() && !std::isspace((unsigned char)filter[filterEnd])) {
+        ++filterEnd;
+      }
+
+      // Each token must match the start of a later PascalCase word
+      bool foundToken = false;
+      for (; labelStart < labelLength; ++labelStart) {
+        if (!isPascalWordStart(label, labelLength, labelStart)) continue;
+        if (!labelStartsWithFilterToken(label, labelLength, labelStart, filter, filterStart, filterEnd)) continue;
+
+        labelStart += filterEnd - filterStart;
+        foundToken = true;
+        break;
+      }
+      if (!foundToken) return false;
+
+      filterStart = filterEnd;
+    }
+
+    return true;
+  }
+
+  /**
+   * Returns whether a label matches a filter, ignoring case.
    * @param label Item text.
    * @param filter Filter text.
    * @return True when the item matches the filter.
    */
   inline bool labelMatchesFilter(const char *label, const std::string &filter)
   {
-    if (filter.empty())return true;
+    // There is no filter --> The label matches
+    if (filter.empty()) return true;
 
+    // The filter contains spaces --> Filter PascalCase words
+    if (std::any_of(filter.begin(), filter.end(), [](unsigned char c) { return std::isspace(c); })) {
+      return labelMatchesPascalWordFilter(label, filter);
+    }
+
+    // std::search needs an explicit end pointer for the C-string label
     const char *labelEnd = label + std::strlen(label);
+
+    // Compare each character case-insensitively while searching for the filter text
     return std::search(label, labelEnd, filter.begin(), filter.end(),
-      [](unsigned char lhs, unsigned char rhs) {
-        return std::tolower(lhs) == std::tolower(rhs);
+      [](unsigned char labelChar, unsigned char filterChar) {
+        return std::tolower(labelChar) == std::tolower(filterChar);
       }
     ) != labelEnd;
   }

--- a/src/editor/imgui/helper.h
+++ b/src/editor/imgui/helper.h
@@ -214,6 +214,16 @@ namespace ImTable
   }
 
   /**
+   * Opens a ComboBox popup on the next BeginCombo call.
+   * @param label Internal ImGui label used by the ComboBox.
+   */
+  inline void unfoldComboBox(const char *label)
+  {
+    ImGuiID popupId = ImHashStr("##ComboPopup", 0, ImGui::GetID(label));
+    ImGui::OpenPopupEx(popupId, ImGuiPopupFlags_None);
+  }
+
+  /**
    * Draws a search input for an opened ComboBox popup.
    * @param label ImGui label used to derive the combo-specific filter state.
    * @return Pointer to the filter string owned by this helper.

--- a/src/project/component/types/compCode.cpp
+++ b/src/project/component/types/compCode.cpp
@@ -16,6 +16,7 @@ namespace Project::Component::Code
   struct Data
   {
     uint64_t scriptUUID{0};
+    bool openScriptComboBox{true}; // Open the Script ComboBox when the component is added
     std::unordered_map<std::string, PropString> args{};
   };
 
@@ -41,6 +42,7 @@ namespace Project::Component::Code
   std::shared_ptr<void> deserialize(nlohmann::json &doc) {
     auto data = std::make_shared<Data>();
     data->scriptUUID = doc["script"].get<uint64_t>();
+    data->openScriptComboBox = false;
     if (doc.contains("args")) {
       auto &argsObj = doc["args"];
       for (auto& [key, val] : argsObj.items()) {
@@ -185,6 +187,13 @@ namespace Project::Component::Code
           }
         }
       }
+
+      // Need to open the Script ComboBox (the component is being added)
+      if (data.openScriptComboBox) {
+        ImTable::unfoldComboBox("##Script");
+        data.openScriptComboBox = false;
+      }
+
       ImTable::end();
     }
   }

--- a/src/project/component/types/compCode.cpp
+++ b/src/project/component/types/compCode.cpp
@@ -101,7 +101,7 @@ namespace Project::Component::Code
 
     if (ImTable::start("Comp", &obj)) {
       ImTable::add("Name", entry.name);
-      ImTable::addAssetVecComboBox("Script", scriptList, data.scriptUUID);
+      ImTable::addAssetVecComboBox("Script", scriptList, data.scriptUUID, true);
 
       auto script = assets.getEntryByUUID(data.scriptUUID);
       if (script) {


### PR DESCRIPTION
## Summary
Enhances the `Script` ComboBox used by the `Code` component by adding a filter, so it is easier to find a component.

## Changes
- Adds a filter TextBox at the top of the DropDown when the `Script` ComboBox is unfolded.
- Supports finding by word by looking at PascalCase word starts when the filter contains spaces.

## Additionally
- Automatically opens the `Script` ComboBox when a `Code` component is added.

<img width="493" height="164" alt="image" src="https://github.com/user-attachments/assets/c3dd5a5a-bba7-4dd0-8a3f-9e29ecca9721" />