### PR TITLE
Allow to drag&drop a Script to add a Code component

### DIFF
--- a/src/editor/imgui/helper.h
+++ b/src/editor/imgui/helper.h
@@ -116,12 +116,18 @@ namespace ImGui
     return idx;
   }
 
-  // Generic drag-drop target handler for combo boxes
-  // Validator signature: bool(uint64_t uuid, const char* payloadType)
-  // Returns true if a valid drop was accepted
+  /**
+   * Handles drag-and-drop over combo boxes.
+   * @tparam TId Target identifier type updated by the drop.
+   * @tparam TValidator Callable with signature bool(uint64_t uuid, const char* payloadType).
+   * @param targetId Identifier currently bound to the control.
+   * @param validator Payload validator for asset/object drops.
+   * @return true if a valid drop was accepted.
+   */
   template<typename TId, typename TValidator>
   bool HandleComboBoxDragDrop(TId& targetId, TValidator validator)
   {
+    // Current item is not an active target --> Do nothing
     if (!ImGui::BeginDragDropTarget()) return false;
 
     bool changed = false;
@@ -129,7 +135,9 @@ namespace ImGui
     // Handle ASSET payload
     if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ASSET", ImGuiDragDropFlags_AcceptBeforeDelivery)) {
       uint64_t uuid = *((uint64_t*)payload->Data);
+      // Is an ASSET
       if (validator(uuid, "ASSET")) {
+        // Mouse button released --> Commit new value
         if (payload->Delivery) {
           auto next = static_cast<TId>(uuid);
           if (targetId != next) {
@@ -137,6 +145,7 @@ namespace ImGui
             changed = true;
           }
         }
+      // Is not an ASSET --> Keep the field highlighted, but show that drop not allowed
       } else {
         ImGui::SetMouseCursor(ImGuiMouseCursor_NotAllowed);
       }
@@ -145,7 +154,9 @@ namespace ImGui
     // Handle OBJECT payload
     if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("OBJECT", ImGuiDragDropFlags_AcceptBeforeDelivery)) {
       uint32_t uuid = *((uint32_t*)payload->Data);
+      // Is an OBJECT
       if (validator(uuid, "OBJECT")) {
+        // Mouse button released --> Commit new value
         if (payload->Delivery) {
           auto next = static_cast<TId>(uuid);
           if (targetId != next) {
@@ -153,11 +164,13 @@ namespace ImGui
             changed = true;
           }
         }
+      // Is not an OBJECT --> Keep the field highlighted, but show that drop not allowed
       } else {
         ImGui::SetMouseCursor(ImGuiMouseCursor_NotAllowed);
       }
     }
 
+    // Close the item-level target scope opened above
     ImGui::EndDragDropTarget();
     return changed;
   }

--- a/src/editor/imgui/helper.h
+++ b/src/editor/imgui/helper.h
@@ -123,33 +123,41 @@ namespace ImGui
   bool HandleComboBoxDragDrop(TId& targetId, TValidator validator)
   {
     if (!ImGui::BeginDragDropTarget()) return false;
-    
+
     bool changed = false;
-    
+
     // Handle ASSET payload
-    if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ASSET")) {
+    if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ASSET", ImGuiDragDropFlags_AcceptBeforeDelivery)) {
       uint64_t uuid = *((uint64_t*)payload->Data);
       if (validator(uuid, "ASSET")) {
-        auto next = static_cast<TId>(uuid);
-        if (targetId != next) {
-          targetId = next;
-          changed = true;
+        if (payload->Delivery) {
+          auto next = static_cast<TId>(uuid);
+          if (targetId != next) {
+            targetId = next;
+            changed = true;
+          }
         }
+      } else {
+        ImGui::SetMouseCursor(ImGuiMouseCursor_NotAllowed);
       }
     }
-    
-    // Handle OBJECT payload  
-    if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("OBJECT")) {
+
+    // Handle OBJECT payload
+    if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("OBJECT", ImGuiDragDropFlags_AcceptBeforeDelivery)) {
       uint32_t uuid = *((uint32_t*)payload->Data);
       if (validator(uuid, "OBJECT")) {
-        auto next = static_cast<TId>(uuid);
-        if (targetId != next) {
-          targetId = next;
-          changed = true;
+        if (payload->Delivery) {
+          auto next = static_cast<TId>(uuid);
+          if (targetId != next) {
+            targetId = next;
+            changed = true;
+          }
         }
+      } else {
+        ImGui::SetMouseCursor(ImGuiMouseCursor_NotAllowed);
       }
     }
-    
+
     ImGui::EndDragDropTarget();
     return changed;
   }

