### PR TITLE
Allow to disable components

### DIFF
--- a/src/build/sceneBuilder.cpp
+++ b/src/build/sceneBuilder.cpp
@@ -116,11 +116,15 @@ uint32_t Build::writeObject(Build::SceneCtx &ctx, Project::Object &obj, bool sav
 
   std::vector<Project::Component::Entry*> compList{};
   for (auto &comp : srcObj->components) {
+    PropScope::Path compPath(comp.uuid);
+    if (!comp.enabled.resolve(obj)) continue;
     compList.push_back(&comp);
   }
 
   if(srcObj != &obj) {
     for (auto &comp : obj.components) {
+      PropScope::Path compPath(comp.uuid);
+      if (!comp.enabled.resolve(obj)) continue;
       compList.push_back(&comp);
     }
   }

--- a/src/editor/pages/parts/objectInspector.cpp
+++ b/src/editor/pages/parts/objectInspector.cpp
@@ -696,11 +696,22 @@ void Editor::ObjectInspector::draw() {
     ImTable::PrefabEditScope prefabScope(isInstance);
     ImGui::PushID(&comp);
 
+    // Keep component path active for both its header state and its regular fields. On prefab instances applies as an override
+    std::optional<PropScope::Dispatch> dispatch;
+    std::optional<PropScope::Path> compPath;
+    if(viaPath) compPath.emplace(comp.uuid);
+    else        dispatch.emplace(obj->propOverrides, comp.uuid);
+
     auto &def = Project::Component::TABLE[comp.id];
     auto name = std::string{def.icon} + "  " + comp.name;
 
-    ImGui::SetNextItemAllowOverlap();
-    bool headerOpen = ImGui::CollapsingHeader(name.c_str(), ImGuiTreeNodeFlags_DefaultOpen);
+    bool headerOpen = ImGui::CollapsingHeader(
+      "##ComponentHeader",
+      ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_AllowOverlap
+    );
+    const ImVec2 headerMin = ImGui::GetItemRectMin();
+    const ImVec2 headerMax = ImGui::GetItemRectMax();
+    const ImVec2 cursorAfterHeader = ImGui::GetCursorScreenPos();
     const bool locked = ImTable::isPrefabLocked(obj);
     const bool headerRightClicked = !locked && ImGui::IsItemClicked(ImGuiMouseButton_Right);
 
@@ -715,6 +726,51 @@ void Editor::ObjectInspector::draw() {
       ImGui::TextUnformatted(name.c_str());
       ImGui::EndDragDropSource();
     }
+
+    // Place the component toggle inside the header, between its folding arrow and icon
+    const float checkboxMargin = 2_px; // Checkbox margin, so doesn't fit full header height
+    const float checkboxSize = (headerMax.y - headerMin.y) - checkboxMargin * 2.0f;
+    const float checkboxPaddingY = std::max(0.0f, (checkboxSize - ImGui::GetFontSize()) * 0.5f);
+    // Position checkbox centered vertically inside the header
+    ImGui::SetCursorScreenPos({
+      headerMin.x + ImGui::GetTreeNodeToLabelSpacing(),
+      headerMin.y + checkboxMargin
+    });
+    // Resolve through the active component path so prefab-instance overrides are shown
+    bool enabled = comp.enabled.resolve(*obj);
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, {
+      ImGui::GetStyle().FramePadding.x,
+      checkboxPaddingY
+    });
+    if (ImGui::Checkbox("##Enabled", &enabled)) {
+      // Snapshot the scene before writing either the base value or an instance override
+      Editor::UndoRedo::getHistory().markChanged(enabled ? "Enable Component" : "Disable Component");
+      // Locked prefab components cannot alter their definition; create an override slot
+      // on the inspected instance before assigning the newly selected value
+      if(locked && !obj->hasPropOverride(comp.enabled)) {
+        obj->addPropOverride(comp.enabled);
+      }
+      // Prefab instances write through the resolved override; regular objects own the base
+      if (locked)
+        comp.enabled.resolve(*obj) = enabled;
+      else
+        comp.enabled.value = enabled;
+    }
+    ImGui::PopStyleVar();
+    ImGui::SetItemTooltip("%s Component", enabled ? "Disable" : "Enable");
+
+    // The collapsing header uses a hidden label, so draw the icon and component name
+    // manually after the checkbox and tint them when the component is disabled
+    const ImVec2 checkMax = ImGui::GetItemRectMax();
+    const ImVec2 textSize = ImGui::CalcTextSize(name.c_str());
+    ImGui::GetWindowDrawList()->AddText(
+      {checkMax.x + ImGui::GetStyle().ItemInnerSpacing.x,
+       headerMin.y + (headerMax.y - headerMin.y - textSize.y) * 0.5f},
+      ImGui::GetColorU32(enabled ? ImGuiCol_Text : ImGuiCol_TextDisabled),
+      name.c_str()
+    );
+    // Restore the cursor so this overlaid header content does not affect following layout
+    ImGui::SetCursorScreenPos(cursorAfterHeader);
 
     // Faint help icon near the right edge of the header
     if (def.docSlug && def.docSlug[0]) {
@@ -743,10 +799,6 @@ void Editor::ObjectInspector::draw() {
         }
       }
 
-      std::optional<PropScope::Dispatch> dispatch;
-      std::optional<PropScope::Path> compPath;
-      if(viaPath) compPath.emplace(comp.uuid);
-      else        dispatch.emplace(obj->propOverrides, comp.uuid);
       def.funcDraw(*obj, comp);
     }
     ImGui::PopID();

