### PR TITLE
Physics API: Add swept-sphere function

### DIFF
--- a/n64/engine/include/collision/collisionScene.h
+++ b/n64/engine/include/collision/collisionScene.h
@@ -12,6 +12,7 @@
 #include "aabbTree.h"
 #include "raycast.h"
 #include "capsuleSweep.h"
+#include "sphereSweep.h"
 #include <array>
 #include <deque>
 #include <functional>
@@ -122,6 +123,16 @@ namespace P64::Coll {
       RaycastColliderTypeFlags collTypes,
       uint8_t readMask,
       CapsuleSweepHit& hit,
+      const Object* ignoreOwner = nullptr
+    ) const;
+
+    bool sphereSweep(
+      const fm_vec3_t& center,
+      float radius,
+      const fm_vec3_t& displacement,
+      RaycastColliderTypeFlags collTypes,
+      uint8_t readMask,
+      SphereSweepHit& hit,
       const Object* ignoreOwner = nullptr
     ) const;
 

--- a/n64/engine/include/collision/sphereSweep.h
+++ b/n64/engine/include/collision/sphereSweep.h
@@ -1,0 +1,45 @@
+/**
+* @copyright 2026 - Max Bebök
+* @license MIT
+*/
+#pragma once
+
+#include "vecMath.h"
+#include "raycast.h"
+
+namespace P64::Coll {
+
+  struct CapsuleSweepHit {
+    fm_vec3_t normal{};   ///< Contact normal pointing away from geometry, toward the capsule
+    fm_vec3_t point{};    ///< Contact point on the geometry surface
+    float t{1.0f};        ///< Normalized fraction [0..1] of displacement at first contact
+    float depth{0.0f};    ///< Overlap depth when t == 0 (capsule was already penetrating)
+    bool didHit{false};
+  };
+
+  /**
+   * Tests a capsule sweep against a single world-space triangle.
+   * Returns true and fills `hit` with the earliest contact (or deepest overlap when t == 0).
+   *
+   * @param center         Capsule center in world space
+   * @param axisUp         Normalized capsule-axis direction
+   * @param radius         Capsule radius
+   * @param innerHalfHeight Half-length of the cylindrical section (not including sphere caps)
+   * @param displacement   World-space displacement vector (not normalized)
+   * @param v0/v1/v2       World-space triangle vertices
+   * @param triNormal      World-space outward triangle normal (should be normalized)
+   */
+  bool capsuleSweepTriangle(
+    const fm_vec3_t& center,
+    const fm_vec3_t& axisUp,
+    float radius,
+    float innerHalfHeight,
+    const fm_vec3_t& displacement,
+    const fm_vec3_t& v0,
+    const fm_vec3_t& v1,
+    const fm_vec3_t& v2,
+    const fm_vec3_t& triNormal,
+    CapsuleSweepHit& hit
+  );
+
+}

