### PR TITLE
Change UI Pos/Rot/Scale order to make it consistent

### DIFF
--- a/src/editor/pages/parts/objectInspector.cpp
+++ b/src/editor/pages/parts/objectInspector.cpp
@@ -455,38 +455,38 @@ void Editor::ObjectInspector::draw() {
           }
         };
 
-        ImTable::add("Pos");
-        ImGui::PushID("Pos");
+        ImTable::add("Position");
+        ImGui::PushID("Position");
         float posWidth = (ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x * 2.0f) / 3.0f;
-        drawFloatField("PosX", mixedPos[0], posValue.x, posWidth, "Edit Pos", [&](float val) {
+        drawFloatField("PosX", mixedPos[0], posValue.x, posWidth, "Edit Position", [&](float val) {
           applyVec3Component(&Project::Object::pos, 0, val);
         });
         ImGui::SameLine();
-        drawFloatField("PosY", mixedPos[1], posValue.y, posWidth, "Edit Pos", [&](float val) {
+        drawFloatField("PosY", mixedPos[1], posValue.y, posWidth, "Edit Position", [&](float val) {
           applyVec3Component(&Project::Object::pos, 1, val);
         });
         ImGui::SameLine();
-        drawFloatField("PosZ", mixedPos[2], posValue.z, posWidth, "Edit Pos", [&](float val) {
+        drawFloatField("PosZ", mixedPos[2], posValue.z, posWidth, "Edit Position", [&](float val) {
           applyVec3Component(&Project::Object::pos, 2, val);
         });
         ImGui::PopID();
 
-        ImTable::add("Rot");
-        ImGui::PushID("Rot");
+        ImTable::add("Rotation");
+        ImGui::PushID("Rotation");
         float rotWidth = (ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x * 3.0f) / 4.0f;
-        drawFloatField("RotX", mixedRot[0], rotValue.x, rotWidth, "Edit Rot", [&](float val) {
+        drawFloatField("RotX", mixedRot[0], rotValue.x, rotWidth, "Edit Rotation", [&](float val) {
           applyQuatComponent(&Project::Object::rot, 0, val);
         });
         ImGui::SameLine();
-        drawFloatField("RotY", mixedRot[1], rotValue.y, rotWidth, "Edit Rot", [&](float val) {
+        drawFloatField("RotY", mixedRot[1], rotValue.y, rotWidth, "Edit Rotation", [&](float val) {
           applyQuatComponent(&Project::Object::rot, 1, val);
         });
         ImGui::SameLine();
-        drawFloatField("RotZ", mixedRot[2], rotValue.z, rotWidth, "Edit Rot", [&](float val) {
+        drawFloatField("RotZ", mixedRot[2], rotValue.z, rotWidth, "Edit Rotation", [&](float val) {
           applyQuatComponent(&Project::Object::rot, 2, val);
         });
         ImGui::SameLine();
-        drawFloatField("RotW", mixedRot[3], rotValue.w, rotWidth, "Edit Rot", [&](float val) {
+        drawFloatField("RotW", mixedRot[3], rotValue.w, rotWidth, "Edit Rotation", [&](float val) {
           applyQuatComponent(&Project::Object::rot, 3, val);
         });
         ImGui::PopID();
@@ -592,7 +592,7 @@ void Editor::ObjectInspector::draw() {
     if(ImTable::start("Transform", tableObj))
     {
       ImTable::addObjProp(
-        "Pos",
+        "Position",
         xfSrc->pos,
         Editor::TransformUtils::preserveChildTransformsDuringEdit<glm::vec3>(obj.get(), [](glm::vec3 *val) -> bool {
           // Use the standard vector editor while preserving child offsets
@@ -602,7 +602,7 @@ void Editor::ObjectInspector::draw() {
       );
 
       ImTable::addObjProp(
-        "Rot",
+        "Rotation",
         xfSrc->rot,
         Editor::TransformUtils::preserveChildTransformsDuringEdit<glm::quat>(obj.get(), [](glm::quat *val) -> bool {
           // Use the standard quaternion editor while preserving child offsets

--- a/src/editor/pages/parts/objectInspector.cpp
+++ b/src/editor/pages/parts/objectInspector.cpp
@@ -471,22 +471,6 @@ void Editor::ObjectInspector::draw() {
         });
         ImGui::PopID();
 
-        ImTable::add("Scale");
-        ImGui::PushID("Scale");
-        float scaleWidth = (ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x * 2.0f) / 3.0f;
-        drawFloatField("ScaleX", mixedScale[0], scaleValue.x, scaleWidth, "Edit Scale", [&](float val) {
-          applyVec3Component(&Project::Object::scale, 0, val);
-        });
-        ImGui::SameLine();
-        drawFloatField("ScaleY", mixedScale[1], scaleValue.y, scaleWidth, "Edit Scale", [&](float val) {
-          applyVec3Component(&Project::Object::scale, 1, val);
-        });
-        ImGui::SameLine();
-        drawFloatField("ScaleZ", mixedScale[2], scaleValue.z, scaleWidth, "Edit Scale", [&](float val) {
-          applyVec3Component(&Project::Object::scale, 2, val);
-        });
-        ImGui::PopID();
-
         ImTable::add("Rot");
         ImGui::PushID("Rot");
         float rotWidth = (ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x * 3.0f) / 4.0f;
@@ -504,6 +488,22 @@ void Editor::ObjectInspector::draw() {
         ImGui::SameLine();
         drawFloatField("RotW", mixedRot[3], rotValue.w, rotWidth, "Edit Rot", [&](float val) {
           applyQuatComponent(&Project::Object::rot, 3, val);
+        });
+        ImGui::PopID();
+
+        ImTable::add("Scale");
+        ImGui::PushID("Scale");
+        float scaleWidth = (ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x * 2.0f) / 3.0f;
+        drawFloatField("ScaleX", mixedScale[0], scaleValue.x, scaleWidth, "Edit Scale", [&](float val) {
+          applyVec3Component(&Project::Object::scale, 0, val);
+        });
+        ImGui::SameLine();
+        drawFloatField("ScaleY", mixedScale[1], scaleValue.y, scaleWidth, "Edit Scale", [&](float val) {
+          applyVec3Component(&Project::Object::scale, 1, val);
+        });
+        ImGui::SameLine();
+        drawFloatField("ScaleZ", mixedScale[2], scaleValue.z, scaleWidth, "Edit Scale", [&](float val) {
+          applyVec3Component(&Project::Object::scale, 2, val);
         });
         ImGui::PopID();
 
@@ -601,6 +601,29 @@ void Editor::ObjectInspector::draw() {
         nullptr
       );
 
+      ImTable::addObjProp(
+        "Rot",
+        xfSrc->rot,
+        Editor::TransformUtils::preserveChildTransformsDuringEdit<glm::quat>(obj.get(), [](glm::quat *val) -> bool {
+          // Use the standard quaternion editor while preserving child offsets
+          return ImTable::typedInput<glm::quat>(val);
+        }),
+        nullptr
+      );
+
+      // icon to toggle between quaternion and euler
+      ImGui::SameLine();
+      ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 32_px);
+      if(ImGui::IconButton(ctx.prefs.showRotAsEuler ? ICON_MDI_AXIS_Z_ROTATE_CLOCKWISE : ICON_MDI_SPHERE, {24_px, 24_px})) {
+        ImGui::ClearActiveID();
+        ctx.prefs.showRotAsEuler = !ctx.prefs.showRotAsEuler;
+        ctx.prefs.save();
+      }
+      ImGui::SetItemTooltip(ctx.prefs.showRotAsEuler
+        ? "Change to Quaternion"
+        : "Change to Euler (degrees)"
+      );
+
       if(xfSrc->proportionalScale)
       {
         std::function<bool(glm::vec3*)> cb = [](glm::vec3 *val) -> bool {
@@ -654,29 +677,6 @@ void Editor::ObjectInspector::draw() {
       ImGui::SetItemTooltip(xfSrc->proportionalScale
         ? "Change to Independent Scale"
         : "Change to Proportional Scale"
-      );
-
-      ImTable::addObjProp(
-        "Rot",
-        xfSrc->rot,
-        Editor::TransformUtils::preserveChildTransformsDuringEdit<glm::quat>(obj.get(), [](glm::quat *val) -> bool {
-          // Use the standard quaternion editor while preserving child offsets
-          return ImTable::typedInput<glm::quat>(val);
-        }),
-        nullptr
-      );
-
-      // icon to toggle between quaternion and euler
-      ImGui::SameLine();
-      ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 32_px);
-      if(ImGui::IconButton(ctx.prefs.showRotAsEuler ? ICON_MDI_AXIS_Z_ROTATE_CLOCKWISE : ICON_MDI_SPHERE, {24_px, 24_px})) {
-        ImGui::ClearActiveID();
-        ctx.prefs.showRotAsEuler = !ctx.prefs.showRotAsEuler;
-        ctx.prefs.save();
-      }
-      ImGui::SetItemTooltip(ctx.prefs.showRotAsEuler
-        ? "Change to Quaternion"
-        : "Change to Euler (degrees)"
       );
 
       ImTable::end();


### PR DESCRIPTION
## Summary
Fix the order of the elements of the Transform in the object inspector to be coherent with the 3D viewport.

## Changes
- Set Pos/Rot/Scale instead of Pos/Scale/Rot.

## Additionally
- Changed name of Pos/Rot to Position/Rotation.

<img width="417" height="188" alt="image" src="https://github.com/user-attachments/assets/22465a25-f32d-49b6-93c7-66c87aa29dbd" />