--- a/src/editor/pages/parts/objectInspector.cpp
+++ b/src/editor/pages/parts/objectInspector.cpp
@@ -558,15 +558,37 @@ void Editor::ObjectInspector::draw() {
       } else {
         // The name belongs to the object itself, not the prefab, so it stays editable even
         // on a locked prefab instance.
-        ImTable::add("Name");
+        // Build this row manually so the object-enabled checkbox sits before the Name label
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
         ImGui::PushID("Name");
+        // Edit a local copy so undo captures the scene before Object::enabled is changed
+        bool enabled = obj->enabled;
+        if (ImGui::Checkbox("##Enabled", &enabled)) {
+          Editor::UndoRedo::getHistory().markChanged(enabled ? "Enable Object" : "Disable Object");
+          obj->enabled = enabled;
+        }
+        ImGui::SetItemTooltip("%s Object", obj->enabled ? "Disable" : "Enable");
+        // Reuse checkbox width and spacing to align following labels with the Name text
+        const float objectLabelOffset = ImGui::GetItemRectSize().x + ImGui::GetStyle().ItemInnerSpacing.x;
+        ImGui::SameLine();
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Name");
+        // The editable name itself remains in the table's value column
+        ImGui::TableSetColumnIndex(1);
         if(ImGui::InputText("##Name", &obj->name)) {
           Editor::UndoRedo::getHistory().markChanged("Edit Name");
         }
         ImGui::PopID();
 
         if(isPrefabInst) {
-          ImTable::add("Prefab");
+          // Leave the checkbox column empty so Prefab starts below Name
+          ImGui::TableNextRow();
+          ImGui::TableSetColumnIndex(0);
+          ImGui::SetCursorPosX(ImGui::GetCursorPosX() + objectLabelOffset);
+          ImGui::AlignTextToFramePadding();
+          ImGui::TextUnformatted("Prefab");
+          ImGui::TableSetColumnIndex(1);
 
           bool editing = ctx.isPrefabEditing(obj->uuid);
           auto name = std::string{ICON_MDI_PENCIL " "};

--- a/src/editor/pages/parts/sceneGraph.cpp
+++ b/src/editor/pages/parts/sceneGraph.cpp
@@ -247,7 +247,8 @@ namespace
   // aren't scene objects, so they're shown dimmed and selecting one targets it as a
   // nested override (rootUuid = instance, path = chain of definition-node uuids).
   void drawPrefabDefNode(Project::Object &node, int depth, uint32_t rootUuid,
-                         std::vector<uint32_t> path, bool selectable)
+                         std::vector<uint32_t> path, bool selectable,
+                         bool parentEnabled = true)
   {
     if(depth > 64)return; // guard against self-referencing prefabs
     path.push_back(node.uuid);
@@ -255,7 +256,7 @@ namespace
     Project::Object* src = Editor::SelectionUtils::prefabDefOf(&node);
 
     bool isSelected = (ctx.selObjectUUID == rootUuid && ctx.selSubPath == path);
-    bool dim = prefabEditObj ? !selectable : false;
+    bool dim = (prefabEditObj && !selectable) || !parentEnabled || !node.enabled;
 
     ImGuiTreeNodeFlags flag = ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_OpenOnArrow
       | ImGuiTreeNodeFlags_OpenOnDoubleClick | ImGuiTreeNodeFlags_FramePadding
@@ -281,7 +282,8 @@ namespace
       // In edit mode we may descend through regular children but stop at nested prefab instances.
       bool childSelectable = prefabEditObj ? (selectable && !node.isPrefabInstance()) : true;
       for(auto &child : src->children) {
-        drawPrefabDefNode(*child, depth + 1, rootUuid, path, childSelectable);
+        drawPrefabDefNode(*child, depth + 1, rootUuid, path, childSelectable,
+                          parentEnabled && node.enabled);
       }
       ImGui::TreePop();
     }
@@ -326,9 +328,11 @@ namespace
 
     std::string nameID = getNodeIcons(obj) + obj.name + "##" + std::to_string(obj.uuid);
 
-    if(!canSelect)ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+    // Set style disabled when editing a prefab or the element or an ancestor is disabled
+    const bool dimNode = !canSelect || !parentEnabled || !obj.enabled;
+    if(dimNode)ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     bool isOpen = ImGui::TreeNodeEx(nameID.c_str(), flag);
-    if(!canSelect)ImGui::PopStyleColor();
+    if(dimNode)ImGui::PopStyleColor();
     ImGui::PopStyleVar(2);
     ImVec2 nodeRectMin = ImGui::GetItemRectMin();
 
@@ -468,7 +472,7 @@ namespace
       // editing a prefab, only the edited instance's own definition is selectable.
       if(prefabDef) {
         for(auto &child : prefabDef->children) {
-          drawPrefabDefNode(*child, 0, obj.uuid, {}, canSelect);
+          drawPrefabDefNode(*child, 0, obj.uuid, {}, canSelect, parentEnabled && obj.enabled);
         }
       }
 

--- a/src/editor/pages/parts/viewport3D.cpp
+++ b/src/editor/pages/parts/viewport3D.cpp
@@ -210,6 +210,7 @@ namespace
       NestedRenderPlacement place{node, pickId, world};
       for(auto &comp : src->components) {
         PropScope::Path compPath(comp.uuid); // so scene-instance overrides on nested props resolve
+        if (!comp.enabled.resolve(node)) continue;
         callback(node, &comp);
       }
       callback(node, nullptr);
@@ -237,6 +238,8 @@ namespace
       }
 
       for(auto &comp : srcObj->components) {
+        PropScope::Dispatch enabledScope(child->propOverrides, comp.uuid);
+        if (!comp.enabled.resolve(*child)) continue;
         callback(*child, &comp);
       }
       callback(*child, nullptr);
