### PR TITLE
Add projection settings camera component (Ortho / Perspective)

### DIFF
--- a/docs/docs/manual/editor/components/camera.md
+++ b/docs/docs/manual/editor/components/camera.md
@@ -12,12 +12,28 @@ Multiple cameras can be active at once (e.g. for split-screen).
 | Option | Description |
 |--------|-------------|
 | **Controlled** | How the camera transform is driven:<br>• **Manually**: you set the camera position/rotation yourself (e.g. from a script).<br>• **By Object**: the camera follows the object's transform. |
+| **Projection** | How the scene is projected:<br>• **Perspective**: objects get smaller with distance, configured via **FOV**.<br>• **Orthographic**: no perspective distortion (e.g. for isometric or 2D games), configured via **Ortho Size**. |
 | **Offset** | The viewport's top-left offset on screen, in pixels. |
 | **Size** | The viewport's size on screen, in pixels. |
-| **FOV** | Vertical field of view, in degrees. |
+| **FOV** | Vertical field of view, in degrees. Only used in perspective mode. |
+| **Ortho Size** | Vertical half-size of the visible area, in world units. The horizontal size is derived from it via the aspect ratio. Only used in orthographic mode. |
 | **Near** | Near clip plane distance. |
 | **Far** | Far clip plane distance. |
 | **Aspect** | Aspect ratio used for the projection. |
+
+## Switching the projection at runtime
+
+The projection can be changed while the game is running:
+
+```cpp
+auto* cam = obj.getComponent<P64::Comp::Camera>();
+
+cam->setOrthographic(300.0f);                 // switch to ortho with a given size
+cam->setPerspective(T3D_DEG_TO_RAD(65.0f));   // switch to perspective with a given fov
+
+// or toggle without touching the fov / ortho-size:
+cam->setProjection(P64::Comp::Camera::Projection::ORTHOGRAPHIC);
+```
 
 ## See also
 