--- a/src/editor/pages/parts/objectInspector.cpp
+++ b/src/editor/pages/parts/objectInspector.cpp
@@ -23,76 +23,117 @@ namespace
 {
   constexpr int COMP_ID_CODE = 0;
 
+  /**
+   * Returns whether the current drag payload is an object-script asset.
+   * @param scriptUUID Optional output for the dragged script UUID.
+   * @return true when the active payload is a CODE_OBJ asset.
+   */
   bool isDraggedObjectScript(uint64_t *scriptUUID = nullptr)
   {
+    // Access ImGui's drag-drop state
     ImGuiContext &g = *GImGui;
+    // There is no drag operation or no project assets to inspect --> Do nothing
     if (!g.DragDropActive || !ctx.project) return false;
 
+    // Only asset payloads with UUIDs can create Code components here
     const ImGuiPayload *payload = ImGui::GetDragDropPayload();
-    if (!payload || !payload->IsDataType("ASSET") || payload->DataSize != sizeof(uint64_t)) {
+    if (!payload || !payload->IsDataType("ASSET") || payload->DataSize != sizeof(uint64_t))
       return false;
-    }
 
+    // Resolve the dragged UUID back to an asset entry and verify that it is an object script
     const uint64_t uuid = *static_cast<const uint64_t*>(payload->Data);
     auto *script = ctx.project->getAssets().getEntryByUUID(uuid);
-    if (!script || script->type != Project::FileType::CODE_OBJ) return false;
+    if (!script || script->type != Project::FileType::CODE_OBJ)
+      return false;
 
-    if (scriptUUID) *scriptUUID = uuid;
+    // Requeted to output the UUID --> Assign it
+    if (scriptUUID)
+      *scriptUUID = uuid;
+
     return true;
   }
 
+  /**
+   * Creates a Code component using dropped Script.
+   * @param targetObj Object receiving the new component.
+   * @param scriptUUID UUID of the dragged script.
+   * @return true when the component was added successfully.
+   */
   bool createCodeComponentFromScript(Project::Object *targetObj, uint64_t scriptUUID)
   {
+    // There is no target object --> Do nothing
     if (!targetObj) return false;
 
+    // Track the component count to detect whether addComponent actually appended one
     const auto oldSize = targetObj->components.size();
+    // Record undo history before modifying the component list
     Editor::UndoRedo::getHistory().markChanged("Add Code Component");
+    // Create a Code component
     targetObj->addComponent(COMP_ID_CODE);
     if (targetObj->components.size() <= oldSize) return false;
 
+    // Set the Script field for the created Code component
     auto &comp = targetObj->components.back();
     Project::Component::Code::setScript(comp, scriptUUID, false);
     return true;
   }
 
+  /**
+   * Handles dropping an object script onto the inspector panel.
+   * @param targetObj Object that should receive a new Code component.
+   * @param dropRect Custom panel-space drop rectangle.
+   * @param highlightWindow True to draw the inspector-wide highlight border.
+   * @return True when a valid script is hovering or was delivered to this target.
+   */
   bool handleScriptComponentDropTarget(Project::Object *targetObj, const ImRect &dropRect, bool highlightWindow)
   {
+    // Register the inspector panel as a custom drop target covering the requested rectangle
     if (!ImGui::BeginDragDropTargetCustom(dropRect, ImGui::GetID("##ScriptComponentDropTarget"))) return false;
 
+    // Peek the asset payload while it hovers so the panel can highlight before delivery
     const ImGuiPayload *payload = ImGui::AcceptDragDropPayload(
       "ASSET",
       ImGuiDragDropFlags_AcceptBeforeDelivery | ImGuiDragDropFlags_AcceptNoDrawDefaultRect
     );
+    // There is no compatible payload --> Skip the target
     if (!payload || payload->DataSize != sizeof(uint64_t)) {
       ImGui::EndDragDropTarget();
       return false;
     }
 
+    // Resolve the hovered asset UUID and reject anything that is not an object Script
     const uint64_t scriptUUID = *static_cast<const uint64_t*>(payload->Data);
     auto *script = ctx.project->getAssets().getEntryByUUID(scriptUUID);
+    // Is not a Code component --> Skip the target
     if (!script || script->type != Project::FileType::CODE_OBJ) {
       ImGui::EndDragDropTarget();
       return false;
     }
 
     if (highlightWindow) {
+      // Use the window's inner rectangle so the border matches the visible inspector panel
       ImGuiWindow *window = ImGui::GetCurrentWindowRead();
       auto col = ImGui::GetColorU32(ImGuiCol_DragDropTarget);
       ImRect borderRect = window->InnerRect;
+      // Fix the rect size not to write outside of the panel
       borderRect.Min.y += 1.0f;
       borderRect.Min.x += 2.0f;
       borderRect.Max.x -= 2.0f;
       borderRect.Max.y -= 2.0f;
+      // Draw an outline to highlight the object inspector panel
       ImGui::GetWindowDrawList()->AddRect(borderRect.Min, borderRect.Max, col, 0.0f, 0, 2.0f);
     }
 
     bool accepted = false;
+    // Released the mouse --> Commit drop, create Code component
     if (payload->Delivery) {
       accepted = createCodeComponentFromScript(targetObj, scriptUUID);
+    // Hovering valid script --> Mark the panel as active drop target
     } else {
       accepted = true;
     }
 
+    // Close the custom target scope opened above
     ImGui::EndDragDropTarget();
     return accepted;
   }

--- a/src/editor/pages/parts/objectInspector.cpp
+++ b/src/editor/pages/parts/objectInspector.cpp
@@ -19,6 +19,85 @@
 #include "../../selectionUtils.h"
 #include "../../undoRedo.h"
 
+namespace
+{
+  constexpr int COMP_ID_CODE = 0;
+
+  bool isDraggedObjectScript(uint64_t *scriptUUID = nullptr)
+  {
+    ImGuiContext &g = *GImGui;
+    if (!g.DragDropActive || !ctx.project) return false;
+
+    const ImGuiPayload *payload = ImGui::GetDragDropPayload();
+    if (!payload || !payload->IsDataType("ASSET") || payload->DataSize != sizeof(uint64_t)) {
+      return false;
+    }
+
+    const uint64_t uuid = *static_cast<const uint64_t*>(payload->Data);
+    auto *script = ctx.project->getAssets().getEntryByUUID(uuid);
+    if (!script || script->type != Project::FileType::CODE_OBJ) return false;
+
+    if (scriptUUID) *scriptUUID = uuid;
+    return true;
+  }
+
+  bool createCodeComponentFromScript(Project::Object *targetObj, uint64_t scriptUUID)
+  {
+    if (!targetObj) return false;
+
+    const auto oldSize = targetObj->components.size();
+    Editor::UndoRedo::getHistory().markChanged("Add Code Component");
+    targetObj->addComponent(COMP_ID_CODE);
+    if (targetObj->components.size() <= oldSize) return false;
+
+    auto &comp = targetObj->components.back();
+    Project::Component::Code::setScript(comp, scriptUUID, false);
+    return true;
+  }
+
+  bool handleScriptComponentDropTarget(Project::Object *targetObj, const ImRect &dropRect, bool highlightWindow)
+  {
+    if (!ImGui::BeginDragDropTargetCustom(dropRect, ImGui::GetID("##ScriptComponentDropTarget"))) return false;
+
+    const ImGuiPayload *payload = ImGui::AcceptDragDropPayload(
+      "ASSET",
+      ImGuiDragDropFlags_AcceptBeforeDelivery | ImGuiDragDropFlags_AcceptNoDrawDefaultRect
+    );
+    if (!payload || payload->DataSize != sizeof(uint64_t)) {
+      ImGui::EndDragDropTarget();
+      return false;
+    }
+
+    const uint64_t scriptUUID = *static_cast<const uint64_t*>(payload->Data);
+    auto *script = ctx.project->getAssets().getEntryByUUID(scriptUUID);
+    if (!script || script->type != Project::FileType::CODE_OBJ) {
+      ImGui::EndDragDropTarget();
+      return false;
+    }
+
+    if (highlightWindow) {
+      ImGuiWindow *window = ImGui::GetCurrentWindowRead();
+      auto col = ImGui::GetColorU32(ImGuiCol_DragDropTarget);
+      ImRect borderRect = window->InnerRect;
+      borderRect.Min.y += 1.0f;
+      borderRect.Min.x += 2.0f;
+      borderRect.Max.x -= 2.0f;
+      borderRect.Max.y -= 2.0f;
+      ImGui::GetWindowDrawList()->AddRect(borderRect.Min, borderRect.Max, col, 0.0f, 0, 2.0f);
+    }
+
+    bool accepted = false;
+    if (payload->Delivery) {
+      accepted = createCodeComponentFromScript(targetObj, scriptUUID);
+    } else {
+      accepted = true;
+    }
+
+    ImGui::EndDragDropTarget();
+    return accepted;
+  }
+}
+
 Editor::ObjectInspector::ObjectInspector() {
 }
 
@@ -461,6 +540,12 @@ void Editor::ObjectInspector::draw() {
   if (ImGui::Button(addLabel)) {
     ImGui::OpenPopup("CompSelect");
   }
+
+  const ImVec2 contentMin = ImGui::GetWindowPos() + ImGui::GetWindowContentRegionMin();
+  const ImVec2 contentMax = ImGui::GetWindowPos() + ImGui::GetWindowContentRegionMax();
+
+  ImRect panelDropRect{contentMin, contentMax};
+  handleScriptComponentDropTarget(srcObj, panelDropRect, true);
 
   if (ImGui::BeginPopupContextItem("CompSelect"))
   {

--- a/src/project/component/components.h
+++ b/src/project/component/components.h
@@ -96,6 +96,11 @@ namespace Project::Component
     View getView(Object &obj, Entry &entry);
   }
 
+  namespace Code
+  {
+    void setScript(Entry &entry, uint64_t scriptUUID, bool openScriptComboBox);
+  }
+
   constexpr std::array TABLE{
     CompInfo{
       .id = 0,

--- a/src/project/component/components.h
+++ b/src/project/component/components.h
@@ -98,6 +98,12 @@ namespace Project::Component
 
   namespace Code
   {
+    /**
+     * Assigns a Script to a Code component.
+     * @param entry Code component entry to assign the Script to.
+     * @param scriptUUID UUID of the Script.
+     * @param openScriptComboBox true to auto-open the combo box.
+     */
     void setScript(Entry &entry, uint64_t scriptUUID, bool openScriptComboBox);
   }
 

--- a/src/project/component/types/compCode.cpp
+++ b/src/project/component/types/compCode.cpp
@@ -25,6 +25,13 @@ namespace Project::Component::Code
     return data;
   }
 
+  void setScript(Entry &entry, uint64_t scriptUUID, bool openScriptComboBox)
+  {
+    Data &data = *static_cast<Data*>(entry.data.get());
+    data.scriptUUID = scriptUUID;
+    data.openScriptComboBox = openScriptComboBox;
+  }
+
   nlohmann::json serialize(const Entry &entry) {
     Data &data = *static_cast<Data*>(entry.data.get());
     Utils::JSON::Builder builder{};

--- a/src/project/component/types/compCode.cpp
+++ b/src/project/component/types/compCode.cpp
@@ -25,10 +25,19 @@ namespace Project::Component::Code
     return data;
   }
 
+  /**
+   * Assigns a Script to a Code component.
+   * @param entry Code component entry to assign the Script to.
+   * @param scriptUUID UUID of the Script.
+   * @param openScriptComboBox true to auto-open the combo box.
+   */
   void setScript(Entry &entry, uint64_t scriptUUID, bool openScriptComboBox)
   {
+    // Reinterpret the generic component payload as Code-specific data
     Data &data = *static_cast<Data*>(entry.data.get());
+    // Set the Script UUID to use
     data.scriptUUID = scriptUUID;
+    // Preserve the requested combo-box behavior for the next draw call
     data.openScriptComboBox = openScriptComboBox;
   }
 


### PR DESCRIPTION
## Summary
Eases creating a Code component by dropping a Script.

## Changes
- Allow to drag and drop a Script from the Files -> Scripts tab to the Object inspector tab to create a Code component.
- Also allow to drop it in the "Script" field of a Code component to switch it.

## Additionally
- Display the NotAllowed cursor when dragging over a non-valid target ComboBox.