### PR TITLE
big collision optimizations

### DIFF
--- a/n64/engine/include/collision/boxBox.h
+++ b/n64/engine/include/collision/boxBox.h
@@ -1,0 +1,56 @@
+/**
+ * @file boxBox.h
+ * @author Kevin Reier <https://github.com/Byterset>
+ * @brief Analytical SAT-based Box vs Box collision with one-shot contact manifold generation.
+ *
+ * Replaces the iterative GJK+EPA path for box-box pairs. A single call produces the
+ * full contact manifold (up to 4 points) instead of one point per frame, which keeps
+ * warm-started impulses valid across frames and lets stacks come to rest faster
+ */
+#pragma once
+
+#include "vecMath.h"
+#include "matrix3x3.h"
+#include "contact.h"
+#include "epa.h"
+
+namespace P64::Coll {
+
+  // Maximum number of contact points analyticalBoxBoxManifold can generate.
+  constexpr int BOX_BOX_MAX_CONTACTS = 4;
+
+  // Speculative contact margin: clipped manifold points separated by up to this
+  // distance are kept instead of being dropped. Without this, micro-tilts of a resting box collapse the manifold
+  // from 4 points to 1, which restarts impulse accumulation every frame and makes
+  // stacks rock and fall over. Points inside the margin are treated as speculative
+  constexpr float BOX_BOX_SPECULATIVE_MARGIN = CONTACT_BREAKING_SEPARATION;
+
+  /// @brief Oriented box input for the SAT box-box test, decoupled from Collider
+  struct SatObb {
+    fm_vec3_t center{};   ///< world-space center
+    Matrix3x3 rotation{}; ///< local-to-world rotation (column i = world direction of local axis i)
+    fm_vec3_t halfSize{}; ///< half extents along the local axes
+  };
+
+  /// @brief Analytical SAT box-box test with one-shot manifold generation.
+  ///
+  /// Tests the 15 separating axes (6 face normals + 9 edge cross products). On overlap
+  /// the minimum-penetration axis is selected with a bias that prefers face contacts
+  /// over edge contacts (prevents the reference axis from flickering between nearly
+  /// equal face/edge depths across frames). Face contacts clip the incident face
+  /// against the reference face's side planes (Sutherland-Hodgman) and reduce the
+  /// clipped polygon to at most `maxResults` well-spread points; edge contacts produce
+  /// the single closest point between the two supporting edges.
+  ///
+  /// Results follow the EpaResult convention: normal points from B to A, contactA lies
+  /// on A's surface, contactB on B's surface, penetration >= 0.
+  ///
+  /// @param a          first box
+  /// @param b          second box
+  /// @param results    array to receive contact data
+  /// @param maxResults maximum number of contact points to generate. Pass 0 for a
+  ///                   boolean overlap query (returns 1 on overlap, 0 otherwise).
+  /// @return Number of contact points generated (0 = no collision).
+  int analyticalBoxBoxManifold(const SatObb &a, const SatObb &b, EpaResult *results, int maxResults);
+
+} // namespace P64::Coll