--- a/n64/engine/include/scene/camera.h
+++ b/n64/engine/include/scene/camera.h
@@ -13,6 +13,13 @@ namespace P64
 {
   class Camera
   {
+    public:
+      enum class Projection : uint8_t
+      {
+        PERSPECTIVE = 0,
+        ORTHOGRAPHIC = 1,
+      };
+
     private:
       T3DViewport viewports{};
       fm_mat4_t viewMatrix{};
@@ -22,10 +29,14 @@ namespace P64
 
       uint8_t needsProjUpdate{false};
     public:
-      float fov{};
+      float fov{}; // FOV in radians, only used in perspective mode
       float near{};
       float far{};
       float aspectRatio{};
+      // Vertical half-size of the view volume in world units, only used in orthographic mode.
+      // The horizontal half-size is derived from it via aspectRatio.
+      float orthoSize{};
+      Projection projection{Projection::PERSPECTIVE};
 
       Camera();
       CLASS_NO_COPY_MOVE(Camera);
@@ -47,6 +58,34 @@ namespace P64
       }
 
       void setScreenArea(int x, int y, int width, int height);
+
+      /**
+       * Switches the camera over to a perspective projection.
+       * @param newFov vertical fov in radians
+       */
+      void setPerspective(float newFov) {
+        fov = newFov;
+        projection = Projection::PERSPECTIVE;
+      }
+
+      /**
+       * Switches the camera over to an orthographic projection.
+       * @param newOrthoSize vertical half-size of the view volume in world units
+       */
+      void setOrthographic(float newOrthoSize) {
+        orthoSize = newOrthoSize;
+        projection = Projection::ORTHOGRAPHIC;
+      }
+
+      /**
+       * Switches between perspective and orthographic projection,
+       * keeping the settings (fov / ortho-size) of both.
+       */
+      void setProjection(Projection newProjection) {
+        projection = newProjection;
+      }
+
+      [[nodiscard]] Projection getProjection() const { return projection; }
 
       /**
        * Sets new camera values based on a look-at transform.

--- a/n64/engine/include/scene/components/camera.h
+++ b/n64/engine/include/scene/components/camera.h
@@ -21,6 +21,8 @@ namespace P64::Comp
       OBJECT = 1,
     };
 
+    using Projection = P64::Camera::Projection;
+
     struct InitData
     {
       int vpOffset[2];
@@ -29,11 +31,33 @@ namespace P64::Comp
       float near;
       float far;
       float aspectRatio;
+      float orthoSize;
       Mode mode;
+      Projection projection;
     };
 
     P64::Camera camera{};
     Mode mode;
+
+    /**
+     * Switches the camera over to a perspective projection.
+     * @param fov vertical fov in radians
+     */
+    void setPerspective(float fov) { camera.setPerspective(fov); }
+
+    /**
+     * Switches the camera over to an orthographic projection.
+     * @param orthoSize vertical half-size of the view volume in world units
+     */
+    void setOrthographic(float orthoSize) { camera.setOrthographic(orthoSize); }
+
+    /**
+     * Switches between perspective and orthographic projection,
+     * keeping the settings (fov / ortho-size) of both.
+     */
+    void setProjection(Projection projection) { camera.setProjection(projection); }
+
+    [[nodiscard]] Projection getProjection() const { return camera.getProjection(); }
 
     static uint32_t getAllocSize([[maybe_unused]] InitData* initData)
     {

--- a/n64/engine/src/scene/camera.cpp
+++ b/n64/engine/src/scene/camera.cpp
@@ -22,7 +22,13 @@ P64::Camera::~Camera() {
 
 void P64::Camera::update([[maybe_unused]] float deltaTime)
 {
-  t3d_viewport_set_perspective(&viewports, fov, aspectRatio, near, far);
+  if(projection == Projection::ORTHOGRAPHIC) {
+    float halfHeight = orthoSize;
+    float halfWidth = orthoSize * aspectRatio;
+    t3d_viewport_set_ortho(&viewports, -halfWidth, halfWidth, -halfHeight, halfHeight, near, far);
+  } else {
+    t3d_viewport_set_perspective(&viewports, fov, aspectRatio, near, far);
+  }
   t3d_viewport_set_view_matrix(&viewports, &viewMatrix);
 }
 

--- a/n64/engine/src/scene/components/camera.cpp
+++ b/n64/engine/src/scene/components/camera.cpp
@@ -24,6 +24,8 @@ void P64::Comp::Camera::initDelete(Object &obj, Camera* data, InitData* initData
   cam.fov  = initData->fov;
   cam.near = initData->near;
   cam.far  = initData->far;
+  cam.orthoSize = initData->orthoSize;
+  cam.projection = initData->projection;
 
   cam.aspectRatio = initData->aspectRatio;
   if(cam.aspectRatio <= 0) {

--- a/src/editor/pages/parts/viewport3D.cpp
+++ b/src/editor/pages/parts/viewport3D.cpp
@@ -582,15 +582,19 @@ void Editor::Viewport3D::onRenderPass(SDL_GPUCommandBuffer* cmdBuff, Renderer::S
 
     // hack to get thicker lines with AA, just draw again with a 1px offset in screen-space
     if(ctx.prefs.renderFactorAA > 1.0f) {
-      auto oldMat = uniGlobal.projMat[2];
-      uniGlobal.projMat[2][0] += 1.0f / uniGlobal.screenSize.x;
-      uniGlobal.projMat[2][1] -= 1.0f / uniGlobal.screenSize.y;
+      // the depth column only yields a constant offset under perspective, where 'w' is -viewZ.
+      // in ortho 'w' is 1, which would scale the offset by depth, so shift the position column.
+      int col = camera.isOrtho ? 3 : 2;
+      float dir = camera.isOrtho ? -1.0f : 1.0f;
+      auto oldMat = uniGlobal.projMat[col];
+      uniGlobal.projMat[col][0] += dir / uniGlobal.screenSize.x;
+      uniGlobal.projMat[col][1] -= dir / uniGlobal.screenSize.y;
       SDL_PushGPUVertexUniformData(cmdBuff, 0, &uniGlobal, sizeof(uniGlobal));
 
       if(showGrid)objGrid.draw(renderPass3D, cmdBuff);
       objLines.draw(renderPass3D, cmdBuff);
 
-      uniGlobal.projMat[2] = oldMat;
+      uniGlobal.projMat[col] = oldMat;
       SDL_PushGPUVertexUniformData(cmdBuff, 0, &uniGlobal, sizeof(uniGlobal));
     }
     if(ctx.debugMode)SDL_PopGPUDebugGroup(cmdBuff);

--- a/src/editor/pages/parts/viewport3D.cpp
+++ b/src/editor/pages/parts/viewport3D.cpp
@@ -745,6 +745,8 @@ void Editor::Viewport3D::draw()
           camera.pos = camObj->pos.resolve(camObj->propOverrides);
           camera.rot = glm::normalize(camObj->rot.resolve(camObj->propOverrides));
           camera.fov = camView.fov;
+          camera.isOrtho = camView.isOrtho;
+          camera.orthoSize = camView.orthoSize;
           camera.velocity = {0,0,0};
           camera.zoomSpeed = 0.0f;
           camLocked = true;
@@ -756,7 +758,11 @@ void Editor::Viewport3D::draw()
       boundCameraUUID = 0; // bound object no longer exists
     }
   }
-  if(!camLocked) camera.fov = 70.0f; // restore the editor default when free-flying
+  if(!camLocked) { // restore the editor defaults when free-flying
+    camera.fov = 70.0f;
+    camera.orthoSize = Renderer::Camera::DEFAULT_ORTHO_SIZE;
+    camera.isOrtho = freeFlyOrtho;
+  }
 
   // Displayed image size; letterboxed to the camera aspect when locked, otherwise fills the area.
   ImVec2 viewSize = availSize;
@@ -910,7 +916,9 @@ void Editor::Viewport3D::draw()
   {
     if(ImGui::IsKeyPressed(ctx.prefs.keymap.toggleOrtho))
     {
-      camera.isOrtho = !camera.isOrtho;
+      freeFlyOrtho = !freeFlyOrtho;
+      // while bound to a camera the projection is mirrored from it, in that case don't fight it
+      if(!camLocked)camera.isOrtho = freeFlyOrtho;
     }
 
     // Handle object deletion when Delete is pressed while the viewport is focused and an object is selected

--- a/src/editor/pages/parts/viewport3D.h
+++ b/src/editor/pages/parts/viewport3D.h
@@ -64,6 +64,8 @@ namespace Editor
       // Mirror the editor view onto a scene camera (0 = free fly).
       uint64_t boundCameraUUID{0};
       bool useCameraRes{false};
+      // Free-fly camera ortho toggle. Keep separate so a bound camera's projection doesn't overwrite.
+      bool freeFlyOrtho{false};
       float fbScale{1.0f}; // framebuffer pixels per displayed pixel (used for object picking)
 
       int gizmoOp{0};

--- a/src/project/component/components.h
+++ b/src/project/component/components.h
@@ -92,7 +92,10 @@ namespace Project::Component
   namespace Camera
   {
     // Resolved view parameters of a camera component, used by the editor viewport to mirror it.
-    struct View { int resX{320}; int resY{240}; float aspect{4.0f/3.0f}; float fov{65.0f}; };
+    struct View {
+      int resX{320}; int resY{240}; float aspect{4.0f/3.0f}; float fov{65.0f};
+      bool isOrtho{false}; float orthoSize{300.0f};
+    };
     View getView(Object &obj, Entry &entry);
   }
 

--- a/src/project/component/types/compCamera.cpp
+++ b/src/project/component/types/compCamera.cpp
@@ -17,6 +17,8 @@
 
 namespace
 {
+  constexpr int PROJ_PERSPECTIVE = 0;
+  constexpr int PROJ_ORTHOGRAPHIC = 1;
 }
 
 namespace Project::Component::Camera
@@ -29,7 +31,9 @@ namespace Project::Component::Camera
     PROP_FLOAT(near);
     PROP_FLOAT(far);
     PROP_FLOAT(aspect);
+    PROP_FLOAT(orthoSize);
     PROP_S32(mode);
+    PROP_S32(projection);
   };
 
   std::shared_ptr<void> init(Object &obj) {
@@ -55,7 +59,9 @@ namespace Project::Component::Camera
       .set(data.near)
       .set(data.far)
       .set(data.aspect)
+      .set(data.orthoSize)
       .set(data.mode)
+      .set(data.projection)
       .doc;
   }
 
@@ -67,7 +73,9 @@ namespace Project::Component::Camera
     Utils::JSON::readProp(doc, data->near, 100.0f);
     Utils::JSON::readProp(doc, data->far, 4000.0f);
     Utils::JSON::readProp(doc, data->aspect, 0.0f);
+    Utils::JSON::readProp(doc, data->orthoSize, 300.0f);
     Utils::JSON::readProp(doc, data->mode, 0);
+    Utils::JSON::readProp(doc, data->projection, PROJ_PERSPECTIVE);
     return data;
   }
 
@@ -81,7 +89,9 @@ namespace Project::Component::Camera
     ctx.fileObj.write<float>(data.near.resolve(obj));
     ctx.fileObj.write<float>(data.far.resolve(obj));
     ctx.fileObj.write<float>(data.aspect.resolve(obj));
+    ctx.fileObj.write<float>(data.orthoSize.resolve(obj));
     ctx.fileObj.write<uint8_t>(data.mode.resolve(obj));
+    ctx.fileObj.write<uint8_t>(data.projection.resolve(obj));
   }
 
   void update(Object &obj, Entry &entry)
@@ -96,7 +106,11 @@ namespace Project::Component::Camera
     if (aspect <= 0.0f) {
       aspect = size.y != 0 ? (float)size.x / (float)size.y : 4.0f / 3.0f;
     }
-    return View{size.x, size.y, aspect, data.fov.resolve(obj)};
+    return View{
+      size.x, size.y, aspect, data.fov.resolve(obj),
+      data.projection.resolve(obj) == PROJ_ORTHOGRAPHIC,
+      data.orthoSize.resolve(obj)
+    };
   }
 
   void draw(Object &obj, Entry &entry) {
@@ -113,9 +127,17 @@ namespace Project::Component::Camera
         "Manually", "By Object"
       });
 
