### PR TITLE
Auto fit colliders

### DIFF
--- a/src/project/component/types/compAnimModel.cpp
+++ b/src/project/component/types/compAnimModel.cpp
@@ -228,9 +228,18 @@ namespace Project::Component::AnimModel
 
   Utils::AABB getAABB(Object &obj, Entry &entry) {
     Data &data = *static_cast<Data*>(entry.data.get());
-    Utils::AABB aabb = data.aabb;
-    aabb.min *= (float)0xFFFF;
-    aabb.max *= (float)0xFFFF;
+    Utils::AABB aabb{};
+    auto asset = ctx.project->getAssets().getEntryByUUID(data.model.value);
+    if (!asset) return aabb;
+
+    // Use the imported bind-pose geometry so bounds are available before first render
+    for (const auto &model : asset->model.t3dm.models) {
+      for (const auto &triangle : model.triangles) {
+        for (const auto &vert : triangle.vert) {
+          aabb.addPoint({vert.pos[0], vert.pos[1], vert.pos[2]});
+        }
+      }
+    }
     return aabb;
   }
 }

--- a/src/project/component/types/compCollBody.cpp
+++ b/src/project/component/types/compCollBody.cpp
@@ -43,12 +43,14 @@ namespace Project::Component::CollBody
     PROP_FLOAT(bounce);
   };
 
-  std::shared_ptr<void> init(Object &obj) {
-    auto data = std::make_shared<Data>();
-    data->halfExtend.value = {10.0f, 10.0f, 10.0f};
-    data->friction.value = 0.8f;
-
-    // Make the collider fit the size of the model, if any
+  /**
+   * Calculates the combined bounds of all static and animated models on an object.
+   * @param obj Object whose model components will be inspected.
+   * @param halfExtend Output half size of the combined model bounds.
+   * @param offset Output centre of the combined model bounds.
+   * @return true when at least one valid model was found.
+   */
+  bool getModelFit(Object &obj, glm::vec3 &halfExtend, glm::vec3 &offset) {
     Utils::AABB modelBounds{};
     bool hasModelBounds = false;
 
@@ -81,12 +83,22 @@ namespace Project::Component::CollBody
     }
 
     if(hasModelBounds) {
-      data->halfExtend.value = modelBounds.getHalfExtend();
-      data->halfExtend.value.x = std::max(data->halfExtend.value.x, 0.001f);
-      data->halfExtend.value.y = std::max(data->halfExtend.value.y, 0.001f);
-      data->halfExtend.value.z = std::max(data->halfExtend.value.z, 0.001f);
-      data->offset.value = modelBounds.getCenter();
+      halfExtend = modelBounds.getHalfExtend();
+      halfExtend.x = std::max(halfExtend.x, 0.001f);
+      halfExtend.y = std::max(halfExtend.y, 0.001f);
+      halfExtend.z = std::max(halfExtend.z, 0.001f);
+      offset = modelBounds.getCenter();
     }
+    return hasModelBounds;
+  }
+
+  std::shared_ptr<void> init(Object &obj) {
+    auto data = std::make_shared<Data>();
+    data->halfExtend.value = {10.0f, 10.0f, 10.0f};
+    data->friction.value = 0.8f;
+
+    // Make the collider fit the size of the model, if any
+    getModelFit(obj, data->halfExtend.value, data->offset.value);
     return data;
   }
 
@@ -174,6 +186,31 @@ namespace Project::Component::CollBody
         ImTable::add("Half Height", ext.y);
       }
       ImTable::addObjProp("Offset", data.offset);
+
+      // Button to auto-fit the size
+      ImTable::add("");
+      if (ImGui::Button("Auto fit")) {
+        glm::vec3 halfExtend{};
+        glm::vec3 offset{};
+        if (getModelFit(obj, halfExtend, offset)) {
+          Editor::UndoRedo::getHistory().markChanged("Auto-fit Collider");
+
+          // Prefab components write the fitted values into instance overrides
+          if (ImTable::isPrefabLocked(&obj)) {
+            if (!obj.hasPropOverride(data.halfExtend))
+              obj.addPropOverride(data.halfExtend);
+            if (!obj.hasPropOverride(data.offset))
+              obj.addPropOverride(data.offset);
+            data.halfExtend.resolve(obj.propOverrides) = halfExtend;
+            data.offset.resolve(obj.propOverrides) = offset;
+          } else {
+            data.halfExtend.value = halfExtend;
+            data.offset.value = offset;
+          }
+        }
+      }
+      ImGui::SetItemTooltip("Fit collider to 3D model");
+
       ImTable::addObjProp("Trigger", data.isTrigger);
 
       ImTable::addMultiSelectMask8("Reacts to", data.maskRead.resolve(obj), ctx.project->conf.collLayerNames, "<Nothing>");

