### PR TITLE
Asset browser improvements

### DIFF
--- a/src/editor/pages/parts/assetsBrowser.cpp
+++ b/src/editor/pages/parts/assetsBrowser.cpp
@@ -597,7 +597,10 @@ void Editor::AssetsBrowser::draw() {
     ImGui::Separator();
     
     if (ImGui::Button("OK", ImVec2(120_px, 0))) {
+        bool isFile = fs::is_regular_file(deletePath);
         fs::remove(deletePath);
+        if(isFile)
+          fs::remove(deletePath + ".conf");
         deletePath.clear();
         ImGui::CloseCurrentPopup(); 
     }

--- a/src/editor/pages/parts/assetsBrowser.cpp
+++ b/src/editor/pages/parts/assetsBrowser.cpp
@@ -22,6 +22,8 @@
 using FileType = Project::FileType;
 namespace fs = std::filesystem;
 
+uint64_t Editor::AssetsBrowser::pendingPrefabFocusUUID{0};
+
 namespace
 {
   constexpr int TAB_IDX_SCENES = 0;
@@ -78,6 +80,15 @@ namespace
 }
 
 void Editor::AssetsBrowser::draw() {
+  if(pendingPrefabFocusUUID) {
+    activeTab = TAB_IDX_PREFABS;
+    tabDirs[TAB_IDX_PREFABS].clear();
+    searchFilter.clear();
+    ctx.selAssetUUID = pendingPrefabFocusUUID;
+    pendingPrefabFocusUUID = 0;
+    ImGui::makeTabVisible("Files");
+  }
+
   auto &scenes = ctx.project->getScenes().getEntries();
 
   // Converts a delivered Scene Graph object into a prefab inside the target directory
@@ -813,6 +824,10 @@ void Editor::AssetsBrowser::draw() {
 
   ImGui::EndChild();
   ImGui::EndChild();
+}
+
+void Editor::AssetsBrowser::focusPrefab(uint64_t prefabUUID) {
+  pendingPrefabFocusUUID = prefabUUID;
 }
 
 void Editor::AssetsBrowser::showContextMenu(const std::string& path, bool showOpenItem) {

--- a/src/editor/pages/parts/assetsBrowser.cpp
+++ b/src/editor/pages/parts/assetsBrowser.cpp
@@ -53,6 +53,26 @@ namespace
     return left + "/" + right;
   }
 
+  /**
+   * Adds a platform-specific menu item that reveals a path in the system file browser.
+   * @param path File or directory path to reveal.
+   */
+  void showInFileBrowserMenuItem(const std::string &path)
+  {
+#if defined(_WIN32)
+    const char* prompt = ICON_MDI_FOLDER_OPEN " Show in Explorer";
+#elif defined(__APPLE__)
+    const char* prompt = ICON_MDI_FOLDER_OPEN " Show in Finder";
+#else
+    const char* prompt = ICON_MDI_FOLDER_OPEN " Show in File Manager";
+#endif
+    if(ImGui::MenuItem(prompt) && !Utils::Proc::openInFileBrowser(path)) {
+      Editor::Noti::add(
+        Editor::Noti::Type::ERROR, "Failed to open File Explorer. This may be due to WSL path conversion failure."
+      );
+    }
+  }
+
   std::string scriptName{};
   int scriptType{0};
 }
@@ -649,23 +669,21 @@ void Editor::AssetsBrowser::draw() {
     ImGui::EndPopup();
   }
 
+  // Show the current directory menu when right-clicking empty browser space
+  if(baseLabel && ImGui::BeginPopupContextWindow(
+       "AssetsBackgroundContext",
+       ImGuiPopupFlags_MouseButtonRight | ImGuiPopupFlags_NoOpenOverItems
+     )) {
+    showInFileBrowserMenuItem((basePathAbs / dirState).string());
+    ImGui::EndPopup();
+  }
+
   ImGui::EndChild();
   ImGui::EndChild();
 }
 
 void Editor::AssetsBrowser::showContextMenu(const std::string& path) {
-#if defined(_WIN32)
-  std::string showPrompt = ICON_MDI_FOLDER_OPEN " Show in Explorer";
-#elif defined(__APPLE__)
-  std::string showPrompt = ICON_MDI_FOLDER_OPEN " Show in Finder";
-#else
-  std::string showPrompt = ICON_MDI_FOLDER_OPEN " Show in File Manager";
-#endif
-  if(ImGui::MenuItem(showPrompt.c_str())) {
-    if (!Utils::Proc::openInFileBrowser(path)) {
-      Editor::Noti::add(Editor::Noti::Type::ERROR, "Failed to open File Explorer. This may be due to WSL path conversion failure.");
-    }
-  }
+  showInFileBrowserMenuItem(path);
 
   if(ImGui::MenuItem(ICON_MDI_OPEN_IN_NEW " Open")) {
     if (!Utils::Proc::openFile(path)) {

--- a/src/editor/pages/parts/assetsBrowser.cpp
+++ b/src/editor/pages/parts/assetsBrowser.cpp
@@ -674,7 +674,33 @@ void Editor::AssetsBrowser::draw() {
        "AssetsBackgroundContext",
        ImGuiPopupFlags_MouseButtonRight | ImGuiPopupFlags_NoOpenOverItems
      )) {
-    showInFileBrowserMenuItem((basePathAbs / dirState).string());
+    const fs::path currentDir = basePathAbs / dirState;
+    
+    // Menu item to display in file browser
+    showInFileBrowserMenuItem(currentDir.string());
+
+    // Menu item to create a folder
+    if (ImGui::MenuItem(ICON_MDI_FOLDER_PLUS " Create Folder")) {
+      std::string folderName = "New Folder";
+      fs::path folderPath = currentDir / folderName;
+      for (unsigned int suffix = 2; fs::exists(folderPath); ++suffix) {
+        folderName = "New Folder (" + std::to_string(suffix) + ")";
+        folderPath = currentDir / folderName;
+      }
+
+      std::error_code ec;
+      if (fs::create_directory(folderPath, ec)) {
+        renamePath = folderPath.string();
+        strncpy(renameBuffer, folderName.c_str(), sizeof(renameBuffer) - 1);
+        renameBuffer[sizeof(renameBuffer) - 1] = '\0';
+        searchFilter.clear();
+      } else {
+        Editor::Noti::add(
+          Editor::Noti::Type::ERROR,
+          "Failed to create folder: " + ec.message()
+        );
+      }
+    }
     ImGui::EndPopup();
   }
 

--- a/src/editor/pages/parts/assetsBrowser.cpp
+++ b/src/editor/pages/parts/assetsBrowser.cpp
@@ -596,6 +596,12 @@ void Editor::AssetsBrowser::draw() {
   }
 
   static std::string newScriptDir{};
+  auto openNewScriptPopup = [&]() {
+    newScriptDir = dirState;
+    scriptName = "New_Script";
+    scriptType = 0;
+    ImGui::OpenPopup("NewScript");
+  };
 
   if (activeTab == TAB_IDX_SCRIPTS || activeTab == TAB_IDX_SCENES)
   {
@@ -608,10 +614,7 @@ void Editor::AssetsBrowser::draw() {
       textBtnSize
     )) {
       if(activeTab == TAB_IDX_SCRIPTS) {
-        newScriptDir = dirState;
-        scriptName = "New_Script";
-        scriptType = 0;
-        ImGui::OpenPopup("NewScript");
+        openNewScriptPopup();
       } else {
         ctx.project->getScenes().add();
       }
@@ -669,6 +672,8 @@ void Editor::AssetsBrowser::draw() {
     ImGui::EndPopup();
   }
 
+  bool createScriptRequested = false;
+
   // Show the current directory menu when right-clicking empty browser space
   if(baseLabel && ImGui::BeginPopupContextWindow(
        "AssetsBackgroundContext",
@@ -680,7 +685,7 @@ void Editor::AssetsBrowser::draw() {
     showInFileBrowserMenuItem(currentDir.string());
 
     // Menu item to create a folder
-    if (ImGui::MenuItem(ICON_MDI_FOLDER_PLUS " Create Folder")) {
+    if (ImGui::MenuItem(ICON_MDI_FOLDER_PLUS " Create new Folder")) {
       std::string folderName = "New Folder";
       fs::path folderPath = currentDir / folderName;
       for (unsigned int suffix = 2; fs::exists(folderPath); ++suffix) {
@@ -701,7 +706,17 @@ void Editor::AssetsBrowser::draw() {
         );
       }
     }
+
+    // Menu item to create a script
+    if(activeTab == TAB_IDX_SCRIPTS &&
+       ImGui::MenuItem(ICON_MDI_FILE_DOCUMENT_PLUS_OUTLINE " Create new Script")) {
+      createScriptRequested = true;
+    }
     ImGui::EndPopup();
+  }
+
+  if(createScriptRequested) {
+    openNewScriptPopup();
   }
 
   ImGui::EndChild();

--- a/src/editor/pages/parts/assetsBrowser.cpp
+++ b/src/editor/pages/parts/assetsBrowser.cpp
@@ -474,12 +474,14 @@ void Editor::AssetsBrowser::draw() {
 
       if(folderClicked) {
         selectedFolderPath = folderPath;
+        ctx.selAssetUUID = 0;
       }
       if(folderDoubleClicked) {
         folderToOpen = folder;
       }
       if(ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
         selectedFolderPath = folderPath;
+        ctx.selAssetUUID = 0;
       }
 
       if(ImGui::BeginPopupContextItem(folder.c_str())) {

--- a/src/editor/pages/parts/assetsBrowser.cpp
+++ b/src/editor/pages/parts/assetsBrowser.cpp
@@ -402,6 +402,7 @@ void Editor::AssetsBrowser::draw() {
       return a->name < b->name;
     });
 
+    std::string folderToOpen{};
     for (const auto &folder : folders) {
       if(!searchFilter.empty() && !folder.contains(searchFilter)) {
         continue;
@@ -411,18 +412,42 @@ void Editor::AssetsBrowser::draw() {
 
       // Show a filled folder when it contains assets for this tab, outlined (empty) folder otherwise
       const char* folderIcon = folderHasAssets[folder] ? ICON_MDI_FOLDER : ICON_MDI_FOLDER_OUTLINE;
-      if (drawGridButton(folderPath, ImTextureRef(nullptr), folderIcon, folder, false, 1.0f)) {
-        dirState = joinDir(dirState, folder);
+      bool folderClicked = drawGridButton(
+        folderPath,
+        ImTextureRef(nullptr),
+        folderIcon,
+        folder,
+        selectedFolderPath == folderPath,
+        1.0f
+      );
+      bool folderDoubleClicked = ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left) && ImGui::IsItemHovered();
+
+      if(folderClicked) {
+        selectedFolderPath = folderPath;
+      }
+      if(folderDoubleClicked) {
+        folderToOpen = folder;
+      }
+      if(ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
+        selectedFolderPath = folderPath;
       }
 
       if(ImGui::BeginPopupContextItem(folder.c_str())) {
-        showContextMenu(folderPath);
+        if(ImGui::MenuItem(ICON_MDI_OPEN_IN_NEW " Open Folder")) {
+          folderToOpen = folder;
+        }
+        showContextMenu(folderPath, false);
         ImGui::EndPopup();
       }
 
       if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
         ImGui::SetTooltip("Folder: %s", joinDir(dirState, folder).c_str());
       }
+    }
+
+    if(!folderToOpen.empty()) {
+      dirState = joinDir(dirState, folderToOpen);
+      selectedFolderPath.clear();
     }
   }
 
@@ -477,6 +502,7 @@ void Editor::AssetsBrowser::draw() {
     bool isDblClick = ImGui::IsMouseDoubleClicked(0) && ImGui::IsItemHovered();
 
     if (clicked) {
+      selectedFolderPath.clear();
       ctx.selAssetUUID = asset.getUUID();
       ImGui::makeTabVisible("Asset");
     }
@@ -534,6 +560,11 @@ void Editor::AssetsBrowser::draw() {
   }
 
   static int ctxSceneId = -1;
+  auto openScene = [&](int sceneId) {
+    ctx.project->getScenes().loadScene(sceneId);
+    ctx.project->conf.sceneIdLastOpened = sceneId;
+    ctx.project->saveConfig();
+  };
 
   if(tab.showScenes)
   {
@@ -542,8 +573,9 @@ void Editor::AssetsBrowser::draw() {
       checkLineBreak();
       auto activeScene = ctx.project->getScenes().getLoadedScene();
 
-      bool isSelected = activeScene && (activeScene->getId() == scene.id);
-      const auto &liveName = isSelected ? activeScene->getName() : scene.name;
+      bool isLoaded = activeScene && (activeScene->getId() == scene.id);
+      bool isSelected = selectedSceneId < 0 ? isLoaded : selectedSceneId == scene.id;
+      const auto &liveName = isLoaded ? activeScene->getName() : scene.name;
       const auto &displayName = liveName.empty() ? "(unnamed)" : liveName;
       auto buttonLabel = displayName + "##" + std::to_string(scene.id);
 
@@ -552,10 +584,13 @@ void Editor::AssetsBrowser::draw() {
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, {0.5f,0.5f,0.7f,0.8f});
       }
 
-      if (ImGui::Button(buttonLabel.c_str(), textBtnSize)) {
-        ctx.project->getScenes().loadScene(scene.id);
-        ctx.project->conf.sceneIdLastOpened = scene.id;
-        ctx.project->saveConfig();
+      bool sceneClicked = ImGui::Button(buttonLabel.c_str(), textBtnSize);
+      bool sceneDoubleClicked = ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left) && ImGui::IsItemHovered();
+      if(sceneClicked) {
+        selectedSceneId = scene.id;
+      }
+      if(sceneDoubleClicked) {
+        openScene(scene.id);
       }
 
       if(isSelected)ImGui::PopStyleColor(2);
@@ -566,6 +601,7 @@ void Editor::AssetsBrowser::draw() {
       }
 
       if(ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
+        selectedSceneId = scene.id;
         ctxSceneId = scene.id;
         ImGui::OpenPopup("SceneCtxMenu");
       }
@@ -574,6 +610,10 @@ void Editor::AssetsBrowser::draw() {
     if(ImGui::BeginPopup("SceneCtxMenu")) {
       bool canDelete = scenes.size() > 1;
 
+      if(ImGui::MenuItem(ICON_MDI_OPEN_IN_NEW " Open Scene")) {
+        openScene(ctxSceneId);
+      }
+
       if(ImGui::MenuItem(ICON_MDI_CONTENT_COPY " Duplicate")) {
         ctx.project->getScenes().duplicate(ctxSceneId);
       }
@@ -581,6 +621,7 @@ void Editor::AssetsBrowser::draw() {
       if(!canDelete) ImGui::BeginDisabled();
       if(ImGui::MenuItem(ICON_MDI_TRASH_CAN_OUTLINE " Delete")) {
         ctx.project->getScenes().remove(ctxSceneId);
+        if(selectedSceneId == ctxSceneId) selectedSceneId = -1;
         ctx.project->conf.sceneIdLastOpened = ctx.project->getScenes().getEntries().empty()
           ? 0 : ctx.project->getScenes().getEntries().front().id;
         ctx.project->saveConfig();
@@ -723,10 +764,10 @@ void Editor::AssetsBrowser::draw() {
   ImGui::EndChild();
 }
 
-void Editor::AssetsBrowser::showContextMenu(const std::string& path) {
+void Editor::AssetsBrowser::showContextMenu(const std::string& path, bool showOpenItem) {
   showInFileBrowserMenuItem(path);
 
-  if(ImGui::MenuItem(ICON_MDI_OPEN_IN_NEW " Open")) {
+  if(showOpenItem && ImGui::MenuItem(ICON_MDI_OPEN_IN_NEW " Open")) {
     if (!Utils::Proc::openFile(path)) {
       Editor::Noti::add(Editor::Noti::Type::ERROR, "Failed to open File. This may be due to WSL path conversion failure.");
     }

--- a/src/editor/pages/parts/assetsBrowser.cpp
+++ b/src/editor/pages/parts/assetsBrowser.cpp
@@ -80,6 +80,38 @@ namespace
 void Editor::AssetsBrowser::draw() {
   auto &scenes = ctx.project->getScenes().getEntries();
 
+  // Converts a delivered Scene Graph object into a prefab inside the target directory
+  auto acceptObjectAsPrefabPayload = [&](const std::string &targetDir) {
+    if(const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(
+         "OBJECT", ImGuiDragDropFlags_AcceptBeforeDelivery
+       )) {
+      uint32_t objectUUID = *static_cast<const uint32_t*>(payload->Data);
+      auto *scene = ctx.project->getScenes().getLoadedScene();
+      auto object = scene ? scene->getObjectByUUID(objectUUID) : nullptr;
+      if(payload->Delivery && object && !object->isPrefabInstance()) {
+        std::string normalizedTargetDir = normalizeDir(targetDir);
+
+        // Prefabs always appear in their dedicated view after a successful drop
+        activeTab = TAB_IDX_PREFABS;
+        tabDirs[TAB_IDX_PREFABS] = normalizedTargetDir;
+        searchFilter.clear();
+
+        // Asset reloads are unsafe while the current frame still references textures
+        ctx.deferAction([scene, objectUUID, normalizedTargetDir]() {
+          uint64_t prefabUUID = scene->createPrefabFromObject(objectUUID, normalizedTargetDir);
+          if(prefabUUID) ctx.selAssetUUID = prefabUUID;
+        });
+      }
+    }
+  };
+
+  // Registers the last ImGui item as a prefab drop target and handles its payload
+  auto acceptObjectAsPrefabDrop = [&](const std::string &targetDir) {
+    if(!ImGui::BeginDragDropTarget()) return;
+    acceptObjectAsPrefabPayload(targetDir);
+    ImGui::EndDragDropTarget();
+  };
+
   const std::array<TabDef, 4> TABS{
     TabDef{
       .name = ICON_MDI_EARTH_BOX "  Scenes",
@@ -103,6 +135,9 @@ void Editor::AssetsBrowser::draw() {
   for (int i=0; i<(int)TABS.size(); ++i) {
     bool isActive = i == activeTab;
     if (ImGui::Selectable(TABS[i].name, isActive))activeTab = i;
+    if (i == TAB_IDX_ASSETS || i == TAB_IDX_PREFABS) {
+      acceptObjectAsPrefabDrop({});
+    }
   }
   ImGui::EndChild();
 
@@ -422,6 +457,10 @@ void Editor::AssetsBrowser::draw() {
       );
       bool folderDoubleClicked = ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left) && ImGui::IsItemHovered();
 
+      if(activeTab == TAB_IDX_ASSETS || activeTab == TAB_IDX_PREFABS) {
+        acceptObjectAsPrefabDrop(joinDir(dirState, folder));
+      }
+
       if(folderClicked) {
         selectedFolderPath = folderPath;
       }
@@ -711,6 +750,18 @@ void Editor::AssetsBrowser::draw() {
       ImGui::CloseCurrentPopup();
     }
     ImGui::EndPopup();
+  }
+
+  // The whole browser panel represents the currently open directory
+  ImRect directoryDropRect = ImGui::GetCurrentWindow()->InnerRect;
+  directoryDropRect.Max.y -= 1_px; // For some reason setting real height overlaps by 1px
+  if((activeTab == TAB_IDX_ASSETS || activeTab == TAB_IDX_PREFABS) &&
+     ImGui::BeginDragDropTargetCustom(
+       directoryDropRect,
+       ImGui::GetID("AssetsDirectoryDropTarget")
+     )) {
+    acceptObjectAsPrefabPayload(dirState);
+    ImGui::EndDragDropTarget();
   }
 
   bool createScriptRequested = false;

--- a/src/editor/pages/parts/assetsBrowser.cpp
+++ b/src/editor/pages/parts/assetsBrowser.cpp
@@ -123,6 +123,81 @@ void Editor::AssetsBrowser::draw() {
     ImGui::EndDragDropTarget();
   };
 
+  // Moves a browser file or folder into a target directory after the current frame
+  auto moveBrowserEntry = [&](const fs::path &sourcePath, const fs::path &targetDir) {
+    fs::path source = fs::absolute(sourcePath).lexically_normal();
+    fs::path target = fs::absolute(targetDir).lexically_normal();
+    fs::path destination = target / source.filename();
+    bool isDirectory = fs::is_directory(source);
+
+    if(source.parent_path() == target) return;
+
+    if(isDirectory) {
+      fs::path relativeTarget = target.lexically_relative(source);
+      bool targetInsideSource = !relativeTarget.empty()
+        && relativeTarget.begin()->string() != "..";
+      if(targetInsideSource) return;
+    }
+
+    if(fs::exists(destination) || (!isDirectory && fs::exists(destination.string() + ".conf"))) {
+      Editor::Noti::add(
+        Editor::Noti::Type::ERROR,
+        "A file or folder with that name already exists in the target directory."
+      );
+      return;
+    }
+
+    bool updateFolderSelection = selectedFolderPath == source.string();
+    ctx.deferAction([this, source, destination, isDirectory, updateFolderSelection]() {
+      std::error_code ec;
+      fs::rename(source, destination, ec);
+      if(ec) {
+        Editor::Noti::add(Editor::Noti::Type::ERROR, "Move failed: " + ec.message());
+        return;
+      }
+
+      if(!isDirectory) {
+        fs::path sourceConf = source.string() + ".conf";
+        fs::path destinationConf = destination.string() + ".conf";
+        if(fs::exists(sourceConf)) {
+          fs::rename(sourceConf, destinationConf, ec);
+          if(ec) {
+            Editor::Noti::add(Editor::Noti::Type::ERROR, "Failed to move .conf: " + ec.message());
+          }
+        }
+      }
+
+      if(updateFolderSelection) selectedFolderPath = destination.string();
+      ctx.project->getAssets().reload();
+    });
+  };
+
+  // Accepts files and folders from the browser over a folder item
+  auto acceptBrowserEntryPayload = [&](const fs::path &targetDir) {
+    const ImGuiPayload* activePayload = ImGui::GetDragDropPayload();
+    if(!activePayload) return;
+
+    if(activePayload->IsDataType("ASSET")) {
+      uint64_t assetUUID = *static_cast<const uint64_t*>(activePayload->Data);
+      auto *asset = ctx.project->getAssets().getEntryByUUID(assetUUID);
+
+      // Node Graphs are shown virtually in Scripts but remain stored under Assets
+      if(asset && asset->type != FileType::NODE_GRAPH) {
+        if(const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(
+             "ASSET", ImGuiDragDropFlags_AcceptBeforeDelivery
+           ); payload && payload->Delivery) {
+          moveBrowserEntry(asset->path, targetDir);
+        }
+      }
+    } else if(activePayload->IsDataType("ASSET_FOLDER")) {
+      if(const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(
+           "ASSET_FOLDER", ImGuiDragDropFlags_AcceptBeforeDelivery
+         ); payload && payload->Delivery) {
+        moveBrowserEntry(static_cast<const char*>(payload->Data), targetDir);
+      }
+    }
+  };
+
   const std::array<TabDef, 4> TABS{
     TabDef{
       .name = ICON_MDI_EARTH_BOX "  Scenes",
@@ -225,6 +300,11 @@ void Editor::AssetsBrowser::draw() {
     if (ImGui::Button(baseLabel)) {
       dirState.clear();
     }
+    if(ImGui::BeginDragDropTarget()) {
+      acceptBrowserEntryPayload(basePathAbs);
+      ImGui::EndDragDropTarget();
+    }
+
     std::string accum{};
     for (const auto &part : crumbParts) {
       ImGui::SameLine();
@@ -233,6 +313,10 @@ void Editor::AssetsBrowser::draw() {
       accum = joinDir(accum, part);
       if (ImGui::Button(part.c_str())) {
         dirState = accum;
+      }
+      if(ImGui::BeginDragDropTarget()) {
+        acceptBrowserEntryPayload(basePathAbs / accum);
+        ImGui::EndDragDropTarget();
       }
     }
     ImGui::PopStyleVar(2);
@@ -468,8 +552,22 @@ void Editor::AssetsBrowser::draw() {
       );
       bool folderDoubleClicked = ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left) && ImGui::IsItemHovered();
 
-      if(activeTab == TAB_IDX_ASSETS || activeTab == TAB_IDX_PREFABS) {
-        acceptObjectAsPrefabDrop(joinDir(dirState, folder));
+      if(ImGui::BeginDragDropSource()) {
+        ImGui::SetDragDropPayload(
+          "ASSET_FOLDER",
+          folderPath.c_str(),
+          folderPath.size() + 1
+        );
+        ImGui::TextUnformatted(folder.c_str());
+        ImGui::EndDragDropSource();
+      }
+
+      if(ImGui::BeginDragDropTarget()) {
+        if(activeTab == TAB_IDX_ASSETS || activeTab == TAB_IDX_PREFABS) {
+          acceptObjectAsPrefabPayload(joinDir(dirState, folder));
+        }
+        acceptBrowserEntryPayload(folderPath);
+        ImGui::EndDragDropTarget();
       }
 
       if(folderClicked) {

--- a/src/editor/pages/parts/assetsBrowser.h
+++ b/src/editor/pages/parts/assetsBrowser.h
@@ -16,12 +16,14 @@ namespace Editor
       int activeTab{1};
       std::array<std::string, 4> tabDirs{};
       std::string searchFilter{};
+      std::string selectedFolderPath{};
+      int selectedSceneId{-1};
       std::string renamePath{};
       std::string deletePath{};
       char renameBuffer[256];
 
     public:
       void draw();
-      void showContextMenu(const std::string& path);
+      void showContextMenu(const std::string& path, bool showOpenItem = true);
   };
 }

--- a/src/editor/pages/parts/assetsBrowser.h
+++ b/src/editor/pages/parts/assetsBrowser.h
@@ -21,8 +21,14 @@ namespace Editor
       std::string renamePath{};
       std::string deletePath{};
       char renameBuffer[256];
+      static uint64_t pendingPrefabFocusUUID;
 
     public:
+      /**
+       * Requests that the Prefabs view displays and selects a prefab.
+       * @param prefabUUID UUID of the prefab to focus.
+       */
+      static void focusPrefab(uint64_t prefabUUID);
       void draw();
       void showContextMenu(const std::string& path, bool showOpenItem = true);
   };

--- a/src/editor/pages/parts/sceneGraph.cpp
+++ b/src/editor/pages/parts/sceneGraph.cpp
@@ -36,6 +36,37 @@ namespace
 
   DragDropTask dragDropTask{};
 
+  struct PrefabDropTask {
+    uint64_t prefabUUID{0};
+    uint32_t targetUUID{0};
+    bool asChild{false};
+  };
+
+  PrefabDropTask prefabDropTask{};
+  ImVec2 lastInsertLineStart{};
+  ImVec2 lastInsertLineEnd{};
+  bool hasInsertLine{false};
+
+  /**
+   * Accepts a prefab asset payload and records where its scene instance should be created.
+   * @param targetUUID Destination object UUID, or zero to add at the scene root.
+   * @param asChild Whether the new instance should become a child of the target.
+   */
+  void acceptPrefabDrop(uint32_t targetUUID, bool asChild)
+  {
+    const ImGuiPayload* payload = ImGui::GetDragDropPayload();
+    if (!payload || !payload->IsDataType("ASSET")) return;
+
+    uint64_t prefabUUID = *static_cast<const uint64_t*>(payload->Data);
+    if (!ctx.project->getAssets().getPrefabByUUID(prefabUUID)) return;
+
+    if (ImGui::AcceptDragDropPayload("ASSET")) {
+      prefabDropTask.prefabUUID = prefabUUID;
+      prefabDropTask.targetUUID = targetUUID;
+      prefabDropTask.asChild = asChild;
+    }
+  }
+
   /**
    * Builds the icon prefix shown before the node name in the scene tree.
    *
@@ -150,6 +181,9 @@ namespace
       cursorScreen.y - (hitHeight / 2) + 3_px
     };
     ImVec2 overlayEnd = ImVec2(cursorScreen.x + fullWidth, cursorScreen.y + hitHeight);
+    lastInsertLineStart = {overlayStart.x, overlayStart.y};
+    lastInsertLineEnd = {overlayEnd.x, overlayStart.y};
+    hasInsertLine = true;
 
     // Push a dummy cursor to draw hit zone *without affecting layout*
     ImGui::SetCursorScreenPos(overlayStart);
@@ -157,7 +191,14 @@ namespace
     ImGui::InvisibleButton("##dropzone", ImVec2(fullWidth, hitHeight));
     bool hovered = ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem);
 
-    if (hovered) {
+    const ImGuiPayload* activePayload = ImGui::GetDragDropPayload();
+    bool acceptsPayload = activePayload && activePayload->IsDataType("OBJECT");
+    if (activePayload && activePayload->IsDataType("ASSET")) {
+      uint64_t assetUUID = *static_cast<const uint64_t*>(activePayload->Data);
+      acceptsPayload = ctx.project->getAssets().getPrefabByUUID(assetUUID) != nullptr;
+    }
+
+    if (hovered && acceptsPayload) {
       drawList->AddLine(
           ImVec2(overlayStart.x, overlayStart.y),
           ImVec2(overlayEnd.x, overlayStart.y),
@@ -175,6 +216,8 @@ namespace
         dragDropTarget = *((uint32_t*)payload->Data);
         res = true;
       }
+      if (!prefabEditObj)
+        acceptPrefabDrop(uuid, false);
       ImGui::EndDragDropTarget();
     }
     ImGui::PopStyleColor();
@@ -332,6 +375,7 @@ namespace
     if(!canSelect)ImGui::PopStyleColor();
     ImGui::PopStyleVar(2);
     ImVec2 nodeRectMin = ImGui::GetItemRectMin();
+    ImVec2 nodeRectMax = ImGui::GetItemRectMax();
 
     // Mark object being edited in prefab-edit mode
     if(ctx.isPrefabEditing(obj.uuid)) {
@@ -366,11 +410,24 @@ namespace
 
     if (obj.parent && ImGui::BeginDragDropTarget()) {
       if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("OBJECT")) {
-        dragDropTask.sourceUUID = *((uint32_t*)payload->Data);
+        dragDropTask.sourceUUID = *static_cast<const uint32_t*>(payload->Data);
         dragDropTask.targetUUID = obj.uuid;
         dragDropTask.isInsert = true;
       }
       ImGui::EndDragDropTarget();
+    }
+
+    // Keep prefab child drops in the centre of the row, away from insertion lines
+    if (!prefabEditObj && !obj.isPrefabInstance()) {
+      ImRect prefabTargetRect{nodeRectMin, nodeRectMax};
+      prefabTargetRect.Min.y += 4_px;
+      prefabTargetRect.Max.y -= 4_px;
+      ImGui::PushID(obj.uuid);
+      if (ImGui::BeginDragDropTargetCustom(prefabTargetRect, ImGui::GetID("PrefabChildDrop"))) {
+        acceptPrefabDrop(obj.parent ? obj.uuid : 0, obj.parent != nullptr);
+        ImGui::EndDragDropTarget();
+      }
+      ImGui::PopID();
     }
 
     // Is renaming the object node
@@ -404,12 +461,6 @@ namespace
 
       if(!parentEnabled)ImGui::EndDisabled();
       ImGui::SetCursorPosY(oldCursorPos.y);
-    }
-
-    if(ImGui::IsDragDropActive()) {
-      if(DrawDropTarget(dragDropTask.sourceUUID, obj.uuid)) {
-        dragDropTask.targetUUID = obj.uuid;
-      }
     }
 
     if (nodeIsClicked && canSelect) {
@@ -464,8 +515,24 @@ namespace
         ImGui::EndPopup();
       }
 
-      for(auto &child : obj.children) {
+      // The scene root provides the insertion point before its first object
+      if (obj.parent == nullptr && !obj.children.empty() && ImGui::IsDragDropActive()) {
+        if (DrawDropTarget(dragDropTask.sourceUUID, obj.uuid)) {
+          dragDropTask.targetUUID = obj.uuid;
+        }
+      }
+
+      for(size_t i = 0; i < obj.children.size(); ++i) {
+        auto &child = obj.children[i];
         drawObjectNode(scene, *child, keyDelete, parentEnabled && obj.enabled);
+
+        // Nested lists leave their final boundary to the parent's sibling line
+        bool needsInsertLine = (i + 1 < obj.children.size()) || obj.parent == nullptr;
+        if (needsInsertLine && ImGui::IsDragDropActive()) {
+          if (DrawDropTarget(dragDropTask.sourceUUID, child->uuid)) {
+            dragDropTask.targetUUID = child->uuid;
+          }
+        }
       }
 
       // Prefab definition tree showing nested prefab content under the instance. Nodes are
@@ -488,6 +555,8 @@ void Editor::SceneGraph::draw()
   if (!scene)return;
 
   dragDropTask = {};
+  prefabDropTask = {};
+  hasInsertLine = false;
   deleteObj = nullptr;
   deleteSelection = false;
   prefabEditObj = Editor::SelectionUtils::getPrefabEditObject(*scene);
@@ -512,6 +581,44 @@ void Editor::SceneGraph::draw()
   auto &root = scene->getRootObject();
   drawObjectNode(*scene, root, keyDelete);
 
+  // Use the remaining tree space as a drop target for root-level prefab instances
+  if (!prefabEditObj && ImGui::IsDragDropActive()) {
+    ImVec2 emptySize = ImGui::GetContentRegionAvail();
+    constexpr float INSERT_DROP_HEIGHT = 8.0f;
+    if (emptySize.x > 0 && emptySize.y > INSERT_DROP_HEIGHT) {
+      ImVec2 emptyStart = ImGui::GetCursorScreenPos();
+      ImVec2 lineStart = hasInsertLine ? lastInsertLineStart : emptyStart;
+      ImVec2 lineEnd = hasInsertLine
+        ? lastInsertLineEnd
+        : ImVec2{ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x, emptyStart.y};
+      ImGui::SetCursorScreenPos({emptyStart.x, emptyStart.y + INSERT_DROP_HEIGHT});
+      emptySize.y -= INSERT_DROP_HEIGHT;
+      ImGui::InvisibleButton("##ScenePrefabDropTarget", emptySize);
+
+      const ImGuiPayload* payload = ImGui::GetDragDropPayload();
+      bool isPrefabPayload = payload && payload->IsDataType("ASSET")
+        && ctx.project->getAssets().getPrefabByUUID(
+          *static_cast<const uint64_t*>(payload->Data)
+        );
+      if (isPrefabPayload && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
+        ImGui::GetWindowDrawList()->AddLine(
+          lineStart,
+          lineEnd,
+          ImGui::GetColorU32(ImGuiCol_DragDropTarget),
+          2_px
+        );
+      }
+
+      // Hide the default full-area frame while preserving the empty-space hit zone
+      ImGui::PushStyleColor(ImGuiCol_DragDropTarget, ImVec4(0, 0, 0, 0));
+      if (ImGui::BeginDragDropTarget()) {
+        acceptPrefabDrop(0, false);
+        ImGui::EndDragDropTarget();
+      }
+      ImGui::PopStyleColor();
+    }
+  }
+
   ImGui::PopStyleVar(1);
 
   bool isCtrlDown = ImGui::GetIO().KeyCtrl;
@@ -533,6 +640,36 @@ void Editor::SceneGraph::draw()
     // Could move --> Add to history
     if (moved)
       UndoRedo::getHistory().markChanged("Move Object");
+  }
+
+  if (prefabDropTask.prefabUUID) {
+    auto &root = scene->getRootObject();
+    bool targetIsRoot = prefabDropTask.targetUUID == root.uuid;
+    std::shared_ptr<Project::Object> target{};
+    if (prefabDropTask.targetUUID && !targetIsRoot) {
+      target = scene->getObjectByUUID(prefabDropTask.targetUUID);
+    }
+
+    bool targetExists = !prefabDropTask.targetUUID || targetIsRoot || target;
+    bool canAddAsChild = !prefabDropTask.asChild || targetIsRoot
+      || (target && !target->isPrefabInstance());
+
+    // A stale target or a child drop on a prefab must not create an instance elsewhere
+    if (targetExists && canAddAsChild) {
+      auto added = scene->addPrefabInstance(prefabDropTask.prefabUUID);
+      if (added) {
+        glm::vec3 position{0.0f};
+        if (prefabDropTask.asChild && target) {
+          position = target->pos.resolve(target->propOverrides);
+          scene->moveObject(added->uuid, target->uuid, true);
+        } else if (prefabDropTask.targetUUID) {
+          scene->moveObject(added->uuid, prefabDropTask.targetUUID, false);
+        }
+        added->pos.resolve(added->propOverrides) = position;
+        ctx.setObjectSelection(added->uuid);
+        UndoRedo::getHistory().markChanged("Add Prefab");
+      }
+    }
   }
 
   if (deleteSelection || deleteObj) {

--- a/src/editor/pages/parts/sceneGraph.cpp
+++ b/src/editor/pages/parts/sceneGraph.cpp
@@ -3,6 +3,7 @@
 * @license MIT
 */
 #include "sceneGraph.h"
+#include "assetsBrowser.h"
 
 #include <algorithm>
 #include <string>
@@ -441,7 +442,11 @@ namespace
             // unsafe mid-frame while ImGui draw data still references them.
             auto *scenePtr = &scene;
             uint32_t uuid = obj.uuid;
-            ctx.deferAction([scenePtr, uuid]() { scenePtr->createPrefabFromObject(uuid); });
+            ctx.deferAction([scenePtr, uuid]() {
+              uint64_t prefabUUID = scenePtr->createPrefabFromObject(uuid);
+              if(prefabUUID)
+                Editor::AssetsBrowser::focusPrefab(prefabUUID);
+            });
           }
 
           if (obj.isPrefabInstance() && ImGui::MenuItem(ICON_MDI_PACKAGE_VARIANT " Unpack Prefab")) {

--- a/src/project/scene/scene.cpp
+++ b/src/project/scene/scene.cpp
@@ -4,6 +4,7 @@
 */
 #include "scene.h"
 #include "object.h"
+#include <filesystem>
 #include <functional>
 #include "../../utils/json.h"
 #include "../../context.h"
@@ -241,7 +242,7 @@ void Project::Scene::save()
   Utils::FS::saveTextFile(scenePath + "/scene.json", serialize());
 }
 
-uint32_t Project::Scene::createPrefabFromObject(uint32_t uuid)
+uint64_t Project::Scene::createPrefabFromObject(uint32_t uuid, const std::string &subDir)
 {
   auto obj = getObjectByUUID(uuid);
   if(!obj)return 0;
@@ -282,10 +283,11 @@ uint32_t Project::Scene::createPrefabFromObject(uint32_t uuid)
   ), name.end());
   if(name.empty())name = "prefab " + std::to_string(prefab.uuid.value);
 
-  Utils::FS::saveTextFile(
-    ctx.project->getPath() + "/assets/" + name + ".prefab",
-    prefabJson
-  );
+  auto prefabPath = std::filesystem::path(ctx.project->getPath()) / "assets";
+  if(!subDir.empty())
+    prefabPath /= subDir;
+  prefabPath /= name + ".prefab";
+  Utils::FS::saveTextFile(prefabPath, prefabJson);
 
   ctx.project->getAssets().reload();
 
@@ -306,7 +308,7 @@ uint32_t Project::Scene::createPrefabFromObject(uint32_t uuid)
   obj->addPropOverride(obj->pos);
   obj->addPropOverride(obj->rot);
   obj->addPropOverride(obj->scale);
-  return 0;
+  return prefab.uuid.value;
 }
 
 void Project::Scene::unpackPrefabInstance(uint32_t uuid)

--- a/src/project/scene/scene.h
+++ b/src/project/scene/scene.h
@@ -91,7 +91,7 @@ namespace Project
         return nullptr;
       }
 
-      uint32_t createPrefabFromObject(uint32_t uuid);
+      uint64_t createPrefabFromObject(uint32_t uuid, const std::string &subDir = {});
 
       // Unpacks a prefab instance (shallow) into real, editable scene objects
       void unpackPrefabInstance(uint32_t uuid);


### PR DESCRIPTION
## Summary
Several improvements on the asset browser.
Adds right-click menu on the folder area.
Allows drag and drob between the scene graph and the asset browser.

## Changes
- Display a context menu for the container folder with options:
  - "Show in Explorer".
  - "Create new Folder".
  - "Create new Script" (only on Scripts).
 - Double-click to open scene/folder. Single click now only selects.
 - Added context menu option to open scene/folder.
 - Allow to drag-drop a file or folder on a folder to move it inside. Also allows to drop on the breadcrumbs.
 - When removing a file, remove also its .conf.
 - Allow to drop an object from the scene graph into the assets browser on the Prefabs/Assets to create a prefab:
   - Dropping on Assets switches to Prefabs.
   - Dropping on a folder creates into the folder and opens it.
   - Focuses the prefab after creating it.
 - In the scene graph, after performing "To Prefab", display and focus prefab in the asset browser.
 - Allow to drop a prefab from the asset browser to the scene graph.

## Suggestion
It would be nice that the Prefabs have their own folder, a sibling or child of the "assets" folder.