+      ImTable::addComboBox("Projection", data.projection.resolve(obj), {
+        "Perspective", "Orthographic"
+      });
+
       ImTable::addObjProp("Offset", data.vpOffset);
       ImTable::addObjProp("Size", data.vpSize);
-      ImTable::addObjProp("FOV", data.fov);
+      if(data.projection.resolve(obj) == PROJ_ORTHOGRAPHIC) {
+        ImTable::addObjProp("Ortho Size", data.orthoSize);
+      } else {
+        ImTable::addObjProp("FOV", data.fov);
+      }
       ImTable::addObjProp("Near", data.near);
       ImTable::addObjProp("Far", data.far);
       ImTable::addObjProp("Aspect", data.aspect);
@@ -140,11 +162,22 @@ namespace Project::Component::Camera
       aspect = (float)data.vpSize.resolve(obj).x / (float)data.vpSize.resolve(obj).y;
     }
 
-    float tanFovY = tanf(fovY * 0.5f);
-    float nearHeight = 2.0f * tanFovY * nearDist;
-    float nearWidth = nearHeight * aspect;
-    float farHeight = 2.0f * tanFovY * farDist;
-    float farWidth = farHeight * aspect;
+    bool isOrtho = data.projection.resolve(obj) == PROJ_ORTHOGRAPHIC;
+
+    float nearHeight, nearWidth, farHeight, farWidth;
+    if (isOrtho) {
+      // in ortho the volume is a box, both planes have the same size
+      nearHeight = 2.0f * data.orthoSize.resolve(obj);
+      nearWidth = nearHeight * aspect;
+      farHeight = nearHeight;
+      farWidth = nearWidth;
+    } else {
+      float tanFovY = tanf(fovY * 0.5f);
+      nearHeight = 2.0f * tanFovY * nearDist;
+      nearWidth = nearHeight * aspect;
+      farHeight = 2.0f * tanFovY * farDist;
+      farWidth = farHeight * aspect;
+    }
 
     glm::vec3 camPos = pos;
     auto rot = obj.rot.resolve(obj);
