### PR TITLE
Fix quote emulator and ROM paths so paths with spaces work

### DIFF
--- a/src/editor/globalActions.cpp
+++ b/src/editor/globalActions.cpp
@@ -159,7 +159,16 @@ namespace Editor::Actions
 
       std::string runCmd{};
       if (arg == "run") {
-        runCmd = ctx.project->conf.pathEmu + " " + z64Path;
+        // Quote both paths so spaces (e.g. "E:\Ares Emulator\ares.exe") don't
+        // split into separate tokens. runSyncLogged() runs this via popen(),
+        // which on Windows invokes `cmd.exe /c`; cmd strips the outermost pair
+        // of quotes, so the whole command is wrapped in an extra pair to keep
+        // the per-path quotes intact.
+#ifdef _WIN32
+        runCmd = "\"\"" + ctx.project->conf.pathEmu + "\" \"" + z64Path + "\"\"";
+#else
+        runCmd = "\"" + ctx.project->conf.pathEmu + "\" \"" + z64Path + "\"";
+#endif
       }
 
       ctx.futureBuildRun = std::async(std::launch::async, [] (std::string configPath, std::string runCmd)


### PR DESCRIPTION
## Problem

Running a project failed when the configured emulator path contained a space (e.g. `E:\Ares Emulator\ares.exe`). The run command was built by joining the emulator path and ROM path with a bare space:

```cpp
runCmd = ctx.project->conf.pathEmu + " " + z64Path;
```

The shell then split the path at the space and reported:

```
'E:\Ares' is not recognized as an internal or external command, operable program or batch file.
```

## Fix

Quote both the emulator path and the ROM path.

`runSyncLogged()` executes the command via `popen()`, which on Windows runs `cmd.exe /c`. `cmd.exe` strips the outermost pair of quotes, so on Windows the whole command is wrapped in an extra pair to keep the per-path quotes intact. POSIX shells need only the per-path quotes.

## Verification

Reproduced the exact failure and confirmed the fix through the same `popen(cmd + " 2>&1")` path the app uses, with a fake emulator placed in a directory containing a space and a ROM path that also contains a space:

- **Before:** `'...\Ares' is not recognized...`, exit 1 (matches the reported bug).
- **After:** the emulator receives `argc=2`, `argv[0]` = full emulator path, `argv[1]` = full ROM path; exit 0.

The default case (`pathEmu = "ares"` resolved from `PATH`) still works, since `cmd.exe` reduces `""ares" "rom.z64""` back to `"ares" "rom.z64"`.