--- a/n64/engine/include/collision/collisionScene.h
+++ b/n64/engine/include/collision/collisionScene.h
@@ -145,6 +145,83 @@ namespace P64::Coll {
     std::unordered_map<ContactConstraintKey, int, ContactConstraintKeyHash> cachedConstraintLookup_{};
     std::vector<ContactConstraint *> solverConstraints_{};
 
+    // Contact solver working data (rebuilt each step in preSolveContacts)
+    // preSolveContacts bakes each side's per-unit-impulse response, so warm start and the solver loops are just multiply-adds
+
+    /// @brief Per-body data for the solver. Index 0 is a sentinel for the static side of a constraint (null/immovable), so the loops need no null checks.
+    struct SolverBody {
+      fm_vec3_t linearVelocity{};
+      fm_vec3_t angularVelocity{};
+      fm_vec3_t pushLinearVelocity{};
+      fm_vec3_t pushAngularVelocity{};
+      RigidBody *body{nullptr};
+    };
+    
+    /// @brief Per-constraint data for the normal (non-penetration) iterations.
+    /// linearResponse* is the velocity change per unit normal impulse, and is zeroed when that side can't respond
+    struct SolverConstraintHeader {
+      fm_vec3_t normal{};
+      fm_vec3_t linearResponseA{};
+      fm_vec3_t linearResponseB{};
+      uint16_t bodyA{0};
+      uint16_t bodyB{0};
+      uint16_t pointStart{0};
+      uint16_t pointCount{0};
+    };
+
+    /// @brief Per-contact point data for the normal iterations (hot loop).
+    /// angularMeasure* = r x n, used to read relative velocity at the contact;
+    /// angularResponse* = the spin change per unit impulse. Both zeroed when unused.
+    struct SolverContactPoint {
+      fm_vec3_t angularMeasureA{};
+      fm_vec3_t angularMeasureB{};
+      fm_vec3_t angularResponseA{};
+      fm_vec3_t angularResponseB{};
+      float normalMass{0.0f};
+      float velocityBias{0.0f};
+      float accumulatedImpulse{0.0f};
+      float positionBias{0.0f};
+      float accumulatedPushImpulse{0.0f};
+    };
+
+    /// @brief Per-constraint friction data (solved in one pass after the normal iterations)
+    /// linearMeasureScale* is 0 when that side's velocity is excluded (disabled/kinematic)
+    struct SolverFrictionHeader {
+      fm_vec3_t tangentU{};
+      fm_vec3_t tangentV{};
+      fm_vec3_t linearResponseUA{};
+      fm_vec3_t linearResponseUB{};
+      fm_vec3_t linearResponseVA{};
+      fm_vec3_t linearResponseVB{};
+      float friction{0.0f};
+      float linearMeasureScaleA{0.0f};
+      float linearMeasureScaleB{0.0f};
+    };
+
+    /// @brief Per-point friction data; index-aligned with solverPoints_
+    struct SolverFrictionPoint {
+      fm_vec3_t angularMeasureUA{};
+      fm_vec3_t angularMeasureUB{};
+      fm_vec3_t angularMeasureVA{};
+      fm_vec3_t angularMeasureVB{};
+      fm_vec3_t angularResponseUA{};
+      fm_vec3_t angularResponseUB{};
+      fm_vec3_t angularResponseVA{};
+      fm_vec3_t angularResponseVB{};
+      float tangentMassU{0.0f};
+      float tangentMassV{0.0f};
+      float accumulatedImpulseU{0.0f};
+      float accumulatedImpulseV{0.0f};
+      ContactPoint *source{nullptr};   // accumulated impulses are written back here for warm starting
+    };
+
+    std::vector<SolverBody> solverBodies_{};
+    std::vector<SolverConstraintHeader> solverHeaders_{};
+    std::vector<SolverContactPoint> solverPoints_{};
+    std::vector<SolverFrictionHeader> solverFrictionHeaders_{};
+    std::vector<SolverFrictionPoint> solverFrictionPoints_{};
+    std::vector<uint16_t> solverOrder_{}; // constraint processing order, shuffled once per step to avoid bias
+
     AABBTree colliderAABBTree;
     AABBTree meshColliderAABBTree;
 
@@ -211,10 +288,11 @@ namespace P64::Coll {
     void removeInactiveContacts();
     void rebuildSolverConstraints();
     void detectAllContacts();
+    uint16_t acquireSolverBodyIndex(RigidBody *body);
     void preSolveContacts();
     void warmStart();
     void solveVelocityConstraints();
-    bool solvePositionConstraints();
+    void solvePositionConstraints();
     void detectSweptCollisions();
     void updateMeshColliderWorldStates();
   };

--- a/n64/engine/include/collision/contact.h
+++ b/n64/engine/include/collision/contact.h
@@ -15,7 +15,14 @@ namespace P64 { class Object; }
 
 namespace P64::Coll {
 
-  constexpr int MAX_CONTACT_POINTS_PER_PAIR = 3;
+  // 4 points so a box resting face-on-face keeps all four corners supported;
+  // with only 3 the unsupported corner makes stacks rock and delays sleep.
+  constexpr int MAX_CONTACT_POINTS_PER_PAIR = 4;
+
+  // Manifold points separated by <= this distance stay active as speculative contacts
+  // The velocity solver lets them approach at up to separation/dt (see
+  // preSolveContacts), so they stabilize resting manifolds against small tilts without hovering
+  constexpr float CONTACT_BREAKING_SEPARATION = 0.01f;
 
   struct RigidBody; // forward declare
   struct Collider;  // forward declare

--- a/n64/engine/include/collision/rigidBody.h
+++ b/n64/engine/include/collision/rigidBody.h
@@ -160,11 +160,6 @@ namespace P64::Coll {
       return matrix3Vec3Mul(constrainedInvWorldInertiaTensor_, in);
     }
 
-    /// Reset split impulse push velocities at the start of each physics step
-    void resetPushVelocities() { pushLinearVelocity_ = VEC3_ZERO; pushAngularVelocity_ = VEC3_ZERO; }
-    const fm_vec3_t &pushLinearVelocity() const { return pushLinearVelocity_; }
-    const fm_vec3_t &pushAngularVelocity() const { return pushAngularVelocity_; }
-
   private:
     friend class CollisionScene;
 
@@ -215,11 +210,9 @@ namespace P64::Coll {
     bool hasAngularConstraints_{false};
     bool compoundPropertiesDirty_{true};
 
-    /// Split impulse push velocities (Bullet-style).
-    /// These accumulate position-correction impulses separately from real velocities,
-    /// preventing the "bouncy stacking" artifact of Baumgarte stabilization.
-    fm_vec3_t pushLinearVelocity_{};
-    fm_vec3_t pushAngularVelocity_{};
+    /// Index into the CollisionScene's per-step solver body array (-1 = not participating).
+    /// Only valid while the scene builds and runs the contact solvers.
+    int16_t solverIndex_{-1};
 
     void refreshConstraintCaches();
     void refreshAngularConstraintProjection();

--- a/n64/engine/src/collision/boxBox.cpp
+++ b/n64/engine/src/collision/boxBox.cpp
@@ -1,0 +1,423 @@
+/**
+ * @file boxBox.cpp
+ * @author Kevin Reier <https://github.com/Byterset>
+ * @brief Analytical SAT Box vs Box collision with one-shot contact manifold generation (see boxBox.h)
+ */
+#include "collision/boxBox.h"
+#include "collision/matrix3x3.h"
+
+#include <cmath>
+
+namespace P64::Coll {
+
+  // Added to |R| entries so near-parallel edges can't produce a false separating axis
+  // from rounding error (ODE/Bullet do the same).
+  constexpr float ABS_R_EPS = 1e-5f;
+  // Edge cross products shorter than this come from parallel edges; the face axes cover them.
+  constexpr float EDGE_AXIS_MIN_LEN2 = 1e-6f;
+  // An edge axis must beat the best face axis by this relative factor to win, so the
+  // reference axis doesn't flicker between near-equal face/edge depths (breaks warm starting).
+  constexpr float FACE_PREFERENCE_FUDGE = 1.05f;
+  // ...plus this absolute margin. Near rest the depths are tiny, so a relative fudge alone
+  // can't stop an edge axis parallel to the face normal (criss-cross stacks) from stealing
+  // the contact on a micro-tilt and collapsing the manifold to one point.
+  constexpr float EDGE_PREFERENCE_ABS_TOL = 0.005f;
+  // Clipped points within this separation still enter the manifold, so a resting stack
+  // keeps its full patch under micro-tilts.
+  constexpr float CLIP_KEEP_SEPARATION = BOX_BOX_SPECULATIVE_MARGIN;
+
+  static constexpr int NEXT_AXIS[3] = {1, 2, 0};
+
+  static inline fm_vec3_t matrixColumn(const Matrix3x3 &m, int col) {
+    return fm_vec3_t{{m.m[0][col], m.m[1][col], m.m[2][col]}};
+  }
+
+  // Clip a convex polygon against one slab side, keeping vertices with v[axis] >= -limit.
+  // outVerts needs room for inCount + 1 vertices.
+  static int clipPolygonToSlabSide(const fm_vec3_t *inVerts, int inCount,
+                                   fm_vec3_t *outVerts, int axis, float limit) {
+    int outCount = 0;
+    for(int i = 0; i < inCount; ++i) {
+      const fm_vec3_t &cur = inVerts[i];
+      const fm_vec3_t &nxt = inVerts[(i + 1) % inCount];
+      const float cVal = cur.v[axis];
+      const float nVal = nxt.v[axis];
+      const bool cInside = (cVal >= -limit);
+      const bool nInside = (nVal >= -limit);
+      if(cInside) outVerts[outCount++] = cur;
+      if(cInside != nInside) {
+        float t = (-limit - cVal) / (nVal - cVal);
+        outVerts[outCount++] = cur + (nxt - cur) * t;
+      }
+    }
+    return outCount;
+  }
+
+  // Closest points between two segments, each given by center, unit direction and half length.
+  static void closestPointsOnEdges(
+    const fm_vec3_t &centerA, const fm_vec3_t &dirA, float halfLenA,
+    const fm_vec3_t &centerB, const fm_vec3_t &dirB, float halfLenB,
+    fm_vec3_t &outPointA, fm_vec3_t &outPointB) {
+    const fm_vec3_t r = centerB - centerA;
+    const float b = fm_vec3_dot(&dirA, &dirB);
+    const float c = fm_vec3_dot(&dirA, &r);
+    const float f = fm_vec3_dot(&dirB, &r);
+
+    const float denom = 1.0f - b * b;
+    float sA = (denom > FM_EPSILON) ? (c - b * f) / denom : 0.0f;
+    sA = fminf(fmaxf(sA, -halfLenA), halfLenA);
+    float sB = b * sA - f;
+    sB = fminf(fmaxf(sB, -halfLenB), halfLenB);
+    sA = fminf(fmaxf(c + b * sB, -halfLenA), halfLenA);
+
+    outPointA = centerA + dirA * sA;
+    outPointB = centerB + dirB * sB;
+  }
+
+  // SAT runs in A's local frame using the relative rotation R (Gottschalk's OBB test,
+  // Real-Time Collision Detection 4.4.1). Face axes are unit length so the face path
+  // needs no sqrt; the single edge normalization is deferred until an edge axis wins.
+  int analyticalBoxBoxManifold(const SatObb &a, const SatObb &b, EpaResult *results, int maxResults) {
+    const float *ha = a.halfSize.v;
+    const float *hb = b.halfSize.v;
+
+    // Relative rotation R = A^T * B (maps B local -> A local); R[i][j] = dot(axisA_i, axisB_j)
+    float R[3][3];
+    float AbsR[3][3];
+    for(int i = 0; i < 3; ++i) {
+      for(int j = 0; j < 3; ++j) {
+        R[i][j] = a.rotation.m[0][i] * b.rotation.m[0][j] +
+                  a.rotation.m[1][i] * b.rotation.m[1][j] +
+                  a.rotation.m[2][i] * b.rotation.m[2][j];
+        AbsR[i][j] = fabsf(R[i][j]) + ABS_R_EPS;
+      }
+    }
+
+    // B's center relative to A's center, in A's local frame
+    const fm_vec3_t d = b.center - a.center;
+    float t[3];
+    for(int i = 0; i < 3; ++i) {
+      t[i] = a.rotation.m[0][i] * d.x + a.rotation.m[1][i] * d.y + a.rotation.m[2][i] * d.z;
+    }
+
+    float bestFaceDepth = 1e30f;
+    int bestFaceAxis = 0;
+    float bestFaceSign = 1.0f;
+    bool faceOfA = true;
+
+    // --- 3 face normals of A ---
+    for(int i = 0; i < 3; ++i) {
+      const float rb = AbsR[i][0] * hb[0] + AbsR[i][1] * hb[1] + AbsR[i][2] * hb[2];
+      const float depth = ha[i] + rb - fabsf(t[i]);
+      if(depth < 0.0f) return 0;
+      if(depth < bestFaceDepth) {
+        bestFaceDepth = depth;
+        bestFaceAxis = i;
+        bestFaceSign = (t[i] >= 0.0f) ? 1.0f : -1.0f;
+        faceOfA = true;
+      }
+    }
+
+    // --- 3 face normals of B ---
+    for(int j = 0; j < 3; ++j) {
+      const float tB = t[0] * R[0][j] + t[1] * R[1][j] + t[2] * R[2][j];
+      const float ra = AbsR[0][j] * ha[0] + AbsR[1][j] * ha[1] + AbsR[2][j] * ha[2];
+      const float depth = ra + hb[j] - fabsf(tB);
+      if(depth < 0.0f) return 0;
+      if(depth < bestFaceDepth) {
+        bestFaceDepth = depth;
+        bestFaceAxis = j;
+        // face normal must point from the reference box (B) toward the other box (A)
+        bestFaceSign = (tB >= 0.0f) ? -1.0f : 1.0f;
+        faceOfA = false;
+      }
+    }
+
+    // --- 9 edge cross products axisA_i x axisB_j ---
+    // Depths are measured on the unnormalized axis; comparisons use the
+    // cross-multiplied form to defer the sqrt until a winner is known.
+    bool edgeFound = false;
+    float bestEdgeDepthUnnorm = 0.0f;
+    float bestEdgeLen2 = 1.0f;
+    float bestEdgeSign = 1.0f;
+    int bestEdgeI = 0;
+    int bestEdgeJ = 0;
+
+    for(int i = 0; i < 3; ++i) {
+      const int i1 = NEXT_AXIS[i];
+      const int i2 = NEXT_AXIS[i1];
+      for(int j = 0; j < 3; ++j) {
+        const int j1 = NEXT_AXIS[j];
+        const int j2 = NEXT_AXIS[j1];
+
+        const float len2 = R[i1][j] * R[i1][j] + R[i2][j] * R[i2][j];
+        if(len2 < EDGE_AXIS_MIN_LEN2) continue; // parallel edges
+
+        const float ra = ha[i1] * AbsR[i2][j] + ha[i2] * AbsR[i1][j];
+        const float rb = hb[j1] * AbsR[i][j2] + hb[j2] * AbsR[i][j1];
+        const float proj = t[i2] * R[i1][j] - t[i1] * R[i2][j];
+        const float depth = ra + rb - fabsf(proj);
+        if(depth < 0.0f) return 0;
+
+        if(!edgeFound ||
+           depth * depth * bestEdgeLen2 < bestEdgeDepthUnnorm * bestEdgeDepthUnnorm * len2) {
+          edgeFound = true;
+          bestEdgeDepthUnnorm = depth;
+          bestEdgeLen2 = len2;
+          bestEdgeSign = (proj >= 0.0f) ? 1.0f : -1.0f;
+          bestEdgeI = i;
+          bestEdgeJ = j;
+        }
+      }
+    }
+
+    // Overlap confirmed past this point
+    if(maxResults <= 0 || !results) return 1; // boolean overlap query
+
+    bool useEdge = false;
+    float edgeDepth = 0.0f;
+    float edgeInvLen = 0.0f;
+    if(edgeFound) {
+      edgeInvLen = 1.0f / sqrtf(bestEdgeLen2);
+      edgeDepth = bestEdgeDepthUnnorm * edgeInvLen;
+      useEdge = edgeDepth * FACE_PREFERENCE_FUDGE + EDGE_PREFERENCE_ABS_TOL < bestFaceDepth;
+    }
+
+    // --- Edge contact: single point between the two supporting edges ---
+    if(useEdge) {
+      const int i = bestEdgeI;
+      const int i1 = NEXT_AXIS[i];
+      const int i2 = NEXT_AXIS[i1];
+      const int j = bestEdgeJ;
+      const int j1 = NEXT_AXIS[j];
+      const int j2 = NEXT_AXIS[j1];
+
+      // Contact axis in A local space (unit, pointing from A toward B):
+      // axisA_i x colB_j has components 0 / -R[i2][j] / R[i1][j] on axes i / i1 / i2.
+      fm_vec3_t axisLocalA = VEC3_ZERO;
+      axisLocalA.v[i1] = -R[i2][j] * (bestEdgeSign * edgeInvLen);
+      axisLocalA.v[i2] = R[i1][j] * (bestEdgeSign * edgeInvLen);
+
+      // Supporting edge on A: the edge along axis i on the side facing B
+      fm_vec3_t edgeCenterALocal = VEC3_ZERO;
+      edgeCenterALocal.v[i1] = (axisLocalA.v[i1] >= 0.0f) ? ha[i1] : -ha[i1];
+      edgeCenterALocal.v[i2] = (axisLocalA.v[i2] >= 0.0f) ? ha[i2] : -ha[i2];
+
+      // Same axis in B local space, pointing from B toward A: -(R^T * axisLocalA)
+      fm_vec3_t axisLocalB;
+      for(int m = 0; m < 3; ++m) {
+        axisLocalB.v[m] = -(R[0][m] * axisLocalA.v[0] + R[1][m] * axisLocalA.v[1] + R[2][m] * axisLocalA.v[2]);
+      }
+      fm_vec3_t edgeCenterBLocal = VEC3_ZERO;
+      edgeCenterBLocal.v[j1] = (axisLocalB.v[j1] >= 0.0f) ? hb[j1] : -hb[j1];
+      edgeCenterBLocal.v[j2] = (axisLocalB.v[j2] >= 0.0f) ? hb[j2] : -hb[j2];
+
+      const fm_vec3_t edgeCenterA = a.center + matrix3Vec3Mul(a.rotation, edgeCenterALocal);
+      const fm_vec3_t edgeCenterB = b.center + matrix3Vec3Mul(b.rotation, edgeCenterBLocal);
+      const fm_vec3_t edgeDirA = matrixColumn(a.rotation, i);
+      const fm_vec3_t edgeDirB = matrixColumn(b.rotation, j);
+
+      fm_vec3_t pointOnA, pointOnB;
+      closestPointsOnEdges(edgeCenterA, edgeDirA, ha[i], edgeCenterB, edgeDirB, hb[j], pointOnA, pointOnB);
+
+      results[0].normal = -matrix3Vec3Mul(a.rotation, axisLocalA); // B -> A
+      results[0].penetration = edgeDepth;
+      results[0].contactA = pointOnA;
+      results[0].contactB = pointOnB;
+      return 1;
+    }
+
+    // --- Face contact: clip the incident face against the reference face's side planes ---
+    const SatObb &ref = faceOfA ? a : b;
+    const SatObb &inc = faceOfA ? b : a;
+    const float *hRef = ref.halfSize.v;
+    const float *hInc = inc.halfSize.v;
+    const int fi = bestFaceAxis;
+    const float fSign = bestFaceSign; // reference face normal (ref local) = fSign * e_fi, points toward incident box
+
+    // Relative transform: incident local -> reference local
+    float relR[3][3];
+    float relT[3];
+    if(faceOfA) {
+      for(int i = 0; i < 3; ++i) {
+        for(int j = 0; j < 3; ++j) relR[i][j] = R[i][j];
+        relT[i] = t[i];
+      }
+    } else {
+      for(int i = 0; i < 3; ++i) {
+        for(int j = 0; j < 3; ++j) relR[i][j] = R[j][i];
+        relT[i] = -(R[0][i] * t[0] + R[1][i] * t[1] + R[2][i] * t[2]);
+      }
+    }
+
+    // Incident face: the face of inc whose normal is most anti-parallel to the reference normal.
+    // Incident axis j direction in ref local space = column j of relR.
+    int ji = 0;
+    float bestAlign = fabsf(relR[fi][0]);
+    for(int j = 1; j < 3; ++j) {
+      const float align = fabsf(relR[fi][j]);
+      if(align > bestAlign) {
+        bestAlign = align;
+        ji = j;
+      }
+    }
+    const float incSign = (fSign * relR[fi][ji] >= 0.0f) ? -1.0f : 1.0f;
+    const int ju = NEXT_AXIS[ji];
+    const int jv = NEXT_AXIS[ju];
+
+    // 4 corners of the incident face (inc local), cyclic winding, then into ref local space
+    static constexpr float CORNER_SIGNS[4][2] = {{1, 1}, {-1, 1}, {-1, -1}, {1, -1}};
+    fm_vec3_t poly[10];
+    fm_vec3_t polyTmp[10];
+    for(int k = 0; k < 4; ++k) {
+      fm_vec3_t corner;
+      corner.v[ji] = incSign * hInc[ji];
+      corner.v[ju] = CORNER_SIGNS[k][0] * hInc[ju];
+      corner.v[jv] = CORNER_SIGNS[k][1] * hInc[jv];
+      for(int m = 0; m < 3; ++m) {
+        poly[k].v[m] = relT[m] + relR[m][0] * corner.v[0] + relR[m][1] * corner.v[1] + relR[m][2] * corner.v[2];
+      }
+    }
+    int polyCount = 4;
+
+    // Clip against the 4 side planes of the reference face (slabs on the two non-face axes)
+    const int u1 = NEXT_AXIS[fi];
+    const int u2 = NEXT_AXIS[u1];
+    for(int step = 0; step < 2; ++step) {
+      const int axis = (step == 0) ? u1 : u2;
+      const float limit = hRef[axis];
+      polyCount = clipPolygonToSlabSide(poly, polyCount, polyTmp, axis, limit);
+      if(polyCount < 1) break;
+      // clip against +limit by mirroring the axis, clipping, mirroring back
+      for(int k = 0; k < polyCount; ++k) polyTmp[k].v[axis] = -polyTmp[k].v[axis];
+      polyCount = clipPolygonToSlabSide(polyTmp, polyCount, poly, axis, limit);
+      if(polyCount < 1) break;
+      for(int k = 0; k < polyCount; ++k) poly[k].v[axis] = -poly[k].v[axis];
+    }
+
+    // Collect penetrating (and barely grazing) points
+    fm_vec3_t candPoints[10];
+    float candSeps[10];
+    int candCount = 0;
+    for(int k = 0; k < polyCount; ++k) {
+      const float sep = fSign * poly[k].v[fi] - hRef[fi]; // <= 0 when penetrating
+      if(sep <= CLIP_KEEP_SEPARATION) {
+        candPoints[candCount] = poly[k];
+        candSeps[candCount] = sep;
+        ++candCount;
+      }
+    }
+
+    // Numerical fallback: SAT reported overlap, so force at least one contact point
+    if(candCount == 0) {
+      if(polyCount > 0) {
+        int minIdx = 0;
+        for(int k = 1; k < polyCount; ++k) {
+          if(poly[k].v[fi] * fSign < poly[minIdx].v[fi] * fSign) minIdx = k;
+        }
+        candPoints[0] = poly[minIdx];
+        candSeps[0] = fSign * poly[minIdx].v[fi] - hRef[fi];
+      } else {
+        // Clipped away entirely (degenerate edge-on case): incident face center
+        // clamped into the reference slab
+        fm_vec3_t p;
+        for(int m = 0; m < 3; ++m) {
+          p.v[m] = relT[m] + relR[m][ji] * (incSign * hInc[ji]);
+        }
+        p.v[u1] = fminf(fmaxf(p.v[u1], -hRef[u1]), hRef[u1]);
+        p.v[u2] = fminf(fmaxf(p.v[u2], -hRef[u2]), hRef[u2]);
+        candPoints[0] = p;
+        candSeps[0] = fSign * p.v[fi] - hRef[fi];
+      }
+      candCount = 1;
+    }
+
+    // Reduce to at most maxKeep well-spread points: deepest point, farthest point from
+    // it, then the extreme points on both sides of that segment (max/min signed area).
+    const int maxKeep = (maxResults < BOX_BOX_MAX_CONTACTS) ? maxResults : BOX_BOX_MAX_CONTACTS;
+    int selected[BOX_BOX_MAX_CONTACTS];
+    int selectedCount = 0;
+
+    if(candCount <= maxKeep) {
+      for(int k = 0; k < candCount; ++k) selected[selectedCount++] = k;
+    } else {
+      int deepest = 0;
+      for(int k = 1; k < candCount; ++k) {
+        if(candSeps[k] < candSeps[deepest]) deepest = k;
+      }
+      selected[selectedCount++] = deepest;
+
+      if(maxKeep > 1) {
+        int farthest = -1;
+        float bestDist2 = -1.0f;
+        for(int k = 0; k < candCount; ++k) {
+          if(k == deepest) continue;
+          const float du = candPoints[k].v[u1] - candPoints[deepest].v[u1];
+          const float dv = candPoints[k].v[u2] - candPoints[deepest].v[u2];
+          const float dist2 = du * du + dv * dv;
+          if(dist2 > bestDist2) {
+            bestDist2 = dist2;
+            farthest = k;
+          }
+        }
+        if(farthest >= 0) selected[selectedCount++] = farthest;
+
+        if(maxKeep > 2 && farthest >= 0) {
+          // signed areas relative to the deepest->farthest segment (in the face plane)
+          const float eu = candPoints[farthest].v[u1] - candPoints[deepest].v[u1];
+          const float ev = candPoints[farthest].v[u2] - candPoints[deepest].v[u2];
+          int maxSide = -1, minSide = -1;
+          float maxArea = 0.0f, minArea = 0.0f;
+          for(int k = 0; k < candCount; ++k) {
+            if(k == deepest || k == farthest) continue;
+            const float pu = candPoints[k].v[u1] - candPoints[deepest].v[u1];
+            const float pv = candPoints[k].v[u2] - candPoints[deepest].v[u2];
+            const float area = eu * pv - ev * pu;
+            if(area > maxArea) { maxArea = area; maxSide = k; }
+            if(area < minArea) { minArea = area; minSide = k; }
+          }
+          if(maxKeep >= 4) {
+            if(maxSide >= 0) selected[selectedCount++] = maxSide;
+            if(minSide >= 0) selected[selectedCount++] = minSide;
+          } else {
+            // room for one more: take the side with the larger spread
+            const int pick = (maxArea >= -minArea) ? maxSide : minSide;
+            if(pick >= 0) selected[selectedCount++] = pick;
+          }
+        }
+      }
+    }
+
+    // --- Emit results in world space, EpaResult convention (normal B -> A) ---
+    const fm_vec3_t refNormalWorld = matrixColumn(ref.rotation, fi) * fSign;
+    const fm_vec3_t worldNormal = faceOfA ? -refNormalWorld : refNormalWorld;
+
+    int resultCount = 0;
+    for(int k = 0; k < selectedCount && resultCount < maxKeep; ++k) {
+      const fm_vec3_t &p = candPoints[selected[k]];
+      const float sep = candSeps[selected[k]];
+
+      // Incident point stays on the incident box surface; the reference-side point
+      // is its projection onto the reference face plane
+      fm_vec3_t pOnFace = p;
+      pOnFace.v[fi] = fSign * hRef[fi];
+
+      const fm_vec3_t worldInc = ref.center + matrix3Vec3Mul(ref.rotation, p);
+      const fm_vec3_t worldRef = ref.center + matrix3Vec3Mul(ref.rotation, pOnFace);
+
+      EpaResult &out = results[resultCount++];
+      out.normal = worldNormal;
+      out.penetration = -sep;
+      if(faceOfA) {
+        out.contactA = worldRef;
+        out.contactB = worldInc;
+      } else {
+        out.contactA = worldInc;
+        out.contactB = worldRef;
+      }
+    }
+
+    return resultCount;
+  }
+
+} // namespace P64::Coll

--- a/n64/engine/src/collision/collide.cpp
+++ b/n64/engine/src/collision/collide.cpp
@@ -4,6 +4,7 @@
  * @brief Functions to detect collisions between different shapes and objects and record them (see collide.h)
  */
 #include "collision/collide.h"
+#include "collision/boxBox.h"
 #include "collision/collisionScene.h"
 #include "collision/contactUtils.h"
 #include "collision/gjk.h"
@@ -1138,6 +1139,177 @@ namespace P64::Coll {
   }
 
 
+  /// @brief Fills a collider-pair contact constraint with the SAT box-box manifold in one pass.
+  /// Counterpart of collideCacheSatContactConstraint for collider pairs: replaces the whole
+  /// manifold each frame while preserving warm-started impulses via proximity matching.
+  /// The caller must pass the pair in canonical cache-key order (see collideDetectBoxBox).
+  static ContactConstraint *collideCacheBoxBoxContactConstraint(
+    RigidBody *rigidBodyA, Collider *colliderA, Object *objectA,
+    RigidBody *rigidBodyB, Collider *colliderB, Object *objectB,
+    const EpaResult *results, int resultCount,
+    float combinedFriction, float combinedBounce,
+    bool respondsA, bool respondsB) {
+
+    if(resultCount <= 0 || !colliderA || !colliderB) return nullptr;
+
+    CollisionScene *scene = collisionSceneGetInstance();
+    const fm_vec3_t normal = makeSafeContactNormal(results[0].normal, results[0].contactA, results[0].contactB);
+
+    ContactConstraintKey key = makeColliderPairConstraintKey(colliderA, colliderB);
+    ContactConstraint *cc = scene->findCachedConstraint(key);
+
+    // Save old points for warm-start matching before we overwrite them
+    ContactPoint oldPoints[MAX_CONTACT_POINTS_PER_PAIR]{};
+    int oldCount = 0;
+    if(cc) {
+      oldCount = cc->pointCount;
+      for(int i = 0; i < oldCount; ++i) oldPoints[i] = cc->points[i];
+    } else {
+      cc = scene->createCachedConstraint(key,
+        rigidBodyA, colliderA, nullptr, objectA,
+        rigidBodyB, colliderB, nullptr, objectB);
+      if(!cc) return nullptr;
+    }
+
+    cc->rigidBodyA = rigidBodyA;
+    cc->colliderA = colliderA;
+    cc->meshColliderA = nullptr;
+    cc->objectA = objectA;
+    cc->rigidBodyB = rigidBodyB;
+    cc->colliderB = colliderB;
+    cc->meshColliderB = nullptr;
+    cc->objectB = objectB;
+    cc->isActive = true;
+    cc->isTrigger = false;
+    cc->normal = normal;
+    vec3CalculateTangents(normal, cc->tangentU, cc->tangentV);
+    cc->combinedFriction = combinedFriction;
+    cc->combinedBounce = combinedBounce;
+    cc->respondsA = respondsA;
+    cc->respondsB = respondsB;
+
+    // The manifold is fresh for the current transforms; recording the versions lets
+    // refreshContacts skip the redundant re-derivation from local anchors this step.
+    cc->transformVersionA = contactTransformVersion(rigidBodyA, colliderA, nullptr);
+    cc->transformVersionB = contactTransformVersion(rigidBodyB, colliderB, nullptr);
+
+    const int newCount = resultCount < MAX_CONTACT_POINTS_PER_PAIR ? resultCount : MAX_CONTACT_POINTS_PER_PAIR;
+    const float MATCH_DIST_SQ = 0.02f;
+    bool oldClaimed[MAX_CONTACT_POINTS_PER_PAIR] = {};
+
+    for(int i = 0; i < newCount; ++i) {
+      const EpaResult &r = results[i];
+      ContactPoint &cp = cc->points[i];
+
+      // Find closest unclaimed old point for warm-start impulse transfer
+      int bestOld = -1;
+      float bestDistSq = MATCH_DIST_SQ;
+      for(int j = 0; j < oldCount; ++j) {
+        if(oldClaimed[j]) continue;
+        fm_vec3_t diff = oldPoints[j].contactA - r.contactA;
+        float distSq = fm_vec3_len2(&diff);
+        if(distSq < bestDistSq) {
+          bestDistSq = distSq;
+          bestOld = j;
+        }
+      }
+
+      if(bestOld >= 0) {
+        oldClaimed[bestOld] = true;
+        cp.accumulatedNormalImpulse = oldPoints[bestOld].accumulatedNormalImpulse;
+        cp.accumulatedTangentImpulseU = oldPoints[bestOld].accumulatedTangentImpulseU;
+        cp.accumulatedTangentImpulseV = oldPoints[bestOld].accumulatedTangentImpulseV;
+      } else {
+        cp.accumulatedNormalImpulse = 0.0f;
+        cp.accumulatedTangentImpulseU = 0.0f;
+        cp.accumulatedTangentImpulseV = 0.0f;
+      }
+
+      cp.contactA = r.contactA;
+      cp.contactB = r.contactB;
+      cp.point = (r.contactA + r.contactB) * 0.5f;
+      cp.penetration = r.penetration;
+      cp.active = true;
+      cp.localPointA = contactLocalPointFromWorldPoint(cp.contactA, rigidBodyA, colliderA, nullptr);
+      cp.localPointB = contactLocalPointFromWorldPoint(cp.contactB, rigidBodyB, colliderB, nullptr);
+    }
+
+    cc->pointCount = newCount;
+    return cc;
+  }
+
+
+  /// @brief Analytical SAT box-box detection with one-shot manifold generation.
+  /// Replaces the GJK+EPA path for box-box pairs: produces the whole contact patch in a
+  /// single call (up to 4 points) instead of one point per frame, which keeps warm
+  /// starting effective and lets stacks settle and sleep.
+  static bool collideDetectBoxBox(
+    Collider *colliderA, RigidBody *rbA, Collider *colliderB, RigidBody *rbB,
+    bool aReadsB, bool bReadsA, bool recordConstraints) {
+
+    CollisionScene *scene = collisionSceneGetInstance();
+
+    // Canonical cache-key order: keeps the SAT A/B roles (and therefore reference-face
+    // selection and normal orientation) stable for a pair across frames regardless of
+    // which collider the broadphase enumerates first.
+    if(shouldSwapColliderPairOrder(colliderA, colliderB)) {
+      std::swap(colliderA, colliderB);
+      std::swap(rbA, rbB);
+      std::swap(aReadsB, bReadsA);
+    }
+
+    const SatObb obbA{colliderA->worldCenter(), colliderA->rotationMatrix(), colliderA->boxShape().halfSize};
+    const SatObb obbB{colliderB->worldCenter(), colliderB->rotationMatrix(), colliderB->boxShape().halfSize};
+
+    // Trigger pairs and probe queries (CCD substeps) only need a boolean overlap answer
+    const bool isTriggerContact = colliderA->isTrigger() || colliderB->isTrigger();
+    if(isTriggerContact || !recordConstraints) {
+      if(analyticalBoxBoxManifold(obbA, obbB, nullptr, 0) == 0) return false;
+
+      if(isTriggerContact) {
+        if(recordConstraints) {
+          EpaResult dummyResult;
+          dummyResult.normal = makeSafeContactNormal(VEC3_ZERO, colliderA->worldCenter(), colliderB->worldCenter());
+          dummyResult.penetration = 0.0f;
+          dummyResult.contactA = colliderA->worldCenter();
+          dummyResult.contactB = colliderB->worldCenter();
+          collideCacheContactConstraint(
+            rbA, colliderA, nullptr, colliderA->ownerObject(),
+            rbB, colliderB, nullptr, colliderB->ownerObject(),
+            dummyResult, 0.0f, 0.0f, true, false, false);
+        }
+        return true;
+      }
+
+      // solid CCD probe: wake sleeping bodies like the GJK+EPA path does
+      if(aReadsB && rbA && rbA->isSleeping()) scene->wakeRigidBodyIsland(rbA);
+      if(bReadsA && rbB && rbB->isSleeping()) scene->wakeRigidBodyIsland(rbB);
+      return true;
+    }
+
+    EpaResult satResults[BOX_BOX_MAX_CONTACTS];
+    constexpr int maxPoints = BOX_BOX_MAX_CONTACTS < MAX_CONTACT_POINTS_PER_PAIR
+                                ? BOX_BOX_MAX_CONTACTS : MAX_CONTACT_POINTS_PER_PAIR;
+    const int satCount = analyticalBoxBoxManifold(obbA, obbB, satResults, maxPoints);
+    if(satCount <= 0) return false;
+
+    if(aReadsB && rbA && rbA->isSleeping()) scene->wakeRigidBodyIsland(rbA);
+    if(bReadsA && rbB && rbB->isSleeping()) scene->wakeRigidBodyIsland(rbB);
+
+    const float combinedFriction = fminf(colliderA->friction(), colliderB->friction());
+    const float combinedBounce = fmaxf(colliderA->bounce(), colliderB->bounce());
+
+    collideCacheBoxBoxContactConstraint(
+      rbA, colliderA, colliderA->ownerObject(),
+      rbB, colliderB, colliderB->ownerObject(),
+      satResults, satCount,
+      combinedFriction, combinedBounce,
+      aReadsB, bReadsA);
+
+    return true;
+  }
+
+
   /// @brief Performs a collision test between a collider and a single Mesh triangle. Used as a subroutine for object-to-mesh collision detection.
   ///
   /// Hint: This function is designed to be called with the collider already transformed into the mesh's local space.
@@ -1368,6 +1540,11 @@ namespace P64::Coll {
       if(colliderA->isTrigger() && colliderB->isTrigger()) return false;
     }
 
+    // Box-Box: analytical SAT with one-shot manifold generation (handles triggers and probes too)
+    if(colliderA->shapeType() == ShapeType::Box && colliderB->shapeType() == ShapeType::Box) {
+      return collideDetectBoxBox(colliderA, rbA, colliderB, rbB, aReadsB, bReadsA, recordConstraints);
+    }
+
     // Try analytical closed-form tests first before falling back to GJK+EPA for general convex shapes.
     
     EpaResult result;
@@ -1412,8 +1589,6 @@ namespace P64::Coll {
       hasAnalyticalPath = true;
       analyticalHit = analyticalCapsuleCapsule(colliderA, colliderB, result);
     }
-
-    // TODO: Implement Box-Box with SAT?
 
     // If an analytical test exists for the pair but reports no collision, we can skip GJK+EPA entirely.
     if(hasAnalyticalPath && !analyticalHit) return false;

--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -1156,7 +1156,8 @@ namespace P64::Coll {
       const float invMassA = cc.respondsA ? constrainedLinearInvMassAlong(a, cc.normal) : 0.0f;
       const float invMassB = cc.respondsB ? constrainedLinearInvMassAlong(b, cc.normal) : 0.0f;
       const float totalInvMass = invMassA + invMassB;
-      if(totalInvMass < FM_EPSILON) continue; // neither side can respond
+      // constraint only drops out when neither side has a linear nor an angular way to respond
+      if(totalInvMass < FM_EPSILON && !aCanRotate && !bCanRotate) continue;
 
       // Tangent effective masses for friction
       const float linearU = (cc.respondsA ? constrainedLinearInvMassAlong(a, cc.tangentU) : 0.0f) +
@@ -1204,34 +1205,41 @@ namespace P64::Coll {
         cp.aToContact = a ? cp.contactA - a->worldCenterOfMass() : VEC3_ZERO;
         cp.bToContact = b ? cp.contactB - b->worldCenterOfMass() : VEC3_ZERO;
 
-        solverPoints_.push_back(SolverContactPoint{});
-        solverFrictionPoints_.push_back(SolverFrictionPoint{});
-        SolverContactPoint &sp = solverPoints_.back();
-        SolverFrictionPoint &fp = solverFrictionPoints_.back();
-        fp.source = &cp;
-
         // Normal effective mass: 1 / (invMassA + invMassB + (rA×n)·I_A^-1·(rA×n) + ...)
         fm_vec3_t raCrossN;
         fm_vec3_cross(&raCrossN, &cp.aToContact, &cc.normal);
         fm_vec3_t rbCrossN;
         fm_vec3_cross(&rbCrossN, &cp.bToContact, &cc.normal);
 
+        fm_vec3_t angularResponseA = VEC3_ZERO;
+        fm_vec3_t angularResponseB = VEC3_ZERO;
         float angularA = 0.0f;
         if(aCanRotate) {
-          sp.angularResponseA = a->applyConstrainedWorldInertia(raCrossN);
-          angularA = fm_vec3_dot(&raCrossN, &sp.angularResponseA);
+          angularResponseA = a->applyConstrainedWorldInertia(raCrossN);
+          angularA = fm_vec3_dot(&raCrossN, &angularResponseA);
         }
         float angularB = 0.0f;
         if(bCanRotate) {
           fm_vec3_t inertia = b->applyConstrainedWorldInertia(rbCrossN);
           angularB = fm_vec3_dot(&rbCrossN, &inertia);
-          sp.angularResponseB = -inertia;
+          angularResponseB = -inertia;
         }
+
+        // Skip points nothing can respond to
+        const float denomN = totalInvMass + angularA + angularB;
+        if(denomN < FM_EPSILON) continue;
+
+        solverPoints_.push_back(SolverContactPoint{});
+        solverFrictionPoints_.push_back(SolverFrictionPoint{});
+        SolverContactPoint &sp = solverPoints_.back();
+        SolverFrictionPoint &fp = solverFrictionPoints_.back();
+        fp.source = &cp;
+
+        sp.angularResponseA = angularResponseA;
+        sp.angularResponseB = angularResponseB;
         if(aHasMotionAngular) sp.angularMeasureA = raCrossN;
         if(bHasMotionAngular) sp.angularMeasureB = rbCrossN;
 
-        float denomN = totalInvMass + angularA + angularB;
-        if(denomN < FM_EPSILON) denomN = FM_EPSILON;
         sp.normalMass = 1.0f / denomN;
         sp.accumulatedImpulse = cp.accumulatedNormalImpulse;
 
@@ -1316,6 +1324,12 @@ namespace P64::Coll {
       }
 
       h.pointCount = static_cast<uint16_t>(solverPoints_.size() - h.pointStart);
+      if(h.pointCount == 0) {
+        // every point was skipped, drop the constraint again
+        solverHeaders_.pop_back();
+        solverFrictionHeaders_.pop_back();
+        continue;
+      }
       solverOrder_.push_back(headerIndex);
     }
   }

--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -28,20 +28,6 @@ namespace P64::Coll {
     return body && body->canApplyAngularResponse();
   }
 
-  static fm_vec3_t constrainLinearWorld(const RigidBody *body, const fm_vec3_t &worldLinear) {
-    return body ? body->constrainLinearWorld(worldLinear) : worldLinear;
-  }
-
-  static void applyConstrainedLinearVelocityDelta(RigidBody *body, const fm_vec3_t &deltaLinearVelocity) {
-    if(!body) return;
-    body->applyConstrainedLinearVelocityDelta(deltaLinearVelocity);
-  }
-
-  static void applyConstrainedImpulseAtContact(RigidBody *body, const fm_vec3_t &impulse, const fm_vec3_t &toContact) {
-    if(!body) return;
-    body->applyConstrainedImpulseAtContact(impulse, toContact);
-  }
-
   static float constrainedLinearInvMassAlong(const RigidBody *body, const fm_vec3_t &direction) {
     return body ? body->constrainedLinearInvMassAlong(direction) : 0.0f;
   }
@@ -189,6 +175,12 @@ namespace P64::Coll {
     cachedConstraints_.clear();
     cachedConstraintLookup_.clear();
     solverConstraints_.clear();
+    solverBodies_.clear();
+    solverHeaders_.clear();
+    solverPoints_.clear();
+    solverFrictionHeaders_.clear();
+    solverFrictionPoints_.clear();
+    solverOrder_.clear();
     ticksWakePrep = 0;
     ticksWorldUpdate = 0;
     ticksIntegrateVel = 0;
@@ -1108,11 +1100,46 @@ namespace P64::Coll {
     removeInactiveContacts();
   }
 
-  // ── Pre-solve ─────────────────────────────────────────────────────
+  // ── Pre-solve: build dense solver data ────────────────────────
+
+  /// @brief Acquires an index for the given rigid body in the solver's body array
+  /// @param body 
+  /// @return index of the body in the solverBodies_ array, or 0 for a static sentinel body
+  uint16_t CollisionScene::acquireSolverBodyIndex(RigidBody *body) {
+    if(!body) return 0; // sentinel static body
+    if(body->solverIndex_ >= 0) return static_cast<uint16_t>(body->solverIndex_);
+
+    body->solverIndex_ = static_cast<int16_t>(solverBodies_.size());
+    solverBodies_.push_back(SolverBody{});
+    SolverBody &sb = solverBodies_.back();
+    sb.body = body;
+    sb.linearVelocity = body->linearVelocity_;
+    sb.angularVelocity = body->angularVelocity_;
+    return static_cast<uint16_t>(body->solverIndex_);
+  }
 
   void CollisionScene::preSolveContacts() {
     const float restitutionSlop = 0.5f;
     const float invFixedDt = (fixedDt_ > 0.0f) ? 1.0f / fixedDt_ : 0.0f;
+    
+    // Position correction settings
+    const float positionSlop = 0.005f; // leave a small slop (in meters) that objects can penetrate before correction is applied
+    const float positionSteering = 0.8f; // push out this fraction of the rest of penetration each step
+    const float maxPositionCorrection = 0.2f; // cap per step (in meters)
+
+    solverBodies_.clear();
+    solverHeaders_.clear();
+    solverPoints_.clear();
+    solverFrictionHeaders_.clear();
+    solverFrictionPoints_.clear();
+    solverOrder_.clear();
+
+    solverBodies_.push_back(SolverBody{}); // index 0: always immovable sentinel
+
+    // Reset solver indices on all bodies
+    for(RigidBody *body : rigidBodies_) {
+      if(body) body->solverIndex_ = -1; 
+    }
 
     for(ContactConstraint *constraint : solverConstraints_) {
       ContactConstraint &cc = *constraint;
@@ -1123,23 +1150,65 @@ namespace P64::Coll {
       const bool bHasMotionAngular = canApplyAngularResponse(b);
       const bool aCanRotate = cc.respondsA && aHasMotionAngular;
       const bool bCanRotate = cc.respondsB && bHasMotionAngular;
+      const bool aRespondsLinear = cc.respondsA && a && a->isEnabled_ && !a->isKinematic_;
+      const bool bRespondsLinear = cc.respondsB && b && b->isEnabled_ && !b->isKinematic_;
 
-      float invMassA = cc.respondsA ? constrainedLinearInvMassAlong(a, cc.normal) : 0.0f;
-      float invMassB = cc.respondsB ? constrainedLinearInvMassAlong(b, cc.normal) : 0.0f;
-      float totalInvMass = invMassA + invMassB;
+      const float invMassA = cc.respondsA ? constrainedLinearInvMassAlong(a, cc.normal) : 0.0f;
+      const float invMassB = cc.respondsB ? constrainedLinearInvMassAlong(b, cc.normal) : 0.0f;
+      const float totalInvMass = invMassA + invMassB;
+      if(totalInvMass < FM_EPSILON) continue; // neither side can respond
+
+      // Tangent effective masses for friction
       const float linearU = (cc.respondsA ? constrainedLinearInvMassAlong(a, cc.tangentU) : 0.0f) +
                 (cc.respondsB ? constrainedLinearInvMassAlong(b, cc.tangentU) : 0.0f);
       const float linearV = (cc.respondsA ? constrainedLinearInvMassAlong(a, cc.tangentV) : 0.0f) +
                 (cc.respondsB ? constrainedLinearInvMassAlong(b, cc.tangentV) : 0.0f);
-      if(totalInvMass < FM_EPSILON) continue;
 
+      const uint16_t headerIndex = static_cast<uint16_t>(solverHeaders_.size());
+      solverHeaders_.push_back(SolverConstraintHeader{});
+      solverFrictionHeaders_.push_back(SolverFrictionHeader{});
+      SolverConstraintHeader &h = solverHeaders_[headerIndex];
+      SolverFrictionHeader &fh = solverFrictionHeaders_[headerIndex];
+
+      h.normal = cc.normal;
+      h.bodyA = acquireSolverBodyIndex(a);
+      h.bodyB = acquireSolverBodyIndex(b);
+      h.pointStart = static_cast<uint16_t>(solverPoints_.size());
+
+      // Linear response per unit impulse, already constrained and respecting B's sign
+      if(aRespondsLinear) h.linearResponseA = a->constrainLinearWorld(cc.normal * a->inverseMass_);
+      if(bRespondsLinear) h.linearResponseB = b->constrainLinearWorld(cc.normal * -b->inverseMass_);
+
+      // Building friction header
+      fh.tangentU = cc.tangentU;
+      fh.tangentV = cc.tangentV;
+      fh.friction = cc.combinedFriction;
+      // Friction measures only enabled, non-kinematic bodies
+      fh.linearMeasureScaleA = (a && a->isEnabled_ && !a->isKinematic_) ? 1.0f : 0.0f;
+      fh.linearMeasureScaleB = (b && b->isEnabled_ && !b->isKinematic_) ? 1.0f : 0.0f;
+      if(aRespondsLinear) {
+        fh.linearResponseUA = a->constrainLinearWorld(cc.tangentU * a->inverseMass_);
+        fh.linearResponseVA = a->constrainLinearWorld(cc.tangentV * a->inverseMass_);
+      }
+      if(bRespondsLinear) {
+        fh.linearResponseUB = b->constrainLinearWorld(cc.tangentU * -b->inverseMass_);
+        fh.linearResponseVB = b->constrainLinearWorld(cc.tangentV * -b->inverseMass_);
+      }
+
+      // Precompute solver points for each contact point in the constraint
       for(int j = 0; j < cc.pointCount; ++j) {
         ContactPoint &cp = cc.points[j];
         if(!cp.active) continue;
 
-        // Relative vectors from centers of mass
+        // Relative vectors from centers of mass (also consumed by collision events)
         cp.aToContact = a ? cp.contactA - a->worldCenterOfMass() : VEC3_ZERO;
         cp.bToContact = b ? cp.contactB - b->worldCenterOfMass() : VEC3_ZERO;
+
+        solverPoints_.push_back(SolverContactPoint{});
+        solverFrictionPoints_.push_back(SolverFrictionPoint{});
+        SolverContactPoint &sp = solverPoints_.back();
+        SolverFrictionPoint &fp = solverFrictionPoints_.back();
+        fp.source = &cp;
 
         // Normal effective mass: 1 / (invMassA + invMassB + (rA×n)·I_A^-1·(rA×n) + ...)
         fm_vec3_t raCrossN;
@@ -1149,19 +1218,22 @@ namespace P64::Coll {
 
         float angularA = 0.0f;
         if(aCanRotate) {
-          fm_vec3_t inertia = a->applyConstrainedWorldInertia(raCrossN);
-          angularA = fm_vec3_dot(&raCrossN, &inertia);
+          sp.angularResponseA = a->applyConstrainedWorldInertia(raCrossN);
+          angularA = fm_vec3_dot(&raCrossN, &sp.angularResponseA);
         }
-
         float angularB = 0.0f;
         if(bCanRotate) {
           fm_vec3_t inertia = b->applyConstrainedWorldInertia(rbCrossN);
           angularB = fm_vec3_dot(&rbCrossN, &inertia);
+          sp.angularResponseB = -inertia;
         }
+        if(aHasMotionAngular) sp.angularMeasureA = raCrossN;
+        if(bHasMotionAngular) sp.angularMeasureB = rbCrossN;
 
         float denomN = totalInvMass + angularA + angularB;
         if(denomN < FM_EPSILON) denomN = FM_EPSILON;
-        cp.normalMass = 1.0f / denomN;
+        sp.normalMass = 1.0f / denomN;
+        sp.accumulatedImpulse = cp.accumulatedNormalImpulse;
 
         // Tangent effective masses
         {
@@ -1171,17 +1243,20 @@ namespace P64::Coll {
           fm_vec3_cross(&rbCrossU, &cp.bToContact, &cc.tangentU);
           float angU_A = 0.0f;
           if(aCanRotate) {
-            fm_vec3_t inertia = a->applyConstrainedWorldInertia(raCrossU);
-            angU_A = fm_vec3_dot(&raCrossU, &inertia);
+            fp.angularResponseUA = a->applyConstrainedWorldInertia(raCrossU);
+            angU_A = fm_vec3_dot(&raCrossU, &fp.angularResponseUA);
           }
           float angU_B = 0.0f;
           if(bCanRotate) {
             fm_vec3_t inertia = b->applyConstrainedWorldInertia(rbCrossU);
             angU_B = fm_vec3_dot(&rbCrossU, &inertia);
+            fp.angularResponseUB = -inertia;
           }
+          if(fh.linearMeasureScaleA > 0.0f && aHasMotionAngular) fp.angularMeasureUA = raCrossU;
+          if(fh.linearMeasureScaleB > 0.0f && bHasMotionAngular) fp.angularMeasureUB = rbCrossU;
           float denomU = linearU + angU_A + angU_B;
           if(denomU < FM_EPSILON) denomU = FM_EPSILON;
-          cp.tangentMassU = 1.0f / denomU;
+          fp.tangentMassU = 1.0f / denomU;
         }
         {
           fm_vec3_t raCrossV;
@@ -1190,23 +1265,26 @@ namespace P64::Coll {
           fm_vec3_cross(&rbCrossV, &cp.bToContact, &cc.tangentV);
           float angV_A = 0.0f;
           if(aCanRotate) {
-            fm_vec3_t inertia = a->applyConstrainedWorldInertia(raCrossV);
-            angV_A = fm_vec3_dot(&raCrossV, &inertia);
+            fp.angularResponseVA = a->applyConstrainedWorldInertia(raCrossV);
+            angV_A = fm_vec3_dot(&raCrossV, &fp.angularResponseVA);
           }
           float angV_B = 0.0f;
           if(bCanRotate) {
             fm_vec3_t inertia = b->applyConstrainedWorldInertia(rbCrossV);
             angV_B = fm_vec3_dot(&rbCrossV, &inertia);
+            fp.angularResponseVB = -inertia;
           }
+          if(fh.linearMeasureScaleA > 0.0f && aHasMotionAngular) fp.angularMeasureVA = raCrossV;
+          if(fh.linearMeasureScaleB > 0.0f && bHasMotionAngular) fp.angularMeasureVB = rbCrossV;
           float denomV = linearV + angV_A + angV_B;
           if(denomV < FM_EPSILON) denomV = FM_EPSILON;
-          cp.tangentMassV = 1.0f / denomV;
+          fp.tangentMassV = 1.0f / denomV;
         }
-
-        // Velocity bias (restitution only; Baumgarte is handled in position solver)
-        cp.velocityBias = 0.0f;
+        fp.accumulatedImpulseU = cp.accumulatedTangentImpulseU;
+        fp.accumulatedImpulseV = cp.accumulatedTangentImpulseV;
 
         // Restitution bias
+        sp.velocityBias = 0.0f;
         fm_vec3_t relVel = VEC3_ZERO;
         if(a) {
           fm_vec3_t aCross;
@@ -1218,17 +1296,27 @@ namespace P64::Coll {
           fm_vec3_cross(&bCross, &b->angularVelocity_, &cp.bToContact);
           relVel -= (b->linearVelocity_ + bCross);
         }
-        float relVelN = fm_vec3_dot(&relVel, &cc.normal);
+        const float relVelN = fm_vec3_dot(&relVel, &cc.normal);
         if(relVelN < -restitutionSlop) {
-          cp.velocityBias += cc.combinedBounce * relVelN;
+          sp.velocityBias += cc.combinedBounce * relVelN;
         }
 
         // Speculative contact: a separated manifold point may approach at up to
-        // gap/dt, this keeps grazing corners of a resting manifold active
+        // gap/dt before normal impulses fire. This keeps grazing corners of a
+        // resting manifold active (stable warm starting) without blocking bodies
+        // from settling into full contact.
         if(cp.penetration < 0.0f) {
-          cp.velocityBias += -cp.penetration * invFixedDt;
+          sp.velocityBias += -cp.penetration * invFixedDt;
+        }
+
+        // Split impulse target: correct most of the remaining penetration this step
+        if(cp.penetration > positionSlop) {
+          sp.positionBias = fminf(positionSteering * (cp.penetration - positionSlop), maxPositionCorrection);
         }
       }
+
+      h.pointCount = static_cast<uint16_t>(solverPoints_.size() - h.pointStart);
+      solverOrder_.push_back(headerIndex);
     }
   }
 
@@ -1242,40 +1330,47 @@ namespace P64::Coll {
     // impulses each frame
     constexpr float IMPULSE_ZERO_THRESHOLD = FM_EPSILON;
 
-    for(ContactConstraint *constraint : solverConstraints_) {
-      ContactConstraint &cc = *constraint;
+    for(std::size_t c = 0; c < solverHeaders_.size(); ++c) {
+      const SolverConstraintHeader &h = solverHeaders_[c];
+      const SolverFrictionHeader &fh = solverFrictionHeaders_[c];
+      SolverBody &bodyA = solverBodies_[h.bodyA];
+      SolverBody &bodyB = solverBodies_[h.bodyB];
 
-      RigidBody *a = cc.rigidBodyA;
-      RigidBody *b = cc.rigidBodyB;
-
-      for(int j = 0; j < cc.pointCount; ++j) {
-        ContactPoint &cp = cc.points[j];
-        if(!cp.active) continue;
+      const uint16_t end = h.pointStart + h.pointCount;
+      for(uint16_t k = h.pointStart; k < end; ++k) {
+        SolverContactPoint &sp = solverPoints_[k];
+        SolverFrictionPoint &fp = solverFrictionPoints_[k];
 
         // Scale accumulated impulses by warm starting factor (Bullet's m_warmstartingFactor = 0.85)
         // This prevents overcorrection when constraint configuration changes between frames
-        cp.accumulatedNormalImpulse *= WARM_STARTING_FACTOR;
-        cp.accumulatedTangentImpulseU *= WARM_STARTING_FACTOR;
-        cp.accumulatedTangentImpulseV *= WARM_STARTING_FACTOR;
+        sp.accumulatedImpulse *= WARM_STARTING_FACTOR;
+        fp.accumulatedImpulseU *= WARM_STARTING_FACTOR;
+        fp.accumulatedImpulseV *= WARM_STARTING_FACTOR;
 
         // Zero out decayed impulses to prevent persistent micro-impulses that can cause jitter and prevent sleeping
-        if(fabsf(cp.accumulatedNormalImpulse) < IMPULSE_ZERO_THRESHOLD) cp.accumulatedNormalImpulse = 0.0f;
-        if(fabsf(cp.accumulatedTangentImpulseU) < IMPULSE_ZERO_THRESHOLD) cp.accumulatedTangentImpulseU = 0.0f;
-        if(fabsf(cp.accumulatedTangentImpulseV) < IMPULSE_ZERO_THRESHOLD) cp.accumulatedTangentImpulseV = 0.0f;
+        if(fabsf(sp.accumulatedImpulse) < IMPULSE_ZERO_THRESHOLD) sp.accumulatedImpulse = 0.0f;
+        if(fabsf(fp.accumulatedImpulseU) < IMPULSE_ZERO_THRESHOLD) fp.accumulatedImpulseU = 0.0f;
+        if(fabsf(fp.accumulatedImpulseV) < IMPULSE_ZERO_THRESHOLD) fp.accumulatedImpulseV = 0.0f;
 
-        fm_vec3_t impulse = cc.normal * cp.accumulatedNormalImpulse;
-        impulse += cc.tangentU * cp.accumulatedTangentImpulseU;
-        impulse += cc.tangentV * cp.accumulatedTangentImpulseV;
-
-        if(cc.respondsA) applyConstrainedImpulseAtContact(a, impulse, cp.aToContact);
-        if(cc.respondsB) applyConstrainedImpulseAtContact(b, -impulse, cp.bToContact);
+        bodyA.linearVelocity += h.linearResponseA * sp.accumulatedImpulse
+                              + fh.linearResponseUA * fp.accumulatedImpulseU
+                              + fh.linearResponseVA * fp.accumulatedImpulseV;
+        bodyA.angularVelocity += sp.angularResponseA * sp.accumulatedImpulse
+                               + fp.angularResponseUA * fp.accumulatedImpulseU
+                               + fp.angularResponseVA * fp.accumulatedImpulseV;
+        bodyB.linearVelocity += h.linearResponseB * sp.accumulatedImpulse
+                              + fh.linearResponseUB * fp.accumulatedImpulseU
+                              + fh.linearResponseVB * fp.accumulatedImpulseV;
+        bodyB.angularVelocity += sp.angularResponseB * sp.accumulatedImpulse
+                               + fp.angularResponseUB * fp.accumulatedImpulseU
+                               + fp.angularResponseVB * fp.accumulatedImpulseV;
       }
     }
   }
 
   // ── Velocity constraint solver ────────────────────────────────────
 
-  /// Fast xorshift32 PRNG for constraint randomization (Bullet's SOLVER_RANDMIZE_ORDER).
+  /// Fast xor shift pseudo RNG for constraint randomization
   static uint32_t s_solverRngState = 0x12345678u;
   static uint32_t solverRand() {
     uint32_t x = s_solverRngState;
@@ -1287,251 +1382,194 @@ namespace P64::Coll {
   }
 
   void CollisionScene::solveVelocityConstraints() {
-    const auto constraintCount = solverConstraints_.size();
+    const std::size_t constraintCount = solverOrder_.size();
     if(constraintCount == 0) return;
 
     constexpr float VELOCITY_SOLVER_EARLY_OUT_THRESHOLD = 1e-4f;
-    constexpr float VELOCITY_SOLVER_NORMAL_ERROR_THRESHOLD_PER_SCALE = 1e-3f;
-    constexpr uint8_t MIN_NORMAL_SOLVER_ITERATIONS = 6;
-    const float velocitySolverNormalErrorThreshold = VELOCITY_SOLVER_NORMAL_ERROR_THRESHOLD_PER_SCALE;
+    constexpr float VELOCITY_SOLVER_NORMAL_ERROR_THRESHOLD = 1e-3f;
+    constexpr uint8_t MIN_NORMAL_SOLVER_ITERATIONS = 4;
 
-    const auto solveFrictionPass = [&]() {
-      for(ContactConstraint *constraint : solverConstraints_) {
-        ContactConstraint &cc = *constraint;
-
-        if(cc.combinedFriction <= FM_EPSILON) continue;
-
-        RigidBody *a = cc.rigidBodyA;
-        RigidBody *b = cc.rigidBodyB;
-        const bool aHasMotionAngular = canApplyAngularResponse(a);
-        const bool bHasMotionAngular = canApplyAngularResponse(b);
-
-        for(int j = 0; j < cc.pointCount; ++j) {
-          ContactPoint &cp = cc.points[j];
-          if(!cp.active) continue;
-
-          fm_vec3_t contactVelA = VEC3_ZERO;
-          fm_vec3_t contactVelB = VEC3_ZERO;
-          if(a && a->isEnabled_ && !a->isKinematic_) {
-            contactVelA = a->linearVelocity_;
-            if(aHasMotionAngular) {
-              fm_vec3_t aCross;
-              fm_vec3_cross(&aCross, &a->angularVelocity_, &cp.aToContact);
-              contactVelA += aCross;
-            }
-          }
-          if(b && b->isEnabled_ && !b->isKinematic_) {
-            contactVelB = b->linearVelocity_;
-            if(bHasMotionAngular) {
-              fm_vec3_t bCross;
-              fm_vec3_cross(&bCross, &b->angularVelocity_, &cp.bToContact);
-              contactVelB += bCross;
-            }
-          }
-
-          fm_vec3_t relVel = contactVelA - contactVelB;
-          float vTangentU = fm_vec3_dot(&relVel, &cc.tangentU);
-          float vTangentV = fm_vec3_dot(&relVel, &cc.tangentV);
-
-          float lambdaU = -vTangentU * cp.tangentMassU;
-          float lambdaV = -vTangentV * cp.tangentMassV;
-
-          float newAccumU = cp.accumulatedTangentImpulseU + lambdaU;
-          float newAccumV = cp.accumulatedTangentImpulseV + lambdaV;
-
-          float maxFriction = cc.combinedFriction * cp.accumulatedNormalImpulse;
-          float tangentMagnitude = sqrtf(newAccumU * newAccumU + newAccumV * newAccumV);
-          if(tangentMagnitude > maxFriction && tangentMagnitude > FM_EPSILON) {
-            float scale = maxFriction / tangentMagnitude;
-            newAccumU *= scale;
-            newAccumV *= scale;
-          }
-
-          lambdaU = newAccumU - cp.accumulatedTangentImpulseU;
-          lambdaV = newAccumV - cp.accumulatedTangentImpulseV;
-
-          cp.accumulatedTangentImpulseU = newAccumU;
-          cp.accumulatedTangentImpulseV = newAccumV;
-
-          fm_vec3_t tangentImpulse = cc.tangentU * lambdaU + cc.tangentV * lambdaV;
-          if(fm_vec3_len2(&tangentImpulse) <= FM_EPSILON * FM_EPSILON) continue;
-
-          if(cc.respondsA) applyConstrainedImpulseAtContact(a, tangentImpulse, cp.aToContact);
-          if(cc.respondsB) applyConstrainedImpulseAtContact(b, -tangentImpulse, cp.bToContact);
-        }
-      }
-    };
+    // Shuffle constraint processing order once per step (Bullet's SOLVER_RANDMIZE_ORDER):
+    // prevents bias where one constraint always "wins" in Gauss-Seidel iteration.
+    for(std::size_t i = constraintCount; i > 1; --i) {
+      const std::size_t j = static_cast<std::size_t>((static_cast<uint64_t>(solverRand()) * i) >> 32);
+      std::swap(solverOrder_[i - 1], solverOrder_[j]);
+    }
 
     for(uint8_t iter = 0; iter < velocitySolverIterations_; ++iter) {
       float maxNormalImpulseDelta = 0.0f;
       float maxNormalError = 0.0f;
 
-      // Shuffle constraint processing order each iteration (Bullet's SOLVER_RANDMIZE_ORDER)
-      // Prevents systematic bias where one constraint always "wins" in Gauss-Seidel iteration
-      for(std::size_t i = constraintCount; i > 1; --i) {
-        std::size_t j = solverRand() % i;
-        std::swap(solverConstraints_[i - 1], solverConstraints_[j]);
-      }
+      for(uint16_t orderIdx : solverOrder_) {
+        const SolverConstraintHeader &h = solverHeaders_[orderIdx];
+        SolverBody &bodyA = solverBodies_[h.bodyA];
+        SolverBody &bodyB = solverBodies_[h.bodyB];
 
-      for(ContactConstraint *constraint : solverConstraints_) {
-        ContactConstraint &cc = *constraint;
+        const uint16_t end = h.pointStart + h.pointCount;
+        for(uint16_t k = h.pointStart; k < end; ++k) {
+          SolverContactPoint &sp = solverPoints_[k];
 
-        RigidBody *a = cc.rigidBodyA;
-        RigidBody *b = cc.rigidBodyB;
-        const bool aHasMotionAngular = canApplyAngularResponse(a);
-        const bool bHasMotionAngular = canApplyAngularResponse(b);
+          // Relative normal velocity via precomputed r×n vectors
+          const fm_vec3_t dv = bodyA.linearVelocity - bodyB.linearVelocity;
+          const float relVelN = fm_vec3_dot(&dv, &h.normal)
+                              + fm_vec3_dot(&bodyA.angularVelocity, &sp.angularMeasureA)
+                              - fm_vec3_dot(&bodyB.angularVelocity, &sp.angularMeasureB);
 
-        for(int j = 0; j < cc.pointCount; ++j) {
-          ContactPoint &cp = cc.points[j];
-          if(!cp.active) continue;
+          maxNormalError = fmaxf(maxNormalError, fmaxf(-(relVelN + sp.velocityBias), 0.0f));
 
-          // Compute relative velocity at contact.
-          fm_vec3_t relVel = VEC3_ZERO;
-          if(a) {
-            relVel = a->linearVelocity_;
-            if(aHasMotionAngular) {
-              fm_vec3_t aCross;
-              fm_vec3_cross(&aCross, &a->angularVelocity_, &cp.aToContact);
-              relVel += aCross;
-            }
-          }
-          if(b) {
-            fm_vec3_t velB = b->linearVelocity_;
-            if(bHasMotionAngular) {
-              fm_vec3_t bCross;
-              fm_vec3_cross(&bCross, &b->angularVelocity_, &cp.bToContact);
-              velB += bCross;
-            }
-            relVel -= velB;
-          }
-
-          const float relVelN = fm_vec3_dot(&relVel, &cc.normal);
-          maxNormalError = fmaxf(maxNormalError, fmaxf(-(relVelN + cp.velocityBias), 0.0f));
-
-          float dImpulseN = cp.normalMass * (-(relVelN + cp.velocityBias));
+          float dImpulseN = sp.normalMass * (-(relVelN + sp.velocityBias));
 
           // Clamp accumulated impulse (normal must be non-negative).
-          const float oldAccum = cp.accumulatedNormalImpulse;
-          cp.accumulatedNormalImpulse = fmaxf(oldAccum + dImpulseN, 0.0f);
-          dImpulseN = cp.accumulatedNormalImpulse - oldAccum;
+          const float oldAccum = sp.accumulatedImpulse;
+          sp.accumulatedImpulse = fmaxf(oldAccum + dImpulseN, 0.0f);
+          dImpulseN = sp.accumulatedImpulse - oldAccum;
           maxNormalImpulseDelta = fmaxf(maxNormalImpulseDelta, fabsf(dImpulseN));
 
-          const fm_vec3_t impulseN = cc.normal * dImpulseN;
           if(fabsf(dImpulseN) > FM_EPSILON) {
-            if(cc.respondsA) applyConstrainedImpulseAtContact(a, impulseN, cp.aToContact);
-            if(cc.respondsB) applyConstrainedImpulseAtContact(b, -impulseN, cp.bToContact);
+            bodyA.linearVelocity += h.linearResponseA * dImpulseN;
+            bodyA.angularVelocity += sp.angularResponseA * dImpulseN;
+            bodyB.linearVelocity += h.linearResponseB * dImpulseN;
+            bodyB.angularVelocity += sp.angularResponseB * dImpulseN;
           }
         }
       }
 
       if(iter + 1 >= MIN_NORMAL_SOLVER_ITERATIONS &&
          maxNormalImpulseDelta < VELOCITY_SOLVER_EARLY_OUT_THRESHOLD &&
-        maxNormalError < velocitySolverNormalErrorThreshold) {
+         maxNormalError < VELOCITY_SOLVER_NORMAL_ERROR_THRESHOLD) {
         break;
       }
     }
 
-    solveFrictionPass();
+    // Friction: single pass after the normal impulses have converged
+    for(uint16_t orderIdx : solverOrder_) {
+      const SolverConstraintHeader &h = solverHeaders_[orderIdx];
+      const SolverFrictionHeader &fh = solverFrictionHeaders_[orderIdx];
+      if(fh.friction <= FM_EPSILON) continue;
+
+      SolverBody &bodyA = solverBodies_[h.bodyA];
+      SolverBody &bodyB = solverBodies_[h.bodyB];
+
+      const uint16_t end = h.pointStart + h.pointCount;
+      for(uint16_t k = h.pointStart; k < end; ++k) {
+        SolverContactPoint &sp = solverPoints_[k];
+        SolverFrictionPoint &fp = solverFrictionPoints_[k];
+
+        const float vTangentU =
+            fh.linearMeasureScaleA * fm_vec3_dot(&bodyA.linearVelocity, &fh.tangentU)
+          - fh.linearMeasureScaleB * fm_vec3_dot(&bodyB.linearVelocity, &fh.tangentU)
+          + fm_vec3_dot(&bodyA.angularVelocity, &fp.angularMeasureUA)
+          - fm_vec3_dot(&bodyB.angularVelocity, &fp.angularMeasureUB);
+        const float vTangentV =
+            fh.linearMeasureScaleA * fm_vec3_dot(&bodyA.linearVelocity, &fh.tangentV)
+          - fh.linearMeasureScaleB * fm_vec3_dot(&bodyB.linearVelocity, &fh.tangentV)
+          + fm_vec3_dot(&bodyA.angularVelocity, &fp.angularMeasureVA)
+          - fm_vec3_dot(&bodyB.angularVelocity, &fp.angularMeasureVB);
+
+        float lambdaU = -vTangentU * fp.tangentMassU;
+        float lambdaV = -vTangentV * fp.tangentMassV;
+
+        float newAccumU = fp.accumulatedImpulseU + lambdaU;
+        float newAccumV = fp.accumulatedImpulseV + lambdaV;
+
+        // Clamp to the friction cone (tangentU ⊥ tangentV, both unit length)
+        const float maxFriction = fh.friction * sp.accumulatedImpulse;
+        const float tangentMagnitude = sqrtf(newAccumU * newAccumU + newAccumV * newAccumV);
+        if(tangentMagnitude > maxFriction && tangentMagnitude > FM_EPSILON) {
+          const float scale = maxFriction / tangentMagnitude;
+          newAccumU *= scale;
+          newAccumV *= scale;
+        }
+
+        lambdaU = newAccumU - fp.accumulatedImpulseU;
+        lambdaV = newAccumV - fp.accumulatedImpulseV;
+        fp.accumulatedImpulseU = newAccumU;
+        fp.accumulatedImpulseV = newAccumV;
+
+        if(lambdaU * lambdaU + lambdaV * lambdaV <= FM_EPSILON * FM_EPSILON) continue;
+
+        bodyA.linearVelocity += fh.linearResponseUA * lambdaU + fh.linearResponseVA * lambdaV;
+        bodyA.angularVelocity += fp.angularResponseUA * lambdaU + fp.angularResponseVA * lambdaV;
+        bodyB.linearVelocity += fh.linearResponseUB * lambdaU + fh.linearResponseVB * lambdaV;
+        bodyB.angularVelocity += fp.angularResponseUB * lambdaU + fp.angularResponseVB * lambdaV;
+      }
+    }
+
+    // Write the results back to the bodies and the contact cache (for warm starting)
+    for(std::size_t i = 1; i < solverBodies_.size(); ++i) {
+      SolverBody &sb = solverBodies_[i];
+      sb.body->linearVelocity_ = sb.linearVelocity;
+      sb.body->angularVelocity_ = sb.angularVelocity;
+    }
+    for(std::size_t k = 0; k < solverPoints_.size(); ++k) {
+      ContactPoint *cp = solverFrictionPoints_[k].source;
+      cp->accumulatedNormalImpulse = solverPoints_[k].accumulatedImpulse;
+      cp->accumulatedTangentImpulseU = solverFrictionPoints_[k].accumulatedImpulseU;
+      cp->accumulatedTangentImpulseV = solverFrictionPoints_[k].accumulatedImpulseV;
+    }
   }
 
 
   // ── Position constraint solver ────────────────────────────────────
 
-  bool CollisionScene::solvePositionConstraints() {
-    const float slop = 0.005f;
-    const float steering = 0.2f;
-    const float maxCorrection = 0.2f;
-    bool appliedCorrection = false;
+  // Split impulse: penetration is pushed out with separate push velocities that reuse the velocity solver's masses and response vectors, 
+  // then baked into each body's transform once at the end.
+  void CollisionScene::solvePositionConstraints() {
+    if(solverOrder_.empty()) return;
 
-    for(ContactConstraint *constraint : solverConstraints_) {
-      ContactConstraint &cc = *constraint;
+    bool anyCorrection = false;
 
-      RigidBody *a = cc.rigidBodyA;
-      RigidBody *b = cc.rigidBodyB;
-      const bool aCanRotate = cc.respondsA && canApplyAngularResponse(a);
-      const bool bCanRotate = cc.respondsB && canApplyAngularResponse(b);
-      const float invMassA = cc.respondsA ? constrainedLinearInvMassAlong(a, cc.normal) : 0.0f;
-      const float invMassB = cc.respondsB ? constrainedLinearInvMassAlong(b, cc.normal) : 0.0f;
+    for(uint8_t iter = 0; iter < positionSolverIterations_; ++iter) {
+      bool applied = false;
 
-      for(int j = 0; j < cc.pointCount; ++j) {
-        ContactPoint &cp = cc.points[j];
-        if(!cp.active) continue;
+      for(uint16_t orderIdx : solverOrder_) {
+        const SolverConstraintHeader &h = solverHeaders_[orderIdx];
+        SolverBody &bodyA = solverBodies_[h.bodyA];
+        SolverBody &bodyB = solverBodies_[h.bodyB];
 
-        refreshContactPointWorldState(cp, cc, true);
+        const uint16_t end = h.pointStart + h.pointCount;
+        for(uint16_t k = h.pointStart; k < end; ++k) {
+          SolverContactPoint &sp = solverPoints_[k];
+          if(sp.positionBias <= 0.0f) continue;
 
-        if(cp.penetration < slop) continue;
+          const fm_vec3_t dv = bodyA.pushLinearVelocity - bodyB.pushLinearVelocity;
+          const float pushVelN = fm_vec3_dot(&dv, &h.normal)
+                               + fm_vec3_dot(&bodyA.pushAngularVelocity, &sp.angularMeasureA)
+                               - fm_vec3_dot(&bodyB.pushAngularVelocity, &sp.angularMeasureB);
 
-        float steeringForce = fminf(steering * (cp.penetration - slop), maxCorrection);
-        if(steeringForce <= 0.0f) continue;
+          float dImpulse = sp.normalMass * (sp.positionBias - pushVelN);
 
-        float invMassSum = invMassA + invMassB;
+          // Push impulses only separate (accumulated impulse must be non-negative)
+          const float oldAccum = sp.accumulatedPushImpulse;
+          sp.accumulatedPushImpulse = fmaxf(oldAccum + dImpulse, 0.0f);
+          dImpulse = sp.accumulatedPushImpulse - oldAccum;
+          if(fabsf(dImpulse) <= FM_EPSILON) continue;
 
-        // Add rotational inertia terms
-        if(aCanRotate) {
-          fm_vec3_t rCrossN;
-          fm_vec3_cross(&rCrossN, &cp.aToContact, &cc.normal);
-          fm_vec3_t inertia = a->applyConstrainedWorldInertia(rCrossN);
-          invMassSum += fm_vec3_dot(&rCrossN, &inertia);
-        }
-        if(bCanRotate) {
-          fm_vec3_t rCrossN;
-          fm_vec3_cross(&rCrossN, &cp.bToContact, &cc.normal);
-          fm_vec3_t inertia = b->applyConstrainedWorldInertia(rCrossN);
-          invMassSum += fm_vec3_dot(&rCrossN, &inertia);
-        }
-
-        if(invMassSum < FM_EPSILON) continue;
-
-        float correctionMag = steeringForce / invMassSum;
-        fm_vec3_t impulse = cc.normal * correctionMag;
-        appliedCorrection = true;
-
-        // Apply linear + angular corrections to A
-        if(a && a->isEnabled_ && !a->isKinematic_) {
-          if(invMassA > 0.0f) {
-            fm_vec3_t corrA = constrainLinearWorld(a, cc.normal * (correctionMag * invMassA));
-            a->position_ += corrA;
-          }
-          if(aCanRotate) {
-            fm_vec3_t angImpulse;
-            fm_vec3_cross(&angImpulse, &cp.aToContact, &impulse);
-            fm_vec3_t rotChange = a->applyConstrainedWorldInertia(angImpulse);
-            float angle = fm_vec3_len(&rotChange);
-            if(angle > FM_EPSILON) {
-              fm_vec3_t axis = rotChange / angle;
-              fm_quat_t dq;
-              fm_quat_from_axis_angle(&dq, &axis, angle);
-              a->rotation_ = dq * a->rotation_;
-              fm_quat_norm(&a->rotation_, &a->rotation_);
-            }
-          }
-        }
-
-        // Apply linear + angular corrections to B
-        if(b && b->isEnabled_ && !b->isKinematic_) {
-          if(invMassB > 0.0f) {
-            fm_vec3_t corrB = constrainLinearWorld(b, cc.normal * (correctionMag * invMassB));
-            b->position_ -= corrB;
-          }
-          if(bCanRotate) {
-            fm_vec3_t angImpulse;
-            fm_vec3_cross(&angImpulse, &cp.bToContact, &impulse);
-            angImpulse = -angImpulse;
-            fm_vec3_t rotChange = b->applyConstrainedWorldInertia(angImpulse);
-            float angle = fm_vec3_len(&rotChange);
-            if(angle > FM_EPSILON) {
-              fm_vec3_t axis = rotChange / angle;
-              fm_quat_t dq;
-              fm_quat_from_axis_angle(&dq, &axis, angle);
-              b->rotation_ = dq * b->rotation_;
-              fm_quat_norm(&b->rotation_, &b->rotation_);
-            }
-          }
+          applied = true;
+          bodyA.pushLinearVelocity += h.linearResponseA * dImpulse;
+          bodyA.pushAngularVelocity += sp.angularResponseA * dImpulse;
+          bodyB.pushLinearVelocity += h.linearResponseB * dImpulse;
+          bodyB.pushAngularVelocity += sp.angularResponseB * dImpulse;
         }
       }
+
+      anyCorrection |= applied;
+      if(!applied) break;
     }
 
-    return appliedCorrection;
+    if(!anyCorrection) return;
+
+    // Apply the accumulated correction to position and rotation of each body at the end
+    for(std::size_t i = 1; i < solverBodies_.size(); ++i) {
+      SolverBody &sb = solverBodies_[i];
+      RigidBody *body = sb.body;
+      if(!vec3IsZero(sb.pushLinearVelocity)) {
+        body->position_ += sb.pushLinearVelocity;
+      }
+      if(!vec3IsZero(sb.pushAngularVelocity)) {
+        body->rotation_ = quatApplyAngularVelocity(body->rotation_, sb.pushAngularVelocity, 1.0f);
+      }
+    }
   }
 
   /// @brief Recalculate the world-space AABBs of all Mesh Colliders in the Collision Scene.
@@ -2102,10 +2140,6 @@ namespace P64::Coll {
 
     // Warm start
     stageStart = get_ticks();
-    // Reset push velocities for split impulse (Bullet-style)
-    for(RigidBody *body : rigidBodies_) {
-      if(body->isEnabled_ && !body->isSleeping_) body->resetPushVelocities();
-    }
     warmStart();
     ticksWarmStart = get_ticks() - stageStart;
 
@@ -2115,7 +2149,7 @@ namespace P64::Coll {
 
     ticksVelocitySolve = get_ticks() - stageStart;
 
-    // Integrate positions and rotations (including split impulse push velocities)
+    // Integrate positions and rotations
     stageStart = get_ticks();
     for(RigidBody *body : rigidBodies_) {
       if(!body->isEnabled_ || body->isSleeping_) continue;
@@ -2128,11 +2162,7 @@ namespace P64::Coll {
 
     // Position constraint solver
     stageStart = get_ticks();
-    for(uint8_t iter = 0; iter < positionSolverIterations_; ++iter) {
-      if(!solvePositionConstraints()) {
-        break;
-      }
-    }
+    solvePositionConstraints();
     ticksPositionSolve = get_ticks() - stageStart;
 
     // Apply position constraints, inertia and world state of rigidbodies and colliders

--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -835,8 +835,9 @@ namespace P64::Coll {
 
         refreshContactPointWorldState(cp, cc);
 
-        // Deactivate if too separated
-        if(cp.penetration < -0.001f) {
+        // Deactivate if too separated; up to the breaking separation the point stays
+        // active as a speculative contact (see preSolveContacts)
+        if(cp.penetration < -CONTACT_BREAKING_SEPARATION) {
           cp.active = false;
         }
       }
@@ -1111,6 +1112,7 @@ namespace P64::Coll {
 
   void CollisionScene::preSolveContacts() {
     const float restitutionSlop = 0.5f;
+    const float invFixedDt = (fixedDt_ > 0.0f) ? 1.0f / fixedDt_ : 0.0f;
 
     for(ContactConstraint *constraint : solverConstraints_) {
       ContactConstraint &cc = *constraint;
@@ -1219,6 +1221,12 @@ namespace P64::Coll {
         float relVelN = fm_vec3_dot(&relVel, &cc.normal);
         if(relVelN < -restitutionSlop) {
           cp.velocityBias += cc.combinedBounce * relVelN;
+        }
+
+        // Speculative contact: a separated manifold point may approach at up to
+        // gap/dt, this keeps grazing corners of a resting manifold active
+        if(cp.penetration < 0.0f) {
+          cp.velocityBias += -cp.penetration * invFixedDt;
         }
       }
     }


### PR DESCRIPTION
Added BoxBox collision detection circumventing expensive GJK with cheaper Separating Axis Theorem which will directly build a full manifold in one step

Moved a lot of the heavy lifting from the solvers into the presolveContacts step. This will now precompute response vectors per contact with mass, inertia and all the enabled/kinematic/frozen-axis etc baked into flat solver data arrays.

Changed the position solver to split impulse inspired by bullet engine, reuses the same precomputed masses/responses and applies the transform once at the end. That saves a *bunch* of contact refreshing and quaternion math.

preSolve Time is expected to go up somewhat due to doing the prepwork, warm start and solver time should drop dramatically in turn. Optimizations scale especially well with many contacts. Eg Stacks of Boxes