@@ -197,12 +230,20 @@ namespace Project::Component::Camera
     Utils::Mesh::addLine(*vp.getLines(), triLeft, triRight, col);
 
 
-    // Connect near plane and camera pos
+    // Connect near plane and camera pos, in ortho the rays are parallel instead of converging
     col = glm::u8vec4{0xCC, 0xAA, 0xAA, 0xFF};
-    Utils::Mesh::addLine(*vp.getLines(), camPos, ntl, col);
-    Utils::Mesh::addLine(*vp.getLines(), camPos, ntr, col);
-    Utils::Mesh::addLine(*vp.getLines(), camPos, nbl, col);
-    Utils::Mesh::addLine(*vp.getLines(), camPos, nbr, col);
+    if (isOrtho) {
+      glm::vec3 planeOffset = forward * nearDist;
+      Utils::Mesh::addLine(*vp.getLines(), ntl - planeOffset, ntl, col);
+      Utils::Mesh::addLine(*vp.getLines(), ntr - planeOffset, ntr, col);
+      Utils::Mesh::addLine(*vp.getLines(), nbl - planeOffset, nbl, col);
+      Utils::Mesh::addLine(*vp.getLines(), nbr - planeOffset, nbr, col);
+    } else {
+      Utils::Mesh::addLine(*vp.getLines(), camPos, ntl, col);
+      Utils::Mesh::addLine(*vp.getLines(), camPos, ntr, col);
+      Utils::Mesh::addLine(*vp.getLines(), camPos, nbl, col);
+      Utils::Mesh::addLine(*vp.getLines(), camPos, nbr, col);
+    }
 
     auto spriteCol = isSelected ? Utils::Colors::kSelectionTint : glm::u8vec4{0xFF};
     Utils::Mesh::addSprite(*vp.getSprites(), pos, obj.uuid, 3, spriteCol);