--- a/n64/engine/include/collision/sphereSweep.h
+++ b/n64/engine/include/collision/sphereSweep.h
@@ -9,7 +9,7 @@
 
 namespace P64::Coll {
 
-  struct CapsuleSweepHit {
+  struct SphereSweepHit {
     fm_vec3_t normal{};   ///< Contact normal pointing away from geometry, toward the capsule
     fm_vec3_t point{};    ///< Contact point on the geometry surface
     float t{1.0f};        ///< Normalized fraction [0..1] of displacement at first contact
@@ -18,28 +18,24 @@ namespace P64::Coll {
   };
 
   /**
-   * Tests a capsule sweep against a single world-space triangle.
+   * Tests a sphere sweep against a single world-space triangle.
    * Returns true and fills `hit` with the earliest contact (or deepest overlap when t == 0).
    *
    * @param center         Capsule center in world space
-   * @param axisUp         Normalized capsule-axis direction
    * @param radius         Capsule radius
-   * @param innerHalfHeight Half-length of the cylindrical section (not including sphere caps)
    * @param displacement   World-space displacement vector (not normalized)
    * @param v0/v1/v2       World-space triangle vertices
    * @param triNormal      World-space outward triangle normal (should be normalized)
    */
-  bool capsuleSweepTriangle(
+  bool sphereSweepTriangle(
     const fm_vec3_t& center,
-    const fm_vec3_t& axisUp,
     float radius,
-    float innerHalfHeight,
     const fm_vec3_t& displacement,
     const fm_vec3_t& v0,
     const fm_vec3_t& v1,
     const fm_vec3_t& v2,
     const fm_vec3_t& triNormal,
-    CapsuleSweepHit& hit
+    SphereSweepHit& hit
   );
 
 }

--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -1624,6 +1624,23 @@ namespace P64::Coll {
     }
   }
 
+  struct SphereGjkData {
+      fm_vec3_t center;
+      float radius;
+  };
+
+  static void sphereGjkSupport(const void *data, const fm_vec3_t &dir, fm_vec3_t &out) {
+    const auto &s = *static_cast<const SphereGjkData*>(data);
+    const float len2 = fm_vec3_len2(&dir);
+    if (len2 > FM_EPSILON * FM_EPSILON) {
+      // Center + (Normalized Direction * Radius)
+      out = s.center + dir * (1.0f / sqrtf(len2) * s.radius);
+    } else {
+      // Fallback if the direction vector is zero
+      out = s.center;
+    }
+  }
+
   // World-space support for a Collider. The shape support functions return LOCAL-space points (centered at origin), 
   // so we rotate the query direction into local space, sample, then transform the result back to world space.
   static void colliderWorldGjkSupport(const void *data, const fm_vec3_t &dir, fm_vec3_t &out) {
@@ -1792,6 +1809,174 @@ namespace P64::Coll {
           hit.normal = n;
           // Swept contact: the capsule is NOT penetrating at the start position,
           // it only reaches the surface partway through the move. 
+          // `depth` is reserved for pre-existing overlaps, so set 0 here
+          hit.depth  = 0.0f;
+          hit.point  = epa.contactB;
+        }
+      }
+    }
+
+    return hit.didHit;
+  }
+
+  bool CollisionScene::sphereSweep(
+          const fm_vec3_t& center,
+          float radius,
+          const fm_vec3_t& displacement,
+          RaycastColliderTypeFlags collTypes,
+          uint8_t readMask,
+          SphereSweepHit& hit,
+          const Object* ignoreOwner
+  ) const {
+    hit = SphereSweepHit{};
+
+    const bool doMesh    = hasFlag(collTypes, RaycastColliderTypeFlags::MESH_COLLIDERS);
+    const bool doBodies  = hasFlag(collTypes, RaycastColliderTypeFlags::COLLIDER_BODIES);
+    if (!doMesh && !doBodies) return false;
+
+    // Compute world-space swept AABB for broadphase
+    fm_vec3_t extents = {
+            radius,
+            radius,
+            radius
+    };
+    AABB capsuleBox = { center - extents, center + extents };
+    AABB sweptBox;
+    aabbExtendDirection(capsuleBox, displacement, sweptBox);
+
+    SphereSweepHit candidate{};
+
+    // ── Mesh colliders ──────────────────────────────────────────────────────
+    if (doMesh) {
+      constexpr int MAX_TRI = 64;
+      NodeProxy triCandidates[MAX_TRI];
+      constexpr int MAX_MESH_CANDIDATES = 32;
+      NodeProxy meshCandidates[MAX_MESH_CANDIDATES];
+
+      int meshCount = meshColliderAABBTree.queryBounds(sweptBox, meshCandidates, MAX_MESH_CANDIDATES);
+      for (int m = 0; m < meshCount; ++m) {
+        const MeshCollider* mesh = static_cast<const MeshCollider*>(
+                meshColliderAABBTree.getNodeData(meshCandidates[m]));
+        if (!mesh || mesh->triangleCount() == 0 || !mesh->ownerObject()) continue;
+
+        AABB localSweptBox = mesh->worldAabbToLocal(sweptBox);
+        int triCount = mesh->queryTriangleNodes(localSweptBox, triCandidates, MAX_TRI);
+
+        for (int i = 0; i < triCount; ++i) {
+          int triIdx = mesh->triangleIndexForNode(triCandidates[i]);
+          if (triIdx < 0 || triIdx >= static_cast<int>(mesh->triangleCount())) continue;
+
+          const MeshTriangleIndices& tri = mesh->triangleIndices(triIdx);
+
+          fm_vec3_t wv0 = mesh->hasTransform() ? mesh->toWorldSpace(mesh->vertex(tri.indices[0])) : mesh->vertex(tri.indices[0]);
+          fm_vec3_t wv1 = mesh->hasTransform() ? mesh->toWorldSpace(mesh->vertex(tri.indices[1])) : mesh->vertex(tri.indices[1]);
+          fm_vec3_t wv2 = mesh->hasTransform() ? mesh->toWorldSpace(mesh->vertex(tri.indices[2])) : mesh->vertex(tri.indices[2]);
+          fm_vec3_t wn  = mesh->hasTransform() ? mesh->localNormalToWorld(mesh->triangleNormal(triIdx)) : mesh->triangleNormal(triIdx);
+
+          candidate = SphereSweepHit{};
+          if (!sphereSweepTriangle(center, radius,
+                                    displacement, wv0, wv1, wv2, wn, candidate))
+            continue;
+
+          if (!hit.didHit || candidate.t < hit.t ||
+              (candidate.t == 0.0f && candidate.depth > hit.depth)) {
+            hit = candidate;
+          }
+        }
+      }
+    }
+
+    // Collider bodies (GJK + EPA)
+    if (doBodies) {
+      constexpr int MAX_CB_CANDIDATES = 16;
+      NodeProxy cbCandidates[MAX_CB_CANDIDATES];
+
+      const fm_vec3_t endCenter = center + displacement;
+      const SphereGjkData sphereStart{ center, radius };
+      const SphereGjkData sphereEnd  { endCenter, radius };
+
+      int cbCount = colliderAABBTree.queryBounds(sweptBox, cbCandidates, MAX_CB_CANDIDATES);
+      for (int ci = 0; ci < cbCount; ++ci) {
+        void *cbData = colliderAABBTree.getNodeData(cbCandidates[ci]);
+        if (!cbData) continue;
+        Collider *coll = static_cast<Collider *>(cbData);
+        if (!coll || !coll->ownerObject() || coll->isTrigger()) continue;
+        // Skip the sweep's filtered colliders
+        if (ignoreOwner && coll->ownerObject() == ignoreOwner) continue;
+        if ((coll->writeMask() & readMask) == 0) continue;
+
+        // Stable fallback direction for when EPA degenerates at a near-zero-depth touch.
+        // Points from the collider toward the sphere
+        // this can happen if .e.g the sphere hangs on the edge of an AABB
+        fm_vec3_t fallbackN = center - coll->worldCenter();
+        //if (fm_vec3_len2(&fallbackN) < FM_EPSILON * FM_EPSILON) fallbackN = axisUp;
+        //else fm_vec3_norm(&fallbackN, &fallbackN);
+        fm_vec3_norm(&fallbackN, &fallbackN);
+
+        // Below this, an "overlap" is really just a surface touch, not a penetration to push out of.
+        // Use the swept check here, which produces a stable contact normal for blocking/sliding.
+        constexpr float MIN_REAL_PENETRATION = 0.001f;
+
+        fm_vec3_t initDir = coll->worldCenter() - center;
+        //if (fm_vec3_len2(&initDir) < FM_EPSILON * FM_EPSILON) initDir = axisUp;
+
+        Simplex simplex{};
+        bool overlapAtStart = gjkCheckForOverlap(simplex,
+                                                 &sphereStart, sphereGjkSupport,
+                                                 coll, colliderWorldGjkSupport,
+                                                 initDir);
+
+        if (overlapAtStart) {
+          // Already inside: EPA gives the push-out normal and dept
+          EpaResult epa{};
+          if (epaSolve(simplex, &sphereStart, sphereGjkSupport, coll, colliderWorldGjkSupport, epa)
+              && epa.penetration > MIN_REAL_PENETRATION) {
+            fm_vec3_t n = epa.normal;
+            if (fm_vec3_len2(&n) < FM_EPSILON * FM_EPSILON) n = fallbackN;
+
+            if (!hit.didHit || hit.t > 0.0f || epa.penetration > hit.depth) {
+              hit.didHit = true;
+              hit.t      = 0.0f;
+              hit.normal = n;
+              hit.depth  = epa.penetration;
+              hit.point  = epa.contactB;
+            }
+            continue;
+          }
+          // Shallow / degenerate touch -> fall through to the swept check below
+        }
+
+        // End-position (swept) overlap check:
+        fm_vec3_t endInitDir = coll->worldCenter() - endCenter;
+        //if (fm_vec3_len2(&endInitDir) < FM_EPSILON * FM_EPSILON) endInitDir = axisUp;
+
+        Simplex endSimplex{};
+        bool overlapAtEnd = gjkCheckForOverlap(endSimplex,
+                                               &sphereEnd, sphereGjkSupport,
+                                               coll, colliderWorldGjkSupport,
+                                               endInitDir);
+
+        if (!overlapAtEnd) continue;
+
+        EpaResult epa{};
+        if (!epaSolve(endSimplex, &sphereEnd, sphereGjkSupport, coll, colliderWorldGjkSupport, epa)) continue;
+
+        fm_vec3_t n = epa.normal;
+        if (fm_vec3_len2(&n) < FM_EPSILON * FM_EPSILON) n = fallbackN;
+
+        // Estimate the touch fraction by backing the end-penetration out along the normal
+        const float dispAlongNormal = fabsf(fm_vec3_dot(&displacement, &n));
+        float t = 1.0f;
+        if (dispAlongNormal > FM_EPSILON) {
+          t = fmaxf(0.0f, fminf(1.0f - epa.penetration / dispAlongNormal, 1.0f));
+        }
+
+        if (!hit.didHit || t < hit.t) {
+          hit.didHit = true;
+          hit.t      = t;
+          hit.normal = n;
+          // Swept contact: the capsule is NOT penetrating at the start position,
+          // it only reaches the surface partway through the move.
           // `depth` is reserved for pre-existing overlaps, so set 0 here
           hit.depth  = 0.0f;
           hit.point  = epa.contactB;

--- a/n64/engine/src/collision/sphereSweep.cpp
+++ b/n64/engine/src/collision/sphereSweep.cpp
@@ -1,0 +1,340 @@
+/**
+* @copyright 2026 - Max Bebök
+* @license MIT
+*/
+#include "collision/capsuleSweep.h"
+#include "collision/meshCollider.h"
+#include "collision/aabb.h"
+#include "collision/vecMath.h"
+
+#include <cmath>
+#include <limits>
+#include <algorithm>
+
+namespace P64::Coll {
+
+static constexpr float SWEEP_EPS  = 1e-6f;
+static constexpr float PARAM_EPS  = 1e-4f; // inset to avoid double-counting end caps
+
+// ── Point-in-triangle (P already projected onto face plane) ──────────────────
+
+static bool pointInTriangle(
+  const fm_vec3_t& P,
+  const fm_vec3_t& v0, const fm_vec3_t& v1, const fm_vec3_t& v2,
+  const fm_vec3_t& n
+) {
+  fm_vec3_t e0 = v1 - v0;
+  fm_vec3_t e1 = v2 - v1;
+  fm_vec3_t e2 = v0 - v2;
+  fm_vec3_t p0 = P - v0;
+  fm_vec3_t p1 = P - v1;
+  fm_vec3_t p2 = P - v2;
+  fm_vec3_t c0, c1, c2;
+  fm_vec3_cross(&c0, &e0, &p0);
+  fm_vec3_cross(&c1, &e1, &p1);
+  fm_vec3_cross(&c2, &e2, &p2);
+  return fm_vec3_dot(&c0, &n) >= 0.0f &&
+         fm_vec3_dot(&c1, &n) >= 0.0f &&
+         fm_vec3_dot(&c2, &n) >= 0.0f;
+}
+
+// ── Sphere sub-tests ──────────────────────────────────────────────────────────
+
+// Sphere at S (radius r) sweeping along dir for up to t_max distance.
+// Returns t ∈ [0, t_max] or FLT_MAX. depth is positive only when t == 0.
+static float sphereFaceTest(
+  const fm_vec3_t& S, float r, const fm_vec3_t& dir, float t_max,
+  const fm_vec3_t& v0, const fm_vec3_t& v1, const fm_vec3_t& v2,
+  const fm_vec3_t& triN,
+  fm_vec3_t& outN, fm_vec3_t& outP, float& outDepth
+) {
+  float face_d   = fm_vec3_dot(&triN, &v0);
+  float sdist    = fm_vec3_dot(&triN, &S) - face_d; // positive = in front
+
+  if (sdist < -r) return std::numeric_limits<float>::max(); // fully behind
+
+  float t;
+  if (sdist >= r) {
+    float ndotd = fm_vec3_dot(&triN, &dir);
+    if (ndotd >= -SWEEP_EPS) return std::numeric_limits<float>::max();
+    t = (sdist - r) / (-ndotd);
+    if (t > t_max) return std::numeric_limits<float>::max();
+    outDepth = 0.0f;
+  } else {
+    t        = 0.0f;
+    outDepth = r - sdist;
+  }
+
+  fm_vec3_t C_t      = S + dir * t;
+  fm_vec3_t hitPlane = C_t - triN * r;
+  if (!pointInTriangle(hitPlane, v0, v1, v2, triN))
+    return std::numeric_limits<float>::max();
+
+  outN = triN;
+  outP = hitPlane;
+  return t;
+}
+
+static float sphereEdgeTest(
+  const fm_vec3_t& S, float r, const fm_vec3_t& dir, float t_max,
+  const fm_vec3_t& E0, const fm_vec3_t& E1,
+  fm_vec3_t& outN, fm_vec3_t& outP, float& outDepth
+) {
+  fm_vec3_t edge   = E1 - E0;
+  float     elen2  = fm_vec3_len2(&edge);
+  if (elen2 < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
+  float     elen   = sqrtf(elen2);
+  fm_vec3_t u_hat  = edge / elen;
+
+  fm_vec3_t ce     = S - E0;
+  float     ce_u   = fm_vec3_dot(&ce, &u_hat);
+  fm_vec3_t c0     = ce - u_hat * ce_u;          // perp component of (S-E0)
+  float     d_u    = fm_vec3_dot(&dir, &u_hat);
+  fm_vec3_t d_perp = dir - u_hat * d_u;          // perp component of dir
+
+  float c0len2 = fm_vec3_len2(&c0);
+  float c_val  = c0len2 - r * r;
+  float a      = fm_vec3_len2(&d_perp);
+  float b      = fm_vec3_dot(&d_perp, &c0);
+
+  float t;
+  if (c_val < 0.0f) {
+    // already within r of the infinite edge line
+    float proj = ce_u;
+    if (proj < 0.0f || proj > elen) return std::numeric_limits<float>::max();
+    t        = 0.0f;
+    outDepth = r - sqrtf(c0len2);
+  } else {
+    if (a < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
+    float disc = b * b - a * c_val;
+    if (disc < 0.0f) return std::numeric_limits<float>::max();
+    t = (-b - sqrtf(disc)) / a;
+    if (t < 0.0f) return std::numeric_limits<float>::max();
+    if (t > t_max) return std::numeric_limits<float>::max();
+    outDepth = 0.0f;
+  }
+
+  fm_vec3_t C_t = S + dir * t;
+  fm_vec3_t C_t_rel = C_t - E0;
+  float proj = fm_vec3_dot(&C_t_rel, &u_hat);
+  if (proj < 0.0f || proj > elen) return std::numeric_limits<float>::max();
+
+  outP = E0 + u_hat * proj;
+  outN = vec3NormalizeOrFallback(C_t - outP, -dir);
+  return t;
+}
+
+static float sphereVertexTest(
+  const fm_vec3_t& S, float r, const fm_vec3_t& dir, float t_max,
+  const fm_vec3_t& V,
+  fm_vec3_t& outN, fm_vec3_t& outP, float& outDepth
+) {
+  fm_vec3_t w    = S - V;
+  float     d2   = fm_vec3_len2(&w);
+  float     t;
+
+  if (d2 < r * r) {
+    t        = 0.0f;
+    outDepth = r - sqrtf(d2);
+  } else {
+    float b    = fm_vec3_dot(&w, &dir);
+    float disc = b * b - (d2 - r * r); // a == 1
+    if (disc < 0.0f) return std::numeric_limits<float>::max();
+    t = -b - sqrtf(disc);
+    if (t < 0.0f) return std::numeric_limits<float>::max();
+    if (t > t_max) return std::numeric_limits<float>::max();
+    outDepth = 0.0f;
+  }
+
+  fm_vec3_t C_t = S + dir * t;
+  outP = V;
+  outN = vec3NormalizeOrFallback(C_t - V, -dir);
+  return t;
+}
+
+// ── Cylinder body sub-tests ───────────────────────────────────────────────────
+// These only fire when the contact is strictly interior to the capsule segment
+// (not at either end cap), so they do not overlap with the sphere tests.
+
+static float cylinderEdgeTest(
+  const fm_vec3_t& P1, const fm_vec3_t& P2, float r,
+  const fm_vec3_t& dir, float t_max,
+  const fm_vec3_t& E0, const fm_vec3_t& E1,
+  fm_vec3_t& outN, fm_vec3_t& outP, float& outDepth
+) {
+  fm_vec3_t d1 = P2 - P1; // capsule axis
+  fm_vec3_t d2 = E1 - E0; // triangle edge
+
+  float a     = fm_vec3_len2(&d1);
+  float e_val = fm_vec3_len2(&d2);
+  float b     = fm_vec3_dot(&d1, &d2);
+  float denom = a * e_val - b * b;
+
+  if (denom < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
+
+  fm_vec3_t n_cross;
+  fm_vec3_cross(&n_cross, &d1, &d2);
+  float n_len = sqrtf(denom);
+  fm_vec3_t n_hat = n_cross / n_len;
+
+  fm_vec3_t r0    = P1 - E0;
+  float r0_dot    = fm_vec3_dot(&r0, &n_hat);
+  float vel_dot   = fm_vec3_dot(&dir, &n_hat); // dir is unit length
+
+  // Helper: verify both segment parameters are interior at a given t
+  auto resolve = [&](float t_phys) -> bool {
+    fm_vec3_t r0_t  = r0 + dir * t_phys;
+    float c_t       = fm_vec3_dot(&d1, &r0_t);
+    float f_t       = fm_vec3_dot(&d2, &r0_t);
+    float s_star    = (b * f_t - c_t * e_val) / denom; // [0,1] for interior
+    float u_star    = (a * f_t - b * c_t) / denom;      // [0,1] for interior
+    if (s_star <= PARAM_EPS || s_star >= 1.0f - PARAM_EPS) return false;
+    if (u_star < 0.0f || u_star > 1.0f) return false;
+    outP = E0 + d2 * u_star;
+    outN = (r0_dot >= 0.0f) ? n_hat : -n_hat;
+    return true;
+  };
+
+  if (fabsf(r0_dot) < r) {
+    if (!resolve(0.0f)) return std::numeric_limits<float>::max();
+    outDepth = r - fabsf(r0_dot);
+    return 0.0f;
+  }
+
+  if (fabsf(vel_dot) < SWEEP_EPS) return std::numeric_limits<float>::max();
+
+  float sign  = (r0_dot > 0.0f) ? 1.0f : -1.0f;
+  float t     = (sign * r - r0_dot) / vel_dot;
+  if (t < 0.0f || t > t_max) return std::numeric_limits<float>::max();
+  if (!resolve(t)) return std::numeric_limits<float>::max();
+  outDepth = 0.0f;
+  return t;
+}
+
+static float cylinderVertexTest(
+  const fm_vec3_t& P1, const fm_vec3_t& P2, float r,
+  const fm_vec3_t& dir, float t_max,
+  const fm_vec3_t& V,
+  fm_vec3_t& outN, fm_vec3_t& outP, float& outDepth
+) {
+  fm_vec3_t d1    = P2 - P1;
+  float d1_len2   = fm_vec3_len2(&d1);
+  if (d1_len2 < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
+  float d1_len    = sqrtf(d1_len2);
+  fm_vec3_t d1hat = d1 / d1_len;
+
+  // Decompose relative to capsule axis
+  fm_vec3_t w        = V - P1; // from P1 to vertex
+  float w_along      = fm_vec3_dot(&w, &d1hat);
+  fm_vec3_t w_perp   = w - d1hat * w_along;
+
+  float dir_along    = fm_vec3_dot(&dir, &d1hat);
+  fm_vec3_t dir_perp = dir - d1hat * dir_along;
+
+  float A      = fm_vec3_len2(&dir_perp);
+  float wperp2 = fm_vec3_len2(&w_perp);
+
+  float t;
+  if (wperp2 < r * r) {
+    // already within r of the capsule axis line
+    t = 0.0f;
+    outDepth = r - sqrtf(wperp2);
+  } else {
+    if (A < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
+    // dist_perp²(t) = |w_perp - t*dir_perp|²
+    float B    = fm_vec3_dot(&w_perp, &dir_perp);
+    float C    = wperp2 - r * r;
+    float disc = B * B - A * C;
+    if (disc < 0.0f) return std::numeric_limits<float>::max();
+    t = (B - sqrtf(disc)) / A; // smallest root
+    if (t < 0.0f) t = (B + sqrtf(disc)) / A;
+    if (t < 0.0f || t > t_max) return std::numeric_limits<float>::max();
+    outDepth = 0.0f;
+  }
+
+  // Verify s is strictly interior (not at end caps)
+  fm_vec3_t w_t = w - dir * t; // V - P1(t)
+  float s       = fm_vec3_dot(&w_t, &d1hat);
+  if (s <= PARAM_EPS || s >= d1_len - PARAM_EPS)
+    return std::numeric_limits<float>::max();
+
+  fm_vec3_t axis_pt = P1 + dir * t + d1hat * s;
+  outP = V;
+  outN = vec3NormalizeOrFallback(axis_pt - V, -dir);
+  return t;
+}
+
+// ── Public: capsule vs. one triangle ─────────────────────────────────────────
+
+bool capsuleSweepTriangle(
+  const fm_vec3_t& center,
+  const fm_vec3_t& axisUp,       // normalized capsule-axis direction
+  float radius,
+  float innerHalfHeight,
+  const fm_vec3_t& displacement, // world-space, not normalized
+  const fm_vec3_t& v0, const fm_vec3_t& v1, const fm_vec3_t& v2,
+  const fm_vec3_t& triNormal,
+  CapsuleSweepHit& hit
+) {
+  float dist = sqrtf(fm_vec3_len2(&displacement));
+  if (dist < SWEEP_EPS) return false;
+  fm_vec3_t dir = displacement / dist;
+
+  fm_vec3_t P1 = center - axisUp * innerHalfHeight;
+  fm_vec3_t P2 = center + axisUp * innerHalfHeight;
+
+  float     bestT     = std::numeric_limits<float>::max();
+  float     bestDepth = 0.0f;
+  fm_vec3_t bestN{}, bestP{};
+
+  auto update = [&](float t, const fm_vec3_t& n, const fm_vec3_t& p, float depth) {
+    if (t > dist + SWEEP_EPS) return;
+    // Among t==0 hits keep the deepest; otherwise keep the earliest
+    if (t < bestT || (t == 0.0f && depth > bestDepth)) {
+      bestT     = t;
+      bestN     = n;
+      bestP     = p;
+      bestDepth = depth;
+    }
+  };
+
+  const fm_vec3_t* verts[3] = {&v0, &v1, &v2};
+  fm_vec3_t n{}, p{};
+  float depth = 0.0f;
+
+  for (const fm_vec3_t* S : {&P1, &P2}) {
+    float t = sphereFaceTest(*S, radius, dir, dist, v0, v1, v2, triNormal, n, p, depth);
+    update(t, n, p, depth);
+
+    for (int i = 0; i < 3; ++i) {
+      t = sphereEdgeTest(*S, radius, dir, dist, *verts[i], *verts[(i+1)%3], n, p, depth);
+      update(t, n, p, depth);
+    }
+
+    for (const fm_vec3_t* V : verts) {
+      t = sphereVertexTest(*S, radius, dir, dist, *V, n, p, depth);
+      update(t, n, p, depth);
+    }
+  }
+
+  for (int i = 0; i < 3; ++i) {
+    float t = cylinderEdgeTest(P1, P2, radius, dir, dist, *verts[i], *verts[(i+1)%3], n, p, depth);
+    update(t, n, p, depth);
+  }
+
+  for (const fm_vec3_t* V : verts) {
+    float t = cylinderVertexTest(P1, P2, radius, dir, dist, *V, n, p, depth);
+    update(t, n, p, depth);
+  }
+
+  if (bestT > dist + SWEEP_EPS) return false;
+
+  hit.t      = fmaxf(0.0f, fminf(1.0f, bestT / dist));
+  hit.depth  = bestDepth;
+  hit.normal = vec3NormalizeOrFallback(bestN, -dir);
+  hit.point  = bestP;
+  hit.didHit = true;
+  return true;
+}
+
+} // namespace P64::Coll

--- a/n64/engine/src/collision/sphereSweep.cpp
+++ b/n64/engine/src/collision/sphereSweep.cpp
@@ -2,7 +2,7 @@
 * @copyright 2026 - Max Bebök
 * @license MIT
 */
-#include "collision/capsuleSweep.h"
+#include "collision/sphereSweep.h"
 #include "collision/meshCollider.h"
 #include "collision/aabb.h"
 #include "collision/vecMath.h"
@@ -152,136 +152,19 @@ static float sphereVertexTest(
   return t;
 }
 
-// ── Cylinder body sub-tests ───────────────────────────────────────────────────
-// These only fire when the contact is strictly interior to the capsule segment
-// (not at either end cap), so they do not overlap with the sphere tests.
+// ── Public: sphere vs. one triangle ─────────────────────────────────────────
 
-static float cylinderEdgeTest(
-  const fm_vec3_t& P1, const fm_vec3_t& P2, float r,
-  const fm_vec3_t& dir, float t_max,
-  const fm_vec3_t& E0, const fm_vec3_t& E1,
-  fm_vec3_t& outN, fm_vec3_t& outP, float& outDepth
-) {
-  fm_vec3_t d1 = P2 - P1; // capsule axis
-  fm_vec3_t d2 = E1 - E0; // triangle edge
-
-  float a     = fm_vec3_len2(&d1);
-  float e_val = fm_vec3_len2(&d2);
-  float b     = fm_vec3_dot(&d1, &d2);
-  float denom = a * e_val - b * b;
-
-  if (denom < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
-
-  fm_vec3_t n_cross;
-  fm_vec3_cross(&n_cross, &d1, &d2);
-  float n_len = sqrtf(denom);
-  fm_vec3_t n_hat = n_cross / n_len;
-
-  fm_vec3_t r0    = P1 - E0;
-  float r0_dot    = fm_vec3_dot(&r0, &n_hat);
-  float vel_dot   = fm_vec3_dot(&dir, &n_hat); // dir is unit length
-
-  // Helper: verify both segment parameters are interior at a given t
-  auto resolve = [&](float t_phys) -> bool {
-    fm_vec3_t r0_t  = r0 + dir * t_phys;
-    float c_t       = fm_vec3_dot(&d1, &r0_t);
-    float f_t       = fm_vec3_dot(&d2, &r0_t);
-    float s_star    = (b * f_t - c_t * e_val) / denom; // [0,1] for interior
-    float u_star    = (a * f_t - b * c_t) / denom;      // [0,1] for interior
-    if (s_star <= PARAM_EPS || s_star >= 1.0f - PARAM_EPS) return false;
-    if (u_star < 0.0f || u_star > 1.0f) return false;
-    outP = E0 + d2 * u_star;
-    outN = (r0_dot >= 0.0f) ? n_hat : -n_hat;
-    return true;
-  };
-
-  if (fabsf(r0_dot) < r) {
-    if (!resolve(0.0f)) return std::numeric_limits<float>::max();
-    outDepth = r - fabsf(r0_dot);
-    return 0.0f;
-  }
-
-  if (fabsf(vel_dot) < SWEEP_EPS) return std::numeric_limits<float>::max();
-
-  float sign  = (r0_dot > 0.0f) ? 1.0f : -1.0f;
-  float t     = (sign * r - r0_dot) / vel_dot;
-  if (t < 0.0f || t > t_max) return std::numeric_limits<float>::max();
-  if (!resolve(t)) return std::numeric_limits<float>::max();
-  outDepth = 0.0f;
-  return t;
-}
-
-static float cylinderVertexTest(
-  const fm_vec3_t& P1, const fm_vec3_t& P2, float r,
-  const fm_vec3_t& dir, float t_max,
-  const fm_vec3_t& V,
-  fm_vec3_t& outN, fm_vec3_t& outP, float& outDepth
-) {
-  fm_vec3_t d1    = P2 - P1;
-  float d1_len2   = fm_vec3_len2(&d1);
-  if (d1_len2 < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
-  float d1_len    = sqrtf(d1_len2);
-  fm_vec3_t d1hat = d1 / d1_len;
-
-  // Decompose relative to capsule axis
-  fm_vec3_t w        = V - P1; // from P1 to vertex
-  float w_along      = fm_vec3_dot(&w, &d1hat);
-  fm_vec3_t w_perp   = w - d1hat * w_along;
-
-  float dir_along    = fm_vec3_dot(&dir, &d1hat);
-  fm_vec3_t dir_perp = dir - d1hat * dir_along;
-
-  float A      = fm_vec3_len2(&dir_perp);
-  float wperp2 = fm_vec3_len2(&w_perp);
-
-  float t;
-  if (wperp2 < r * r) {
-    // already within r of the capsule axis line
-    t = 0.0f;
-    outDepth = r - sqrtf(wperp2);
-  } else {
-    if (A < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
-    // dist_perp²(t) = |w_perp - t*dir_perp|²
-    float B    = fm_vec3_dot(&w_perp, &dir_perp);
-    float C    = wperp2 - r * r;
-    float disc = B * B - A * C;
-    if (disc < 0.0f) return std::numeric_limits<float>::max();
-    t = (B - sqrtf(disc)) / A; // smallest root
-    if (t < 0.0f) t = (B + sqrtf(disc)) / A;
-    if (t < 0.0f || t > t_max) return std::numeric_limits<float>::max();
-    outDepth = 0.0f;
-  }
-
-  // Verify s is strictly interior (not at end caps)
-  fm_vec3_t w_t = w - dir * t; // V - P1(t)
-  float s       = fm_vec3_dot(&w_t, &d1hat);
-  if (s <= PARAM_EPS || s >= d1_len - PARAM_EPS)
-    return std::numeric_limits<float>::max();
-
-  fm_vec3_t axis_pt = P1 + dir * t + d1hat * s;
-  outP = V;
-  outN = vec3NormalizeOrFallback(axis_pt - V, -dir);
-  return t;
-}
-
-// ── Public: capsule vs. one triangle ─────────────────────────────────────────
-
-bool capsuleSweepTriangle(
+bool sphereSweepTriangle(
   const fm_vec3_t& center,
-  const fm_vec3_t& axisUp,       // normalized capsule-axis direction
   float radius,
-  float innerHalfHeight,
   const fm_vec3_t& displacement, // world-space, not normalized
   const fm_vec3_t& v0, const fm_vec3_t& v1, const fm_vec3_t& v2,
   const fm_vec3_t& triNormal,
-  CapsuleSweepHit& hit
+  SphereSweepHit& hit
 ) {
   float dist = sqrtf(fm_vec3_len2(&displacement));
   if (dist < SWEEP_EPS) return false;
   fm_vec3_t dir = displacement / dist;
-
-  fm_vec3_t P1 = center - axisUp * innerHalfHeight;
-  fm_vec3_t P2 = center + axisUp * innerHalfHeight;
 
   float     bestT     = std::numeric_limits<float>::max();
   float     bestDepth = 0.0f;
@@ -302,28 +185,16 @@ bool capsuleSweepTriangle(
   fm_vec3_t n{}, p{};
   float depth = 0.0f;
 
-  for (const fm_vec3_t* S : {&P1, &P2}) {
-    float t = sphereFaceTest(*S, radius, dir, dist, v0, v1, v2, triNormal, n, p, depth);
-    update(t, n, p, depth);
-
-    for (int i = 0; i < 3; ++i) {
-      t = sphereEdgeTest(*S, radius, dir, dist, *verts[i], *verts[(i+1)%3], n, p, depth);
-      update(t, n, p, depth);
-    }
-
-    for (const fm_vec3_t* V : verts) {
-      t = sphereVertexTest(*S, radius, dir, dist, *V, n, p, depth);
-      update(t, n, p, depth);
-    }
-  }
+  float t = sphereFaceTest(center, radius, dir, dist, v0, v1, v2, triNormal, n, p, depth);
+  update(t, n, p, depth);
 
   for (int i = 0; i < 3; ++i) {
-    float t = cylinderEdgeTest(P1, P2, radius, dir, dist, *verts[i], *verts[(i+1)%3], n, p, depth);
+    t = sphereEdgeTest(center, radius, dir, dist, *verts[i], *verts[(i+1)%3], n, p, depth);
     update(t, n, p, depth);
   }
 
   for (const fm_vec3_t* V : verts) {
-    float t = cylinderVertexTest(P1, P2, radius, dir, dist, *V, n, p, depth);
+    t = sphereVertexTest(center, radius, dir, dist, *V, n, p, depth);
     update(t, n, p, depth);
   }
 


### PR DESCRIPTION
This PR adds functionality to the collision scene based upon the swept capsule logic. It's more performant than the swept capsule and has the shape of a sphere.