### PR TITLE
feat: Allow mathematical operations in the object inspector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ add_executable(pyrite64 src/main.cpp
         src/editor/imgui/theme.h
         src/editor/imgui/theme.cpp
         src/editor/imgui/helper.h
+        src/editor/imgui/mathInput.h
         src/utils/filePicker.h
         src/utils/filePicker.cpp
         src/editor/pages/parts/viewport3D.h
@@ -232,7 +233,7 @@ add_executable(pyrite64 src/main.cpp
         src/project/component/types/compLight.cpp
         src/project/component/types/compCamera.cpp
         src/editor/imgui/helper.cpp
-        src/editor/imgui/helper.cpp
+        src/editor/imgui/mathInput.cpp
         n64/engine/include/scene/objectFlags.h
         src/utils/fs.cpp
         src/project/component/types/compCollMesh.cpp

--- a/src/editor/imgui/helper.cpp
+++ b/src/editor/imgui/helper.cpp
@@ -73,13 +73,14 @@ bool ImGui::HelpIcon(const char* docPath, const char* tooltip, float glyphSize)
 
 glm::vec3 tmpEuler;
 bool ImGui::rotationInput(glm::quat &quat) {
-  if(!ctx.prefs.showRotAsEuler) return InputFloat4("##", glm::value_ptr(quat));
+  // Both quaternion and Euler representations accept expressions on every axis
+  if(!ctx.prefs.showRotAsEuler) return MathInputFloatN("##", glm::value_ptr(quat), 4);
   
   glm::quat calcRot = glm::normalize(glm::quat(glm::radians(tmpEuler)));
   glm::quat orgRot = glm::normalize(quat);
   if (glm::dot(calcRot, orgRot) < 1) tmpEuler = glm::degrees(glm::eulerAngles(orgRot));
 
-  if (!InputFloat3("##RotEuler", glm::value_ptr(tmpEuler))) return false;
+  if (!MathInputFloatN("##RotEuler", glm::value_ptr(tmpEuler), 3)) return false;
   quat = glm::normalize(glm::quat(glm::radians(tmpEuler)));
   return true;
 }

--- a/src/editor/imgui/helper.h
+++ b/src/editor/imgui/helper.h
@@ -19,10 +19,12 @@
 #include "../../utils/filePicker.h"
 #include "../../utils/prop.h"
 #include "theme.h"
+#include "mathInput.h"
 #include "glm/vec3.hpp"
 #include "glm/gtc/quaternion.hpp"
 #include "glm/gtc/type_ptr.hpp"
 #include <functional>
+#include <type_traits>
 
 #include "imgui_internal.h"
 
@@ -820,27 +822,27 @@ namespace ImTable
   bool typedInput(T *value)
   {
     if constexpr (std::is_same_v<T, float>) {
-      return ImGui::InputFloat("##", value);
+      return ImGui::MathInputFloat("##", value);
     } else if constexpr (std::is_same_v<T, bool>) {
       return ImGui::Checkbox("##", value);
     } else if constexpr (std::is_same_v<T, int>) {
-      return ImGui::InputInt("##", value);
+      return ImGui::MathInputInt("##", value);
     } else if constexpr (std::is_same_v<T, uint32_t>) {
-      return ImGui::InputScalar("##", ImGuiDataType_U32, value);
+      return ImGui::MathInputU32("##", value);
     } else if constexpr (std::is_same_v<T, uint16_t>) {
-      return ImGui::InputScalar("##", ImGuiDataType_U16, value);
+      return ImGui::MathInputU16("##", value);
     } else if constexpr (std::is_same_v<T, uint8_t>) {
-      return ImGui::InputScalar("##", ImGuiDataType_U8, value);
+      return ImGui::MathInputU8("##", value);
     } else if constexpr (std::is_same_v<T, glm::vec2>) {
-      return ImGui::InputFloat2("##", glm::value_ptr(*value));
+      return ImGui::MathInputFloatN("##", glm::value_ptr(*value), 2);
     } else if constexpr (std::is_same_v<T, glm::vec3>) {
-      return ImGui::InputFloat3("##", glm::value_ptr(*value));
+      return ImGui::MathInputFloatN("##", glm::value_ptr(*value), 3);
     } else if constexpr (std::is_same_v<T, glm::vec4>) {
       return ImGui::ColorEdit4("##", glm::value_ptr(*value), ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoLabel | ImGuiColorEditFlags_AlphaPreviewHalf);
     } else if constexpr (std::is_same_v<T, glm::quat>) {
       return ImGui::rotationInput(*value);
     } else if constexpr (std::is_same_v<T, glm::ivec2>) {
-      return ImGui::InputInt2("##", glm::value_ptr(*value));
+      return ImGui::MathInputIntN("##", glm::value_ptr(*value), 2);
     } else if constexpr (std::is_same_v<T, std::string>) {
       return ImGui::InputText("##", value);
     } else {

--- a/src/editor/imgui/helper.h
+++ b/src/editor/imgui/helper.h
@@ -857,8 +857,12 @@ namespace ImTable
     bool disabled  (isPrefabLocked());
     ImGui::PushID(name.c_str());
     if(disabled)ImGui::BeginDisabled();
+    auto mathInputBefore = ImGui::GetMathInputActivity();
     bool changed = typedInput<T>(&value);
-    if(changed)Editor::UndoRedo::getHistory().markChanged("Edit " + name);
+    auto mathInputAfter = ImGui::GetMathInputActivity();
+    bool usedMathInput = mathInputAfter.uses != mathInputBefore.uses;
+    bool confirmed = mathInputAfter.confirmations != mathInputBefore.confirmations;
+    if(usedMathInput ? confirmed : changed)Editor::UndoRedo::getHistory().markChanged("Edit " + name);
     if(disabled)ImGui::EndDisabled();
     ImGui::PopID();
     return changed;
@@ -869,8 +873,12 @@ namespace ImTable
   {
     add(name);
     ImGui::PushID(name.c_str());
+    auto mathInputBefore = ImGui::GetMathInputActivity();
     bool changed = typedInput<T>(&prop.value);
-    if(changed)Editor::UndoRedo::getHistory().markChanged("Edit " + name);
+    auto mathInputAfter = ImGui::GetMathInputActivity();
+    bool usedMathInput = mathInputAfter.uses != mathInputBefore.uses;
+    bool confirmed = mathInputAfter.confirmations != mathInputBefore.confirmations;
+    if(usedMathInput ? confirmed : changed)Editor::UndoRedo::getHistory().markChanged("Edit " + name);
     ImGui::PopID();
     return changed;
   }
@@ -945,8 +953,12 @@ namespace ImTable
       ImGui::SameLine();
     }
 
+    auto mathInputBefore = ImGui::GetMathInputActivity();
     res = editFunc(val);
-    if (res) Editor::UndoRedo::getHistory().markChanged("Edit " + name);
+    auto mathInputAfter = ImGui::GetMathInputActivity();
+    bool usedMathInput = mathInputAfter.uses != mathInputBefore.uses;
+    bool confirmed = mathInputAfter.confirmations != mathInputBefore.confirmations;
+    if (usedMathInput ? confirmed : res) Editor::UndoRedo::getHistory().markChanged("Edit " + name);
 
     if(isDisabled)ImGui::EndDisabled();
 

--- a/src/editor/imgui/mathInput.cpp
+++ b/src/editor/imgui/mathInput.cpp
@@ -24,6 +24,7 @@ namespace
 
   // ImGui IDs distinguish repeated labels across tables, components and vector axes
   std::unordered_map<ImGuiID, MathInputState> mathInputStates{};
+  ImGui::MathInputActivity mathInputActivity{};
 
   /**
    * Parses arithmetic expressions through recursive descent and operator precedence.
@@ -246,6 +247,9 @@ namespace
   template<typename T>
   bool mathInputScalar(const char *label, T *value)
   {
+    // Record that the surrounding inspector control uses a mathematical input
+    ++mathInputActivity.uses;
+
     // Keep one editable expression per concrete widget
     ImGuiID id = ImGui::GetID(label);
     auto [stateIt, inserted] = mathInputStates.try_emplace(id);
@@ -274,10 +278,12 @@ namespace
 
     bool enterPressed = (active || wasActive)
       && (ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter));
-    bool confirmed = enterPressed || ImGui::IsItemDeactivated();
+    bool confirmed = (active || wasActive)
+      && (enterPressed || ImGui::IsItemDeactivated());
     if (confirmed) {
       // Replace the expression with its calculated value on Enter or focus loss
       state.expression = formatMathValue(*value);
+      ++mathInputActivity.confirmations;
       if (active) ImGui::ClearActiveID();
       active = false;
     }
@@ -314,6 +320,10 @@ namespace
     ImGui::EndGroup();
     return changed;
   }
+}
+
+ImGui::MathInputActivity ImGui::GetMathInputActivity() {
+  return mathInputActivity;
 }
 
 bool ImGui::MathInputFloat(const char *label, float *value) {

--- a/src/editor/imgui/mathInput.cpp
+++ b/src/editor/imgui/mathInput.cpp
@@ -1,0 +1,353 @@
+#include "mathInput.h"
+
+#include "imgui.h"
+#include "imgui_internal.h"
+#include "misc/cpp/imgui_stdlib.h"
+
+#include <algorithm>
+#include <charconv>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
+#include <type_traits>
+#include <unordered_map>
+
+namespace
+{
+  // Keeps the typed expression alive while its ImGui field remains active
+  struct MathInputState
+  {
+    std::string expression{};
+    bool active{false};
+  };
+
+  // ImGui IDs distinguish repeated labels across tables, components and vector axes
+  std::unordered_map<ImGuiID, MathInputState> mathInputStates{};
+
+  /**
+   * Parses arithmetic expressions through recursive descent and operator precedence.
+   */
+  class MathExpressionParser
+  {
+    private:
+      const char *cursor{};
+
+      /**
+       * Advances the parser cursor past consecutive whitespace characters.
+       */
+      void skipSpaces()
+      {
+        // Whitespace is allowed between every token
+        while (*cursor && std::isspace(static_cast<unsigned char>(*cursor)))
+          ++cursor;
+      }
+
+      /**
+       * Consumes a token when it is the next non-space character.
+       * @param token Character expected at the current parser position.
+       * @return True when the token was found and consumed.
+       */
+      bool consume(char token)
+      {
+        // Advance only when the next non-space character matches the requested token
+        skipSpaces();
+        if (*cursor != token) return false;
+        ++cursor;
+        return true;
+      }
+
+      /**
+       * Parses addition and subtraction expressions.
+       * @param value Destination for the evaluated expression.
+       * @return True when this precedence level was parsed successfully.
+       */
+      bool parseExpression(double &value)
+      {
+        // Addition and subtraction are evaluated after all higher-precedence operations
+        if (!parseTerm(value)) return false;
+        
+        while (true) {
+          if (consume('+')) {
+            double rhs{};
+            if (!parseTerm(rhs)) return false;
+            value += rhs;
+          } else if (consume('-')) {
+            double rhs{};
+            if (!parseTerm(rhs)) return false;
+            value -= rhs;
+          } else {
+            return std::isfinite(value);
+          }
+        }
+      }
+
+      /**
+       * Parses multiplication, division and remainder expressions.
+       * @param value Destination for the evaluated term.
+       * @return True when this precedence level was parsed successfully.
+       */
+      bool parseTerm(double &value)
+      {
+        // Multiplication, division and remainder share precedence and associate to the left
+        if (!parseUnary(value)) return false;
+
+        while (true) {
+          if (consume('*')) {
+            double rhs{};
+            if (!parseUnary(rhs)) return false;
+            value *= rhs;
+          } else if (consume('/')) {
+            double rhs{};
+            // Division by zero invalidates the expression without changing the property
+            if (!parseUnary(rhs) || rhs == 0.0) return false;
+            value /= rhs;
+          } else if (consume('%')) {
+            double rhs{};
+            if (!parseUnary(rhs) || rhs == 0.0) return false;
+            value = std::fmod(value, rhs);
+          } else {
+            return std::isfinite(value);
+          }
+        }
+      }
+
+      /**
+       * Parses recursive unary plus and minus operators.
+       * @param value Destination for the evaluated unary expression.
+       * @return True when this precedence level was parsed successfully.
+       */
+      bool parseUnary(double &value)
+      {
+        // Recursive unary parsing accepts chains such as --2 and preserves power precedence
+        if (consume('+')) return parseUnary(value);
+        if (consume('-')) {
+          if (!parseUnary(value)) return false;
+          value = -value;
+          return true;
+        }
+        return parsePower(value);
+      }
+
+      /**
+       * Parses right-associative exponentiation expressions.
+       * @param value Destination for the evaluated power expression.
+       * @return True when this precedence level was parsed successfully.
+       */
+      bool parsePower(double &value)
+      {
+        // Parsing the exponent through unary makes powers right-associative and allows 2^-2
+        if (!parsePrimary(value)) return false;
+        if (consume('^')) {
+          double exponent{};
+          if (!parseUnary(exponent)) return false;
+          value = std::pow(value, exponent);
+        }
+        return std::isfinite(value);
+      }
+
+      /**
+       * Parses a numeric literal or a parenthesised expression.
+       * @param value Destination for the evaluated primary expression.
+       * @return True when a complete primary value was parsed successfully.
+       */
+      bool parsePrimary(double &value)
+      {
+        // A primary value is either a parenthesised expression or a floating-point literal
+        skipSpaces();
+        if (consume('(')) {
+          if (!parseExpression(value) || !consume(')')) return false;
+          return true;
+        }
+
+        char *numberEnd{};
+        // strtod also supports decimal and scientific notation
+        value = std::strtod(cursor, &numberEnd);
+        if (numberEnd == cursor) return false;
+        cursor = numberEnd;
+        return std::isfinite(value);
+      }
+
+    public:
+      /**
+       * Creates a parser positioned at the beginning of an expression.
+       * @param expression Expression whose storage remains valid during parsing.
+       */
+      explicit MathExpressionParser(const std::string &expression)
+        : cursor{expression.c_str()}
+      {
+      }
+
+      /**
+       * Evaluates the complete expression and rejects trailing invalid tokens.
+       * @param value Destination for the evaluated result.
+       * @return True when the complete expression is valid and finite.
+       */
+      bool parse(double &value)
+      {
+        // A valid result must consume the complete input except for trailing whitespace
+        if (!parseExpression(value)) return false;
+        skipSpaces();
+        return *cursor == '\0' && std::isfinite(value);
+      }
+  };
+
+  /**
+   * Formats a numeric value using its shortest round-trippable representation.
+   * @tparam T Numeric value type.
+   * @param value Value to format.
+   * @return Text suitable for displaying and parsing again without precision loss.
+   */
+  template<typename T>
+  std::string formatMathValue(T value)
+  {
+    if constexpr (std::is_floating_point_v<T>) {
+      // Normalise negative zero before presenting the confirmed result
+      if (value == static_cast<T>(0)) value = static_cast<T>(0);
+    }
+
+    // The default general format produces the shortest representation that round-trips
+    char buffer[64]{};
+    auto [end, error] = std::to_chars(buffer, buffer + sizeof(buffer), value);
+    if (error == std::errc{}) return std::string(buffer, end);
+    return "0";
+  }
+
+  /**
+   * Converts an evaluated double to a bounded destination numeric type.
+   * @tparam T Destination numeric type.
+   * @param value Evaluated expression result.
+   * @return Truncated when integral and clamped value converted to T.
+   */
+  template<typename T>
+  T convertMathValue(double value)
+  {
+    if constexpr (std::is_integral_v<T>) {
+      // Integer fields follow normal truncation towards zero
+      value = std::trunc(value);
+    }
+
+    // Clamp before casting so large or negative expressions cannot wrap integer fields
+    long double bounded = std::clamp(
+      static_cast<long double>(value),
+      static_cast<long double>(std::numeric_limits<T>::lowest()),
+      static_cast<long double>(std::numeric_limits<T>::max())
+    );
+    return static_cast<T>(bounded);
+  }
+
+  /**
+   * Draws one expression-aware scalar input and updates its value in real time.
+   * @tparam T Numeric value type.
+   * @param label ImGui identifier and optional visible label.
+   * @param value Value updated by valid expressions.
+   * @return True when the calculated value changed during this frame.
+   */
+  template<typename T>
+  bool mathInputScalar(const char *label, T *value)
+  {
+    // Keep one editable expression per concrete widget
+    ImGuiID id = ImGui::GetID(label);
+    auto [stateIt, inserted] = mathInputStates.try_emplace(id);
+    MathInputState &state = stateIt->second;
+    if (inserted || !state.active) {
+      // Inactive fields mirror external changes made by gizmos, scripts or other inspectors
+      state.expression = formatMathValue(*value);
+    }
+
+    // Auto-select preserves the normal behaviour of numeric ImGui inputs on activation
+    bool wasActive = state.active;
+    ImGui::InputText(label, &state.expression, ImGuiInputTextFlags_AutoSelectAll);
+    bool active = ImGui::IsItemActive();
+
+    bool changed = false;
+    double result{};
+    bool valid = MathExpressionParser{state.expression}.parse(result);
+    if ((active || wasActive) && valid) {
+      // Apply every complete intermediate expression so the viewport updates in real time
+      T calculated = convertMathValue<T>(result);
+      if (*value != calculated) {
+        *value = calculated;
+        changed = true;
+      }
+    }
+
+    bool enterPressed = (active || wasActive)
+      && (ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter));
+    bool confirmed = enterPressed || ImGui::IsItemDeactivated();
+    if (confirmed) {
+      // Replace the expression with its calculated value on Enter or focus loss
+      state.expression = formatMathValue(*value);
+      if (active) ImGui::ClearActiveID();
+      active = false;
+    }
+
+    state.active = active;
+    return changed;
+  }
+
+  /**
+   * Draws several scalar expression inputs using the standard ImGui vector layout.
+   * @tparam T Numeric component type.
+   * @param label ImGui identifier shared by the group.
+   * @param values Contiguous component array.
+   * @param components Number of components to draw.
+   * @param input Typed scalar input function.
+   * @return True when at least one component changed during this frame.
+   */
+  template<typename T>
+  bool mathInputScalarN(const char *label, T *values, int components, bool (*input)(const char*, T*))
+  {
+    // Reproduce the standard ImGui multi-component layout with one expression per axis
+    bool changed = false;
+    ImGui::BeginGroup();
+    ImGui::PushID(label);
+    ImGui::PushMultiItemsWidths(components, ImGui::CalcItemWidth());
+    for (int component = 0; component < components; ++component) {
+      ImGui::PushID(component);
+      if (component > 0) ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+      changed |= input("##value", &values[component]);
+      ImGui::PopItemWidth();
+      ImGui::PopID();
+    }
+    ImGui::PopID();
+    ImGui::EndGroup();
+    return changed;
+  }
+}
+
+bool ImGui::MathInputFloat(const char *label, float *value) {
+  // Public typed wrappers share the same parser and interaction state
+  return mathInputScalar(label, value);
+}
+
+bool ImGui::EvaluateMathExpression(const std::string &expression, double &result) {
+  // Expose the parser for custom text fields such as mixed multi-selection values
+  return MathExpressionParser{expression}.parse(result);
+}
+
+bool ImGui::MathInputInt(const char *label, int *value) {
+  return mathInputScalar(label, value);
+}
+
+bool ImGui::MathInputU32(const char *label, uint32_t *value) {
+  return mathInputScalar(label, value);
+}
+
+bool ImGui::MathInputU16(const char *label, uint16_t *value) {
+  return mathInputScalar(label, value);
+}
+
+bool ImGui::MathInputU8(const char *label, uint8_t *value) {
+  return mathInputScalar(label, value);
+}
+
+bool ImGui::MathInputFloatN(const char *label, float *values, int components) {
+  // Build vector inputs from the scalar float implementation
+  return mathInputScalarN(label, values, components, MathInputFloat);
+}
+
+bool ImGui::MathInputIntN(const char *label, int *values, int components) {
+  // Build vector inputs from the scalar integer implementation
+  return mathInputScalarN(label, values, components, MathInputInt);
+}

--- a/src/editor/imgui/mathInput.cpp
+++ b/src/editor/imgui/mathInput.cpp
@@ -3,12 +3,12 @@
 #include "imgui.h"
 #include "imgui_internal.h"
 #include "misc/cpp/imgui_stdlib.h"
+#include "quickjs.h"
 
 #include <algorithm>
 #include <charconv>
 #include <cctype>
 #include <cmath>
-#include <cstdlib>
 #include <limits>
 #include <optional>
 #include <type_traits>
@@ -29,181 +29,132 @@ namespace
   ImGui::MathInputActivity mathInputActivity{};
 
   /**
-   * Parses arithmetic expressions through recursive descent and operator precedence.
+   * Evaluates restricted arithmetic expressions with an isolated QuickJS context.
    */
-  class MathExpressionParser
+  class MathExpressionEvaluator
   {
     private:
-      const char *cursor{};
-      std::optional<double> currentValue{};
+      JSRuntime *runtime{};
+      JSContext *context{};
 
       /**
-       * Advances the parser cursor past consecutive whitespace characters.
+       * Checks that an expression contains only supported arithmetic tokens.
+       * @param expression Expression to validate.
+       * @return True when no JavaScript identifiers or statements are present.
        */
-      void skipSpaces()
+      bool hasOnlyArithmeticTokens(const std::string &expression) const
       {
-        // Whitespace is allowed between every token
-        while (*cursor && std::isspace(static_cast<unsigned char>(*cursor)))
-          ++cursor;
-      }
-
-      /**
-       * Consumes a token when it is the next non-space character.
-       * @param token Character expected at the current parser position.
-       * @return True when the token was found and consumed.
-       */
-      bool consume(char token)
-      {
-        // Advance only when the next non-space character matches the requested token
-        skipSpaces();
-        if (*cursor != token) return false;
-        ++cursor;
+        if (expression.empty() || expression.size() > 1024) return false;
+        for (unsigned char token : expression) {
+          if (std::isdigit(token) || std::isspace(token)) continue;
+          switch (token) {
+            case '.': case '+': case '-': case '*': case '/':
+            case '%': case '^': case '(': case ')': case '#':
+            case 'e': case 'E':
+              break;
+            default:
+              return false;
+          }
+        }
         return true;
-      }
-
-      /**
-       * Parses addition and subtraction expressions.
-       * @param value Destination for the evaluated expression.
-       * @return True when this precedence level was parsed successfully.
-       */
-      bool parseExpression(double &value)
-      {
-        // Addition and subtraction are evaluated after all higher-precedence operations
-        if (!parseTerm(value)) return false;
-        
-        while (true) {
-          if (consume('+')) {
-            double rhs{};
-            if (!parseTerm(rhs)) return false;
-            value += rhs;
-          } else if (consume('-')) {
-            double rhs{};
-            if (!parseTerm(rhs)) return false;
-            value -= rhs;
-          } else {
-            return std::isfinite(value);
-          }
-        }
-      }
-
-      /**
-       * Parses multiplication, division and remainder expressions.
-       * @param value Destination for the evaluated term.
-       * @return True when this precedence level was parsed successfully.
-       */
-      bool parseTerm(double &value)
-      {
-        // Multiplication, division and remainder share precedence and associate to the left
-        if (!parseUnary(value)) return false;
-
-        while (true) {
-          if (consume('*')) {
-            double rhs{};
-            if (!parseUnary(rhs)) return false;
-            value *= rhs;
-          } else if (consume('/')) {
-            double rhs{};
-            // Division by zero invalidates the expression without changing the property
-            if (!parseUnary(rhs) || rhs == 0.0) return false;
-            value /= rhs;
-          } else if (consume('%')) {
-            double rhs{};
-            if (!parseUnary(rhs) || rhs == 0.0) return false;
-            value = std::fmod(value, rhs);
-          } else {
-            return std::isfinite(value);
-          }
-        }
-      }
-
-      /**
-       * Parses recursive unary plus and minus operators.
-       * @param value Destination for the evaluated unary expression.
-       * @return True when this precedence level was parsed successfully.
-       */
-      bool parseUnary(double &value)
-      {
-        // Recursive unary parsing accepts chains such as --2 and preserves power precedence
-        if (consume('+')) return parseUnary(value);
-        if (consume('-')) {
-          if (!parseUnary(value)) return false;
-          value = -value;
-          return true;
-        }
-        return parsePower(value);
-      }
-
-      /**
-       * Parses right-associative exponentiation expressions.
-       * @param value Destination for the evaluated power expression.
-       * @return True when this precedence level was parsed successfully.
-       */
-      bool parsePower(double &value)
-      {
-        // Parsing the exponent through unary makes powers right-associative and allows 2^-2
-        if (!parsePrimary(value)) return false;
-        if (consume('^')) {
-          double exponent{};
-          if (!parseUnary(exponent)) return false;
-          value = std::pow(value, exponent);
-        }
-        return std::isfinite(value);
-      }
-
-      /**
-       * Parses a current-value token, numeric literal or parenthesised expression.
-       * @param value Destination for the evaluated primary expression.
-       * @return True when a complete primary value was parsed successfully.
-       */
-      bool parsePrimary(double &value)
-      {
-        // A primary value can be the supplied current value, a parenthesised expression or a number
-        skipSpaces();
-        if (consume('#')) {
-          if (!currentValue.has_value()) return false;
-          value = *currentValue;
-          return std::isfinite(value);
-        }
-        if (consume('(')) {
-          if (!parseExpression(value) || !consume(')')) return false;
-          return true;
-        }
-
-        char *numberEnd{};
-        // strtod also supports decimal and scientific notation
-        value = std::strtod(cursor, &numberEnd);
-        if (numberEnd == cursor) return false;
-        cursor = numberEnd;
-        return std::isfinite(value);
       }
 
     public:
       /**
-       * Creates a parser positioned at the beginning of an expression.
-       * @param expression Expression whose storage remains valid during parsing.
-       * @param currentValue Optional value substituted for # tokens.
+       * Creates the isolated runtime used by all mathematical inspector inputs.
        */
-      explicit MathExpressionParser(
-        const std::string &expression,
-        std::optional<double> currentValue = std::nullopt
-      )
-        : cursor{expression.c_str()}, currentValue{currentValue}
+      MathExpressionEvaluator()
       {
+        runtime = JS_NewRuntime();
+        if (!runtime) return;
+        JS_SetMemoryLimit(runtime, 1024 * 1024);
+        context = JS_NewContext(runtime);
       }
 
       /**
-       * Evaluates the complete expression and rejects trailing invalid tokens.
-       * @param value Destination for the evaluated result.
-       * @return True when the complete expression is valid and finite.
+       * Releases the private QuickJS context and runtime.
        */
-      bool parse(double &value)
+      ~MathExpressionEvaluator()
       {
-        // A valid result must consume the complete input except for trailing whitespace
-        if (!parseExpression(value)) return false;
-        skipSpaces();
-        return *cursor == '\0' && std::isfinite(value);
+        if (context) JS_FreeContext(context);
+        if (runtime) JS_FreeRuntime(runtime);
+      }
+
+      MathExpressionEvaluator(const MathExpressionEvaluator&) = delete;
+      MathExpressionEvaluator& operator=(const MathExpressionEvaluator&) = delete;
+
+      /**
+       * Evaluates an arithmetic expression and optionally supplies the value represented by #.
+       * @param expression Arithmetic expression to evaluate.
+       * @param value Destination for the finite numeric result.
+       * @param currentValue Optional value substituted for # tokens.
+       * @return True when QuickJS produced a finite number.
+       */
+      bool evaluate(
+        const std::string &expression,
+        double &value,
+        std::optional<double> currentValue = std::nullopt
+      )
+      {
+        if (!context || !hasOnlyArithmeticTokens(expression)) return false;
+
+        std::string jsExpression{};
+        jsExpression.reserve(expression.size() * 2 + 2);
+        jsExpression.push_back('(');
+        for (char token : expression) {
+          if (token == '#') {
+            if (!currentValue.has_value()) return false;
+            jsExpression += "__currentValue";
+          } else if (token == '^') {
+            // JavaScript spells exponentiation as ** while the inspector exposes ^
+            jsExpression += "**";
+          } else {
+            jsExpression.push_back(token);
+          }
+        }
+        jsExpression.push_back(')');
+
+        JSValue global = JS_GetGlobalObject(context);
+        JS_SetPropertyStr(
+          context,
+          global,
+          "__currentValue",
+          JS_NewFloat64(context, currentValue.value_or(0.0))
+        );
+        JS_FreeValue(context, global);
+
+        JSValue result = JS_Eval(
+          context,
+          jsExpression.c_str(),
+          jsExpression.size(),
+          "<math-input>",
+          JS_EVAL_TYPE_GLOBAL
+        );
+        if (JS_IsException(result)) {
+          // Reading the exception clears it before the next live evaluation
+          JSValue exception = JS_GetException(context);
+          JS_FreeValue(context, exception);
+          JS_FreeValue(context, result);
+          return false;
+        }
+
+        bool valid = JS_IsNumber(result)
+          && JS_ToFloat64(context, &value, result) == 0
+          && std::isfinite(value);
+        JS_FreeValue(context, result);
+        return valid;
       }
   };
+
+  /**
+   * Returns the evaluator shared by mathematical inspector inputs.
+   * @return Process-local evaluator instance.
+   */
+  MathExpressionEvaluator& getMathExpressionEvaluator()
+  {
+    static MathExpressionEvaluator evaluator{};
+    return evaluator;
+  }
 
   /**
    * Formats a numeric value using its shortest round-trippable representation.
@@ -279,8 +230,9 @@ namespace
 
     bool changed = false;
     double result{};
-    bool valid = MathExpressionParser{state.expression, state.baseValue}.parse(result);
-    if ((active || wasActive) && valid) {
+    bool valid = (active || wasActive)
+      && getMathExpressionEvaluator().evaluate(state.expression, result, state.baseValue);
+    if (valid) {
       // Apply every complete intermediate expression so the viewport updates in real time
       T calculated = convertMathValue<T>(result);
       if (*value != calculated) {
@@ -340,13 +292,13 @@ ImGui::MathInputActivity ImGui::GetMathInputActivity() {
 }
 
 bool ImGui::MathInputFloat(const char *label, float *value) {
-  // Public typed wrappers share the same parser and interaction state
+  // Public typed wrappers share the same evaluator and interaction state
   return mathInputScalar(label, value);
 }
 
 bool ImGui::EvaluateMathExpression(const std::string &expression, double &result) {
-  // Expose the parser for custom text fields such as mixed multi-selection values
-  return MathExpressionParser{expression}.parse(result);
+  // Expose the evaluator for custom text fields such as mixed multi-selection values
+  return getMathExpressionEvaluator().evaluate(expression, result);
 }
 
 bool ImGui::EvaluateMathExpression(
@@ -355,7 +307,7 @@ bool ImGui::EvaluateMathExpression(
   double currentValue
 ) {
   // Supply the per-object base value used by # during multi-selection edits
-  return MathExpressionParser{expression, currentValue}.parse(result);
+  return getMathExpressionEvaluator().evaluate(expression, result, currentValue);
 }
 
 bool ImGui::MathInputInt(const char *label, int *value) {

--- a/src/editor/imgui/mathInput.cpp
+++ b/src/editor/imgui/mathInput.cpp
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <limits>
+#include <optional>
 #include <type_traits>
 #include <unordered_map>
 
@@ -19,6 +20,7 @@ namespace
   struct MathInputState
   {
     std::string expression{};
+    double baseValue{};
     bool active{false};
   };
 
@@ -33,6 +35,7 @@ namespace
   {
     private:
       const char *cursor{};
+      std::optional<double> currentValue{};
 
       /**
        * Advances the parser cursor past consecutive whitespace characters.
@@ -148,14 +151,19 @@ namespace
       }
 
       /**
-       * Parses a numeric literal or a parenthesised expression.
+       * Parses a current-value token, numeric literal or parenthesised expression.
        * @param value Destination for the evaluated primary expression.
        * @return True when a complete primary value was parsed successfully.
        */
       bool parsePrimary(double &value)
       {
-        // A primary value is either a parenthesised expression or a floating-point literal
+        // A primary value can be the supplied current value, a parenthesised expression or a number
         skipSpaces();
+        if (consume('#')) {
+          if (!currentValue.has_value()) return false;
+          value = *currentValue;
+          return std::isfinite(value);
+        }
         if (consume('(')) {
           if (!parseExpression(value) || !consume(')')) return false;
           return true;
@@ -173,9 +181,13 @@ namespace
       /**
        * Creates a parser positioned at the beginning of an expression.
        * @param expression Expression whose storage remains valid during parsing.
+       * @param currentValue Optional value substituted for # tokens.
        */
-      explicit MathExpressionParser(const std::string &expression)
-        : cursor{expression.c_str()}
+      explicit MathExpressionParser(
+        const std::string &expression,
+        std::optional<double> currentValue = std::nullopt
+      )
+        : cursor{expression.c_str()}, currentValue{currentValue}
       {
       }
 
@@ -257,6 +269,7 @@ namespace
     if (inserted || !state.active) {
       // Inactive fields mirror external changes made by gizmos, scripts or other inspectors
       state.expression = formatMathValue(*value);
+      state.baseValue = static_cast<double>(*value);
     }
 
     // Auto-select preserves the normal behaviour of numeric ImGui inputs on activation
@@ -266,7 +279,7 @@ namespace
 
     bool changed = false;
     double result{};
-    bool valid = MathExpressionParser{state.expression}.parse(result);
+    bool valid = MathExpressionParser{state.expression, state.baseValue}.parse(result);
     if ((active || wasActive) && valid) {
       // Apply every complete intermediate expression so the viewport updates in real time
       T calculated = convertMathValue<T>(result);
@@ -334,6 +347,15 @@ bool ImGui::MathInputFloat(const char *label, float *value) {
 bool ImGui::EvaluateMathExpression(const std::string &expression, double &result) {
   // Expose the parser for custom text fields such as mixed multi-selection values
   return MathExpressionParser{expression}.parse(result);
+}
+
+bool ImGui::EvaluateMathExpression(
+  const std::string &expression,
+  double &result,
+  double currentValue
+) {
+  // Supply the per-object base value used by # during multi-selection edits
+  return MathExpressionParser{expression, currentValue}.parse(result);
 }
 
 bool ImGui::MathInputInt(const char *label, int *value) {

--- a/src/editor/imgui/mathInput.h
+++ b/src/editor/imgui/mathInput.h
@@ -30,6 +30,15 @@ namespace ImGui
   bool EvaluateMathExpression(const std::string &expression, double &result);
 
   /**
+   * Evaluates a mathematical expression using # as the supplied current value.
+   * @param expression Expression to evaluate.
+   * @param result Destination for the calculated value.
+   * @param currentValue Value substituted for every # token.
+   * @return True when the complete expression is valid.
+   */
+  bool EvaluateMathExpression(const std::string &expression, double &result, double currentValue);
+
+  /**
    * Draws a floating-point input that evaluates mathematical expressions in real time.
    * @param label ImGui identifier and optional visible label.
    * @param value Floating-point value updated with valid expression results.

--- a/src/editor/imgui/mathInput.h
+++ b/src/editor/imgui/mathInput.h
@@ -9,6 +9,18 @@
 
 namespace ImGui
 {
+  struct MathInputActivity
+  {
+    uint64_t uses{};
+    uint64_t confirmations{};
+  };
+
+  /**
+   * Returns counters used to distinguish live previews from confirmed mathematical inputs.
+   * @return Current mathematical input activity counters.
+   */
+  MathInputActivity GetMathInputActivity();
+
   /**
    * Evaluates a mathematical expression containing arithmetic operators and parentheses.
    * @param expression Expression to evaluate.

--- a/src/editor/imgui/mathInput.h
+++ b/src/editor/imgui/mathInput.h
@@ -1,0 +1,77 @@
+/**
+* @copyright 2025 - Max Bebök
+* @license MIT
+*/
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace ImGui
+{
+  /**
+   * Evaluates a mathematical expression containing arithmetic operators and parentheses.
+   * @param expression Expression to evaluate.
+   * @param result Destination for the calculated value.
+   * @return True when the complete expression is valid.
+   */
+  bool EvaluateMathExpression(const std::string &expression, double &result);
+
+  /**
+   * Draws a floating-point input that evaluates mathematical expressions in real time.
+   * @param label ImGui identifier and optional visible label.
+   * @param value Floating-point value updated with valid expression results.
+   * @return True when the calculated value changed during this frame.
+   */
+  bool MathInputFloat(const char *label, float *value);
+
+  /**
+   * Draws an integer input that evaluates mathematical expressions in real time.
+   * @param label ImGui identifier and optional visible label.
+   * @param value Integer value updated with valid expression results.
+   * @return True when the calculated value changed during this frame.
+   */
+  bool MathInputInt(const char *label, int *value);
+
+  /**
+   * Draws an unsigned 32-bit input that evaluates mathematical expressions in real time.
+   * @param label ImGui identifier and optional visible label.
+   * @param value Unsigned value updated with clamped valid expression results.
+   * @return True when the calculated value changed during this frame.
+   */
+  bool MathInputU32(const char *label, uint32_t *value);
+
+  /**
+   * Draws an unsigned 16-bit input that evaluates mathematical expressions in real time.
+   * @param label ImGui identifier and optional visible label.
+   * @param value Unsigned value updated with clamped valid expression results.
+   * @return True when the calculated value changed during this frame.
+   */
+  bool MathInputU16(const char *label, uint16_t *value);
+
+  /**
+   * Draws an unsigned 8-bit input that evaluates mathematical expressions in real time.
+   * @param label ImGui identifier and optional visible label.
+   * @param value Unsigned value updated with clamped valid expression results.
+   * @return True when the calculated value changed during this frame.
+   */
+  bool MathInputU8(const char *label, uint8_t *value);
+
+  /**
+   * Draws multiple floating-point expression inputs in a standard vector layout.
+   * @param label ImGui identifier shared by the complete vector input.
+   * @param values Contiguous floating-point component array.
+   * @param components Number of components to draw.
+   * @return True when at least one calculated component changed during this frame.
+   */
+  bool MathInputFloatN(const char *label, float *values, int components);
+
+  /**
+   * Draws multiple integer expression inputs in a standard vector layout.
+   * @param label ImGui identifier shared by the complete vector input.
+   * @param values Contiguous integer component array.
+   * @param components Number of components to draw.
+   * @return True when at least one calculated component changed during this frame.
+   */
+  bool MathInputIntN(const char *label, int *values, int components);
+}

--- a/src/editor/pages/parts/objectInspector.cpp
+++ b/src/editor/pages/parts/objectInspector.cpp
@@ -11,7 +11,6 @@
 #include <functional>
 #include <iterator>
 #include <optional>
-#include <sstream>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -304,27 +303,6 @@ void Editor::ObjectInspector::draw() {
 
     static std::unordered_map<std::string, std::string> mixedValueCache{};
 
-    auto parseFloatList = [](const std::string &text, float *out, int count) {
-      std::string cleaned = text;
-      for (auto &ch : cleaned) {
-        if (ch == ',' || ch == ';' || ch == '(' || ch == ')' || ch == '[' || ch == ']') {
-          ch = ' ';
-        }
-      }
-
-      std::stringstream stream(cleaned);
-      for (int i = 0; i < count; ++i) {
-        if (!(stream >> out[i])) {
-          return false;
-        }
-      }
-      return true;
-    };
-
-    auto parseFloat = [&](const std::string &text, float &out) {
-      return parseFloatList(text, &out, 1);
-    };
-
     if (ImGui::CollapsingHeader("General", ImGuiTreeNodeFlags_DefaultOpen)) {
       if (ImTable::start("General", nullptr)) {
         bool mixedName = false;
@@ -437,18 +415,21 @@ void Editor::ObjectInspector::draw() {
           ImGui::SetNextItemWidth(width);
           if (mixed) {
             auto &text = mixedValueCache[inputId];
-            ImGui::InputTextWithHint(inputId.c_str(), "-", &text);
+            bool edited = ImGui::InputTextWithHint(inputId.c_str(), "-", &text);
             handleHistory(snapshotLabel);
-            if (ImGui::IsItemDeactivatedAfterEdit()) {
-              float parsed = value;
-              if (parseFloat(text, parsed)) {
+            if (edited) {
+              double result{};
+              if (ImGui::EvaluateMathExpression(text, result)) {
+                float parsed = static_cast<float>(result);
                 value = parsed;
                 applyValue(parsed);
               }
+            }
+            if (ImGui::IsItemDeactivatedAfterEdit()) {
               text.clear();
             }
           } else {
-            if (ImGui::InputFloat(inputId.c_str(), &value)) {
+            if (ImGui::MathInputFloat(inputId.c_str(), &value)) {
               applyValue(value);
             }
             handleHistory(snapshotLabel);
@@ -629,7 +610,7 @@ void Editor::ObjectInspector::draw() {
         std::function<bool(glm::vec3*)> cb = [](glm::vec3 *val) -> bool {
           glm::vec3 scale = *val;
           if (scale == glm::vec3(0,0,0)) {
-            if (!ImGui::InputFloat3("##", glm::value_ptr(*val))) return false;
+            if (!ImGui::MathInputFloatN("##", glm::value_ptr(*val), 3)) return false;
             *val = glm::vec3(val->x + val->y + val->z);
             return true;
           }
@@ -641,7 +622,7 @@ void Editor::ObjectInspector::draw() {
             if (i > 0) ImGui::SameLine(0, g.Style.ItemInnerSpacing.x);
             bool isZero = glm::abs(scale[i]) < 0.0001f;
             if (isZero) ImGui::BeginDisabled();
-            if (ImGui::InputFloat("", &(*val)[i])) ratio = (*val)[i] / scale[i];
+            if (ImGui::MathInputFloat("", &(*val)[i])) ratio = (*val)[i] / scale[i];
             if (isZero) ImGui::EndDisabled();
             ImGui::PopID();
             ImGui::PopItemWidth();

--- a/src/editor/pages/parts/objectInspector.cpp
+++ b/src/editor/pages/parts/objectInspector.cpp
@@ -429,10 +429,14 @@ void Editor::ObjectInspector::draw() {
               text.clear();
             }
           } else {
+            auto mathInputBefore = ImGui::GetMathInputActivity();
             if (ImGui::MathInputFloat(inputId.c_str(), &value)) {
               applyValue(value);
             }
-            handleHistory(snapshotLabel);
+            auto mathInputAfter = ImGui::GetMathInputActivity();
+            // Expression confirmed --> Record one undo step
+            if (mathInputAfter.confirmations != mathInputBefore.confirmations)
+              Editor::UndoRedo::getHistory().markChanged(snapshotLabel);
           }
         };
 

--- a/src/editor/pages/parts/objectInspector.cpp
+++ b/src/editor/pages/parts/objectInspector.cpp
@@ -302,6 +302,7 @@ void Editor::ObjectInspector::draw() {
     };
 
     static std::unordered_map<std::string, std::string> mixedValueCache{};
+    static std::unordered_map<std::string, std::vector<float>> mixedValueBaselines{};
 
     if (ImGui::CollapsingHeader("General", ImGuiTreeNodeFlags_DefaultOpen)) {
       if (ImTable::start("General", nullptr)) {
@@ -360,8 +361,18 @@ void Editor::ObjectInspector::draw() {
           if (!floatEqual(rot.w, rotValue.w)) mixedRot[3] = true;
         }
 
-        auto applyVec3Component = [&](Property<glm::vec3> Project::Object::*prop, int index, float value) {
+        auto collectVec3Component = [&](Property<glm::vec3> Project::Object::*prop, int index) {
+          std::vector<float> values{};
+          values.reserve(selectedObjects.size());
           for (auto *selObj : selectedObjects) {
+            values.push_back((selObj->*prop).resolve(selObj->propOverrides)[index]);
+          }
+          return values;
+        };
+
+        auto applyVec3Component = [&](Property<glm::vec3> Project::Object::*prop, int index, const std::vector<float> &values) {
+          for (size_t objectIndex = 0; objectIndex < selectedObjects.size(); ++objectIndex) {
+            auto *selObj = selectedObjects[objectIndex];
             bool createdOverride = false;
             glm::vec3 resolvedBefore = (selObj->*prop).resolve(selObj->propOverrides);
             if (selObj->isPrefabInstance()
@@ -375,14 +386,22 @@ void Editor::ObjectInspector::draw() {
             if (createdOverride) {
               vec = resolvedBefore;
             }
-            if (index == 0) vec.x = value;
-            if (index == 1) vec.y = value;
-            if (index == 2) vec.z = value;
+            vec[index] = values[objectIndex];
           }
         };
 
-        auto applyQuatComponent = [&](Property<glm::quat> Project::Object::*prop, int index, float value) {
+        auto collectQuatComponent = [&](Property<glm::quat> Project::Object::*prop, int index) {
+          std::vector<float> values{};
+          values.reserve(selectedObjects.size());
           for (auto *selObj : selectedObjects) {
+            values.push_back((selObj->*prop).resolve(selObj->propOverrides)[index]);
+          }
+          return values;
+        };
+
+        auto applyQuatComponent = [&](Property<glm::quat> Project::Object::*prop, int index, const std::vector<float> &values) {
+          for (size_t objectIndex = 0; objectIndex < selectedObjects.size(); ++objectIndex) {
+            auto *selObj = selectedObjects[objectIndex];
             bool createdOverride = false;
             glm::quat resolvedBefore = (selObj->*prop).resolve(selObj->propOverrides);
             if (selObj->isPrefabInstance()
@@ -396,10 +415,7 @@ void Editor::ObjectInspector::draw() {
             if (createdOverride) {
               quat = resolvedBefore;
             }
-            if (index == 0) quat.x = value;
-            if (index == 1) quat.y = value;
-            if (index == 2) quat.z = value;
-            if (index == 3) quat.w = value;
+            quat[index] = values[objectIndex];
           }
         };
 
@@ -409,29 +425,48 @@ void Editor::ObjectInspector::draw() {
           float &value,
           float width,
           const std::string &snapshotLabel,
-          const std::function<void(float)> &applyValue
+          const std::function<std::vector<float>()> &collectValues,
+          const std::function<void(const std::vector<float>&)> &applyValues
         ) {
           std::string inputId = std::string{"##Value_"} + widgetKey;
           ImGui::SetNextItemWidth(width);
-          if (mixed) {
+          auto baselineIt = mixedValueBaselines.find(inputId);
+          bool mixedEditActive = baselineIt != mixedValueBaselines.end() && !baselineIt->second.empty();
+          if (mixed || mixedEditActive) {
             auto &text = mixedValueCache[inputId];
             bool edited = ImGui::InputTextWithHint(inputId.c_str(), "-", &text);
+            auto &baseline = mixedValueBaselines[inputId];
+            if (ImGui::IsItemActivated()
+                || (ImGui::IsItemActive() && baseline.size() != selectedObjects.size())) {
+              // Capture one stable value per object so live previews never compound # expressions
+              baseline = collectValues();
+            }
             handleHistory(snapshotLabel);
             if (edited) {
-              double result{};
-              if (ImGui::EvaluateMathExpression(text, result)) {
-                float parsed = static_cast<float>(result);
-                value = parsed;
-                applyValue(parsed);
+              std::vector<float> calculatedValues{};
+              calculatedValues.reserve(baseline.size());
+              bool valid = true;
+              for (float baseValue : baseline) {
+                double result{};
+                if (!ImGui::EvaluateMathExpression(text, result, baseValue)) {
+                  valid = false;
+                  break;
+                }
+                calculatedValues.push_back(static_cast<float>(result));
+              }
+              if (valid && !calculatedValues.empty()) {
+                value = calculatedValues.front();
+                applyValues(calculatedValues);
               }
             }
             if (ImGui::IsItemDeactivatedAfterEdit()) {
               text.clear();
+              baseline.clear();
             }
           } else {
             auto mathInputBefore = ImGui::GetMathInputActivity();
             if (ImGui::MathInputFloat(inputId.c_str(), &value)) {
-              applyValue(value);
+              applyValues(std::vector<float>(selectedObjects.size(), value));
             }
             auto mathInputAfter = ImGui::GetMathInputActivity();
             // Expression confirmed --> Record one undo step
@@ -440,56 +475,68 @@ void Editor::ObjectInspector::draw() {
           }
         };
 
+        auto drawVec3Field = [&](\
+          const char *widgetKey,
+          bool mixed,
+          float &value,
+          float width,
+          const std::string &snapshotLabel,
+          Property<glm::vec3> Project::Object::*prop,
+          int index
+        ) {
+          drawFloatField(
+            widgetKey, mixed, value, width, snapshotLabel,
+            [&]() { return collectVec3Component(prop, index); },
+            [&](const std::vector<float> &values) { applyVec3Component(prop, index, values); }
+          );
+        };
+
+        auto drawQuatField = [&](\
+          const char *widgetKey,
+          bool mixed,
+          float &value,
+          float width,
+          const std::string &snapshotLabel,
+          Property<glm::quat> Project::Object::*prop,
+          int index
+        ) {
+          drawFloatField(
+            widgetKey, mixed, value, width, snapshotLabel,
+            [&]() { return collectQuatComponent(prop, index); },
+            [&](const std::vector<float> &values) { applyQuatComponent(prop, index, values); }
+          );
+        };
+
         ImTable::add("Position");
         ImGui::PushID("Position");
         float posWidth = (ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x * 2.0f) / 3.0f;
-        drawFloatField("PosX", mixedPos[0], posValue.x, posWidth, "Edit Position", [&](float val) {
-          applyVec3Component(&Project::Object::pos, 0, val);
-        });
+        drawVec3Field("PosX", mixedPos[0], posValue.x, posWidth, "Edit Position", &Project::Object::pos, 0);
         ImGui::SameLine();
-        drawFloatField("PosY", mixedPos[1], posValue.y, posWidth, "Edit Position", [&](float val) {
-          applyVec3Component(&Project::Object::pos, 1, val);
-        });
+        drawVec3Field("PosY", mixedPos[1], posValue.y, posWidth, "Edit Position", &Project::Object::pos, 1);
         ImGui::SameLine();
-        drawFloatField("PosZ", mixedPos[2], posValue.z, posWidth, "Edit Position", [&](float val) {
-          applyVec3Component(&Project::Object::pos, 2, val);
-        });
+        drawVec3Field("PosZ", mixedPos[2], posValue.z, posWidth, "Edit Position", &Project::Object::pos, 2);
         ImGui::PopID();
 
         ImTable::add("Rotation");
         ImGui::PushID("Rotation");
         float rotWidth = (ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x * 3.0f) / 4.0f;
-        drawFloatField("RotX", mixedRot[0], rotValue.x, rotWidth, "Edit Rotation", [&](float val) {
-          applyQuatComponent(&Project::Object::rot, 0, val);
-        });
+        drawQuatField("RotX", mixedRot[0], rotValue.x, rotWidth, "Edit Rotation", &Project::Object::rot, 0);
         ImGui::SameLine();
-        drawFloatField("RotY", mixedRot[1], rotValue.y, rotWidth, "Edit Rotation", [&](float val) {
-          applyQuatComponent(&Project::Object::rot, 1, val);
-        });
+        drawQuatField("RotY", mixedRot[1], rotValue.y, rotWidth, "Edit Rotation", &Project::Object::rot, 1);
         ImGui::SameLine();
-        drawFloatField("RotZ", mixedRot[2], rotValue.z, rotWidth, "Edit Rotation", [&](float val) {
-          applyQuatComponent(&Project::Object::rot, 2, val);
-        });
+        drawQuatField("RotZ", mixedRot[2], rotValue.z, rotWidth, "Edit Rotation", &Project::Object::rot, 2);
         ImGui::SameLine();
-        drawFloatField("RotW", mixedRot[3], rotValue.w, rotWidth, "Edit Rotation", [&](float val) {
-          applyQuatComponent(&Project::Object::rot, 3, val);
-        });
+        drawQuatField("RotW", mixedRot[3], rotValue.w, rotWidth, "Edit Rotation", &Project::Object::rot, 3);
         ImGui::PopID();
 
         ImTable::add("Scale");
         ImGui::PushID("Scale");
         float scaleWidth = (ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x * 2.0f) / 3.0f;
-        drawFloatField("ScaleX", mixedScale[0], scaleValue.x, scaleWidth, "Edit Scale", [&](float val) {
-          applyVec3Component(&Project::Object::scale, 0, val);
-        });
+        drawVec3Field("ScaleX", mixedScale[0], scaleValue.x, scaleWidth, "Edit Scale", &Project::Object::scale, 0);
         ImGui::SameLine();
-        drawFloatField("ScaleY", mixedScale[1], scaleValue.y, scaleWidth, "Edit Scale", [&](float val) {
-          applyVec3Component(&Project::Object::scale, 1, val);
-        });
+        drawVec3Field("ScaleY", mixedScale[1], scaleValue.y, scaleWidth, "Edit Scale", &Project::Object::scale, 1);
         ImGui::SameLine();
-        drawFloatField("ScaleZ", mixedScale[2], scaleValue.z, scaleWidth, "Edit Scale", [&](float val) {
-          applyVec3Component(&Project::Object::scale, 2, val);
-        });
+        drawVec3Field("ScaleZ", mixedScale[2], scaleValue.z, scaleWidth, "Edit Scale", &Project::Object::scale, 2);
         ImGui::PopID();
 
         ImTable::end();

--- a/src/project/component/types/compCode.cpp
+++ b/src/project/component/types/compCode.cpp
@@ -230,7 +230,7 @@ namespace Project::Component::Code
             ImTable::addObjProp<std::string>(name, prop, [&](std::string *val) -> bool {
               auto values = Utils::parseFloatList(*val);
               values.resize(3, 0.0f);
-              if (ImGui::InputFloat3("##", values.data())) {
+              if (ImGui::MathInputFloatN("##", values.data(), 3)) {
                 *val = Utils::floatListToString(values.data(), 3);
                 return true;
               }
@@ -241,7 +241,7 @@ namespace Project::Component::Code
               auto values = Utils::parseFloatList(*val);
               if (values.empty()) values = {0,0,0,1};
               values.resize(4, 0.0f);
-              if (ImGui::InputFloat4("##", values.data())) {
+              if (ImGui::MathInputFloatN("##", values.data(), 4)) {
                 *val = Utils::floatListToString(values.data(), 4);
                 return true;
               }

--- a/src/project/component/types/compNodeGraph.cpp
+++ b/src/project/component/types/compNodeGraph.cpp
@@ -230,20 +230,20 @@ namespace Project::Component::NodeGraph
             ImTable::add(var.name);
             float v = def.is_number() ? def.get<float>() : 0.0f;
             ImGui::SetNextItemWidth(-1);
-            if(ImGui::InputFloat("##v", &v)) def = v;
+            if(ImGui::MathInputFloat("##v", &v)) def = v;
           } else if(var.type == "vec3" || var.type == "vec4") {
             int n = (var.type == "vec4") ? 4 : 3;
             float v[4] = {0,0,0,0};
             for(int i=0;i<n;++i) if(def.is_array() && (size_t)i<def.size() && def[i].is_number()) v[i]=def[i].get<float>();
             ImTable::add(var.name);
             ImGui::SetNextItemWidth(-1);
-            bool ch = (n == 4) ? ImGui::InputFloat4("##v", v) : ImGui::InputFloat3("##v", v);
+            bool ch = ImGui::MathInputFloatN("##v", v, n);
             if(ch) { def = nlohmann::json::array(); for(int i=0;i<n;++i) def.push_back(v[i]); }
           } else { // i32 / u32: integer field
             ImTable::add(var.name);
             int v = def.is_number() ? def.get<int>() : 0;
             ImGui::SetNextItemWidth(-1);
-            if(ImGui::InputInt("##v", &v)) def = v;
+            if(ImGui::MathInputInt("##v", &v)) def = v;
           }
           ImGui::PopID();
         }


### PR DESCRIPTION
## Summary
Allows mathematical operations on the numeric inputs of the object inspector.
Allowed operators:
 - Addition: +
 - Subtraction: -
 - Multiplication: *
 - Division: /
 - Power: ^ or **
 - Remainder: %.

Also allows using parenthesis.
Allows to use "#" as a wildcard for multiple selection with different values, taking into account the current value of every object individually.

<img width="356" height="187" alt="image" src="https://github.com/user-attachments/assets/4bdedb8f-10bc-491b-9b6c-c6fa7061a9d2" />

## Notes
I have removed the function objectInspector.parseFloatList(), as it would potentially conflict with this feature and would make the code more complex. Could still be possible, as it uses commas and semicolons, which don't conflict, but parenthesis do.
Furthermore, now it is possible to specify the 3 fields of fm_vec3_t from the inspector as individual fields, so I think it is not necessary anymore.
So after these changes it is not possible to use expressions to set several float values as:
(1, 2, 3)
[1; 2; 3]