--- a/src/renderer/camera.cpp
+++ b/src/renderer/camera.cpp
@@ -12,7 +12,6 @@ namespace
 {
   constexpr glm::vec3 WORLD_UP{0,1,0};
   constexpr glm::vec3 WORLD_FORWARD{0,0,-1};
-  constexpr float ORTHO_SIZE = 310.0f;
 }
 
 Renderer::Camera::Camera() {
@@ -54,7 +53,6 @@ void Renderer::Camera::apply(UniformGlobal &uniGlobal)
   if(isOrtho)
   {
     uniGlobal.spriteSize = {10, 10};
-    float orthoSize = ORTHO_SIZE;
     uniGlobal.projMat = glm::ortho(
       -orthoSize * aspect,
       orthoSize * aspect,
@@ -124,7 +122,7 @@ void Renderer::Camera::moveDelta(glm::vec2 screenDelta) {
   float pixelsToWorld = 0.001f;
   if (isOrtho) {
     if (screenSize.y > 0.0f) {
-      pixelsToWorld = (ORTHO_SIZE * 2.0f) / screenSize.y;
+      pixelsToWorld = (orthoSize * 2.0f) / screenSize.y;
     }
   } else {
     float dist = glm::length(pivot - pos);

--- a/src/renderer/camera.h
+++ b/src/renderer/camera.h
@@ -17,6 +17,8 @@ namespace Renderer
     private:
 
     public:
+      static constexpr float DEFAULT_ORTHO_SIZE = 310.0f;
+
       glm::vec3 pos{};
       glm::vec3 pivot{};
       glm::quat rot{0,0,0,1};
@@ -32,6 +34,7 @@ namespace Renderer
       bool isMoving{false};
       bool isOrtho{false};
       float fov{70.0f};
+      float orthoSize{DEFAULT_ORTHO_SIZE};
 
       Camera();
 


### PR DESCRIPTION
Added projection settings to camera component in the editor. If Ortho is selected, ortho size will be shown instead of FOV.
Added helpers to set the projection in the engine during runtime
changed In-editor viewport to mirror the reflection of the selected camera
Fixed ghost lines being rendered in the viewport when orthographic projection was applied. This was due to the hack that was supposed to render thicker lines when antialiasing is turned on, that only considered perspective projection
Adjusted Camera Docs