@@ -367,7 +370,8 @@ namespace
     for (auto &child : parent.children) {
       auto srcObj = Editor::SelectionUtils::prefabDefOf(child.get());
       for (auto &comp : srcObj->components) {
-        if (comp.id == 3) { // Camera
+        PropScope::Dispatch enabledScope(child->propOverrides, comp.uuid);
+        if (comp.enabled.resolve(*child) && comp.id == 3) { // Camera
           out.push_back({child->uuid, child->name.empty() ? "Camera" : child->name});
           break;
         }
@@ -740,7 +744,8 @@ void Editor::Viewport3D::draw()
     if (auto camObj = scene->getObjectByUUID(boundCameraUUID)) {
       auto srcObj = Editor::SelectionUtils::prefabDefOf(camObj.get());
       for (auto &comp : srcObj->components) {
-        if (comp.id == 3) {
+        PropScope::Dispatch enabledScope(camObj->propOverrides, comp.uuid);
+        if (comp.enabled.resolve(*camObj) && comp.id == 3) {
           camView = Project::Component::Camera::getView(*camObj, comp);
           camera.pos = camObj->pos.resolve(camObj->propOverrides);
           camera.rot = glm::normalize(camObj->rot.resolve(camObj->propOverrides));

--- a/src/project/component/components.h
+++ b/src/project/component/components.h
@@ -11,6 +11,7 @@
 #include "IconsMaterialDesignIcons.h"
 #include "../../build/sceneContext.h"
 #include "../../utils/aabb.h"
+#include "../../utils/prop.h"
 
 namespace Editor
 {
@@ -30,6 +31,7 @@ namespace Project::Component
     int id{};
     uint64_t uuid{};
     std::string name{};
+    Property<bool> enabled{"enabled", true};
     std::shared_ptr<void> data{};
   };
 

--- a/src/project/scene/object.cpp
+++ b/src/project/scene/object.cpp
@@ -45,6 +45,7 @@ namespace
       c["id"] = comp.id;
       c["uuid"] = comp.uuid;
       c["name"] = comp.name;
+      c["enabled"] = comp.enabled.value;
       c["data"] = def.funcSerialize(comp);
       comps.push_back(c);
     }
@@ -147,6 +148,7 @@ void Project::Object::deserialize(Scene *scene, nlohmann::json &doc)
         .id = id,
         .uuid = compObj["uuid"],
         .name = compObj["name"],
+        .enabled = Property<bool>{"enabled", compObj.value("enabled", true)},
         .data = def.funcDeserialize(compObj["data"])
       });
 

--- a/src/project/scene/object.h
+++ b/src/project/scene/object.h
@@ -103,6 +103,8 @@ namespace Project
         Utils::AABB aabb{};
         bool hasVolume = false;
         for (const auto &entry : components) {
+          PropScope::Dispatch enabledScope(propOverrides, entry.uuid);
+          if (!entry.enabled.resolve(*this)) continue;
           const auto &info = Component::TABLE[entry.id];
           if (!info.funcGetAABB) continue;
           PropScope::Dispatch dispatchScope(propOverrides, entry.uuid);

--- a/src/project/scene/scene.cpp
+++ b/src/project/scene/scene.cpp
@@ -329,6 +329,7 @@ void Project::Scene::unpackPrefabInstance(uint32_t uuid)
       auto data = cdef.funcSerialize(comp);
       dst.components.push_back(Component::Entry{
         .id = comp.id, .uuid = comp.uuid, .name = comp.name,
+        .enabled = comp.enabled,
         .data = cdef.funcDeserialize(data)
       });
     }


### PR DESCRIPTION
## Summary
Allows to enable/disable object components.
This is mainly to ease testing, not having to remove the components, with the consequential problems, but also to leave uncompleted changes or non-configured fields which could lead to errors.
I wanted to keep it outside of the build to make it the simplest way, but a different approach could be to allow the API to enable/disable components during runtime.

## Changes
- Adds a checkbox per component in the object inspector to enable/disable it.
- Disabled components are not displayed in the 3D viewport.
- Disabled components are ommited during the build.
- Prefab overrides are taken into account.
- Allows undo/redo.

## Additionally
- Added a checkbox in the object inspector to enable/disable the object.
- Display the object in the scene graph as disabled when it is disabled.

## Notes
If #298 is merged and also this pull request, the prior will require changes to ignore disabled components.

Object inspector:
<img width="358" height="675" alt="image" src="https://github.com/user-attachments/assets/482b0cde-a9e1-402e-aade-554f8c1190f1" />

Scene graph:
<img width="378" height="90" alt="image" src="https://github.com/user-attachments/assets/9648bec8-b61f-4b81-9210-1e932faae869" />