### PR TITLE
Add viewport lock mode for touchpad/laptop navigation

### DIFF
--- a/src/editor/pages/parts/preferenceOverlay.cpp
+++ b/src/editor/pages/parts/preferenceOverlay.cpp
@@ -23,6 +23,7 @@ bool Editor::PreferenceOverlay::draw()
     ImTable::add("Pan Speed", ctx.prefs.panSpeed);
     ImTable::add("Look Speed", ctx.prefs.lookSpeed);
     ImTable::add("Invert Wheel Y", ctx.prefs.invertWheelY);
+    ImTable::add("Lock Viewport Navigation", ctx.prefs.viewportLockMode);
     ImTable::end();
   }
 

--- a/src/editor/pages/parts/viewport3D.cpp
+++ b/src/editor/pages/parts/viewport3D.cpp
@@ -849,8 +849,10 @@ void Editor::Viewport3D::draw()
   bool anyMouseClicked = ImGui::IsMouseClicked(ImGuiMouseButton_Left)
     || ImGui::IsMouseClicked(ImGuiMouseButton_Right)
     || ImGui::IsMouseClicked(ImGuiMouseButton_Middle);
-  if (!newMouseDown) inputActive = false;
+  if (!newMouseDown && !navLocked) inputActive = false;
   else if (anyMouseClicked && isMouseHover) inputActive = true;
+  if (navLocked) inputActive = true;
+  if (navLocked && !ctx.prefs.viewportLockMode) { navLocked = false; setCameraDrag(false); }
 
   bool isCameraFlying = false;
   bool isAltDown = ImGui::GetIO().KeyAlt;
@@ -866,8 +868,9 @@ void Editor::Viewport3D::draw()
   bool leftClicked = ImGui::IsMouseClicked(ImGuiMouseButton_Left);
   bool leftDown = ImGui::IsMouseDown(ImGuiMouseButton_Left);
   bool leftReleased = ImGui::IsMouseReleased(ImGuiMouseButton_Left);
+  bool rightClicked = ImGui::IsMouseClicked(ImGuiMouseButton_Right);
 
-  if (!overGizmo && isMouseHover && leftClicked && !isAltDown && !overRotGizmo) {
+  if (!navLocked && !overGizmo && isMouseHover && leftClicked && !isAltDown && !overRotGizmo) {
     selectionPending = true;
     selectionDragging = false;
     selectionStart = mousePos;
@@ -947,13 +950,22 @@ void Editor::Viewport3D::draw()
       obj = nullptr;
     }
 
-    isCameraFlying = mouseHeldRight && inputActive;
+    isCameraFlying = (mouseHeldRight && inputActive) || navLocked;
+
+    if (ctx.prefs.viewportLockMode && !camLocked) {
+      if (rightClicked && isMouseHover && !navLocked) {
+        navLocked = true;
+      } else if (navLocked && rightClicked) {
+        navLocked = false;
+        inputActive = false;
+      }
+    }
 
     if (deletedSelection) {
       hasSelection = false;
     }
 
-    if (newMouseDown && !camLocked && inputActive) {
+    if ((newMouseDown || navLocked) && !camLocked && inputActive) {
       glm::vec3 moveDir = {0,0,0};
       if (ImGui::IsKeyDown(ctx.prefs.keymap.moveForward))moveDir.z = -moveSpeed;
       if (ImGui::IsKeyDown(ctx.prefs.keymap.moveBack))moveDir.z = moveSpeed;
@@ -1114,14 +1126,21 @@ void Editor::Viewport3D::draw()
   auto dragDelta = mousePos - mousePosStart;
 
   // Orbit / pan / look all move the view freely, so lock the cursor for them
-  bool wantCameraDrag = isMouseDown && inputActive && !camLocked &&
-    ((isAltDown && mouseHeldLeft) || mouseHeldMiddle || mouseHeldRight);
+  bool wantCameraDrag = !camLocked && (navLocked ||
+    (isMouseDown && inputActive &&
+     ((isAltDown && mouseHeldLeft) || mouseHeldMiddle ||
+      (!ctx.prefs.viewportLockMode && mouseHeldRight))));
   setCameraDrag(wantCameraDrag);
 
-  if (isMouseDown && inputActive) {
+  if (navLocked || (isMouseDown && inputActive)) {
     ImGui::ClearActiveID();
     if (!camLocked) {
-      if (isAltDown && mouseHeldLeft) {
+      if (navLocked) {
+        camera.stopMoveDelta();
+        camera.lookDelta(dragDelta);
+        mousePosStart = mousePos = {0,0};
+        camera.stopRotateDelta();
+      } else if (isAltDown && mouseHeldLeft) {
         camera.stopMoveDelta();
         camera.orbitDelta(dragDelta);
       } else if (mouseHeldMiddle) {

--- a/src/editor/pages/parts/viewport3D.h
+++ b/src/editor/pages/parts/viewport3D.h
@@ -71,6 +71,7 @@ namespace Editor
       bool overRotGizmo{false};
       bool inputActive{false};    // this viewport captured the camera drag (started inside it)
       bool viewGizmoOwned{false}; // this viewport owns the active orientation-cube drag
+      bool navLocked{false};      // viewport lock mode: cursor captured, right-click to toggle
 
       void onRenderPass(SDL_GPUCommandBuffer* cmdBuff, Renderer::Scene& renderScene);
       void onCopyPass(SDL_GPUCommandBuffer* cmdBuff, SDL_GPUCopyPass *copyPass);

--- a/src/editor/preferences.cpp
+++ b/src/editor/preferences.cpp
@@ -45,6 +45,7 @@ void Editor::Preferences::load()
     fpsLimit = doc.value("fpsLimit", DEF.fpsLimit);
     showRotAsEuler = doc.value("showRotAsEuler", DEF.showRotAsEuler);
     mouseWheelModifiesSpeed = doc.value("mouseWheelModifiesSpeed", DEF.mouseWheelModifiesSpeed);
+    viewportLockMode = doc.value("viewportLockMode", DEF.viewportLockMode);
   } else {
     applyKeymapPreset();
   }
@@ -72,6 +73,7 @@ void Editor::Preferences::save()
     .set("fpsLimit", fpsLimit)
     .set("showRotAsEuler", showRotAsEuler)
     .set("mouseWheelModifiesSpeed", mouseWheelModifiesSpeed)
+    .set("viewportLockMode", viewportLockMode)
     .toString();
   auto prefPath = getPrefsPath();
   printf("Saving prefs to %s\n", prefPath.c_str());

--- a/src/editor/preferences.h
+++ b/src/editor/preferences.h
@@ -32,6 +32,7 @@ namespace Editor
     int fpsLimit = 60;
     bool showRotAsEuler = false;
     bool mouseWheelModifiesSpeed = false;
+    bool viewportLockMode = false;
 
     void load();
     void save();


### PR DESCRIPTION
Summary
- Adds a "Lock Viewport Navigation" toggle to Preferences → Navigation
- When enabled, right-clicking the 3D viewport locks the cursor into free-look mode — no need to hold the button down
- Right-click again to exit and camera stays exactly where you were looking
- WASD movement works freely while locked; alt+drag orbit and middle-drag pan continue to work normally


<img width="502" height="298" alt="image" src="https://github.com/user-attachments/assets/e4f4ce07-a0fb-4dae-82d3-b5de463622ac" />


On laptops and trackpads, holding right-click while simultaneously using WASD is awkward or impossible. This mode lets users toggle into navigation freely and exit cleanly.