--- a/src/project/component/types/compCollBody.cpp
+++ b/src/project/component/types/compCollBody.cpp
@@ -14,6 +14,7 @@
 #include "../../../utils/meshGen.h"
 #include <glm/gtc/quaternion.hpp>
 #include <algorithm>
+#include <cmath>
 
 #include "../../../../n64/engine/include/collision/types.h"
 
@@ -46,6 +47,46 @@ namespace Project::Component::CollBody
     auto data = std::make_shared<Data>();
     data->halfExtend.value = {10.0f, 10.0f, 10.0f};
     data->friction.value = 0.8f;
+
+    // Make the collider fit the size of the model, if any
+    Utils::AABB modelBounds{};
+    bool hasModelBounds = false;
+
+    // Include every static or animated model owned by the supplied object
+    auto includeModels = [&](Object &componentSource, Object &overrideSource) {
+      for (auto &entry : componentSource.components) {
+        if (entry.id != 1 && entry.id != 10) continue;
+
+        auto bounds = Component::TABLE[entry.id].funcGetAABB(overrideSource, entry);
+        const bool valid =
+          std::isfinite(bounds.min.x) && std::isfinite(bounds.min.y) && std::isfinite(bounds.min.z) &&
+          std::isfinite(bounds.max.x) && std::isfinite(bounds.max.y) && std::isfinite(bounds.max.z) &&
+          bounds.min.x <= bounds.max.x && bounds.min.y <= bounds.max.y && bounds.min.z <= bounds.max.z;
+        if (!valid) continue;
+
+        modelBounds.addPoint(bounds.min);
+        modelBounds.addPoint(bounds.max);
+        hasModelBounds = true;
+      }
+    };
+
+    includeModels(obj, obj);
+
+    // Components added to a prefab instance are stored on the instance, while its model
+    // usually lives on the prefab definition, so resolve it through the instance
+    if (obj.isPrefabInstance() && ctx.project) {
+      auto prefab = ctx.project->getAssets().getPrefabByUUID(obj.uuidPrefab.value);
+      if (prefab)
+        includeModels(prefab->obj, obj);
+    }
+
+    if(hasModelBounds) {
+      data->halfExtend.value = modelBounds.getHalfExtend();
+      data->halfExtend.value.x = std::max(data->halfExtend.value.x, 0.001f);
+      data->halfExtend.value.y = std::max(data->halfExtend.value.y, 0.001f);
+      data->halfExtend.value.z = std::max(data->halfExtend.value.z, 0.001f);
+      data->offset.value = modelBounds.getCenter();
+    }
     return data;
   }
 

--- a/src/project/component/types/compModel.cpp
+++ b/src/project/component/types/compModel.cpp
@@ -264,9 +264,19 @@ namespace Project::Component::Model
 
   Utils::AABB getAABB(Object &obj, Entry &entry) {
     Data &data = *static_cast<Data*>(entry.data.get());
-    Utils::AABB aabb = data.aabb;
-    aabb.min *= (float)0xFFFF;
-    aabb.max *= (float)0xFFFF;
+    Utils::AABB aabb{};
+    auto asset = ctx.project->getAssets().getEntryByUUID(data.model.value);
+    if (!asset) return aabb;
+
+    // Imported positions already use the local units expected by scene components
+    // Reading them directly also works before the renderer has created the GPU mesh
+    for (const auto &model : asset->model.t3dm.models) {
+      for (const auto &triangle : model.triangles) {
+        for (const auto &vert : triangle.vert) {
+          aabb.addPoint({vert.pos[0], vert.pos[1], vert.pos[2]});
+        }
+      }
+    }
     return aabb;
   }
 }


### PR DESCRIPTION
## Summary
Automatically fits the colliders to the size of the 3D model.
It was very painful and slow to fit the default collider after adding it.

## Changes
- Auto-fit the collider to the model when the collider is added.
- Added button to auto-fit the collider size.

<img width="349" height="314" alt="image" src="https://github.com/user-attachments/assets/0bcafd41-112b-4e38-9bd5-687b9757aa38" />