### PR TITLE
Allow to open the selected Script from the Code component

### DIFF
--- a/src/project/component/types/compCode.cpp
+++ b/src/project/component/types/compCode.cpp
@@ -5,10 +5,12 @@
 #include "../components.h"
 #include "../../../context.h"
 #include "../../../editor/imgui/helper.h"
+#include "../../../editor/imgui/notification.h"
 #include "../../../utils/json.h"
 #include "../../../utils/jsonBuilder.h"
 #include "../../../utils/binaryFile.h"
 #include "../../../utils/logger.h"
+#include "../../../utils/proc.h"
 #include "../../../utils/string.h"
 
 namespace Project::Component::Code
@@ -119,9 +121,27 @@ namespace Project::Component::Code
 
     if (ImTable::start("Comp", &obj)) {
       ImTable::add("Name", entry.name);
-      ImTable::addAssetVecComboBox("Script", scriptList, data.scriptUUID, true);
+      ImTable::add("Script");
+
+      // Reserve space for the edit button so the Script combo box keeps its full row layout
+      const float editButtonWidth = ImGui::GetFontSize() + ImGui::GetStyle().FramePadding.x * 2;
+      const float spacing = ImGui::GetStyle().ItemSpacing.x;
+      ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - editButtonWidth - spacing);
+      ImTable::addAssetVecComboBox("", scriptList, data.scriptUUID, true);
 
       auto script = assets.getEntryByUUID(data.scriptUUID);
+      ImGui::SameLine();
+      if (!script) ImGui::BeginDisabled();
+
+      // Open the selected Script in an external application
+      if (ImGui::Button(ICON_MDI_PENCIL, {editButtonWidth, 0}) && script) {
+        if (!Utils::Proc::openFile(script->path)) {
+          Editor::Noti::add(Editor::Noti::Type::ERROR, "Failed to open File. This may be due to WSL path conversion failure.");
+        }
+      }
+      if (!script) ImGui::EndDisabled();
+      ImGui::SetItemTooltip("Edit Script");
+
       if (script) {
 
         ImTable::add("Arguments:");


### PR DESCRIPTION
## Summary
Adds a button to edit the selected script in the Code component, so it is not necessary to find it in the Files -> Scripts tab.

## Notes
- I have tried to make it square, but due to the icon size and the overall padding, the icon was not centered, but displaced to the right.
- I have also tried to make smaller the space between the combo box and the button, to have the same as for Vector3, for example, but I couldn't figure out how.
<img width="528" height="204" alt="image" src="https://github.com/user-attachments/assets/f3b86319-7d53-4945-b35f-3632565a80cd" />
