### PR TITLE
Small physics memory optimizations

### DIFF
--- a/n64/engine/include/collision/collisionScene.h
+++ b/n64/engine/include/collision/collisionScene.h
@@ -14,6 +14,7 @@
 #include "capsuleSweep.h"
 #include "sphereSweep.h"
 #include <array>
+#include <deque>
 #include <functional>
 #include <cstddef>
 #include <unordered_map>
@@ -21,7 +22,6 @@
 #include <vector>
 
 namespace P64::Coll {
-  constexpr int INITIAL_CONSTRAINT_CAPACITY = 10;
   constexpr float DEFAULT_FIXED_DT = 1.0f / 50.0f;
   constexpr fm_vec3_t DEFAULT_GRAVITY = {0.0f, -9.8f, 0.0f};
   constexpr uint8_t DEFAULT_VELOCITY_SOLVER_ITERATIONS = 8;
@@ -140,7 +140,7 @@ namespace P64::Coll {
     std::unordered_map<const Object *, RigidBody *> ownerRigidBodies_{};
     std::vector<Collider *> colliders_{};
     std::unordered_map<const Object *, std::vector<Collider *>> ownerColliders_{};
-    std::vector<ContactConstraint> cachedConstraints_{};
+    std::deque<ContactConstraint> cachedConstraints_{};
     std::unordered_map<ContactConstraintKey, int, ContactConstraintKeyHash> cachedConstraintLookup_{};
     std::vector<ContactConstraint *> solverConstraints_{};
 

--- a/n64/engine/include/collision/collisionScene.h
+++ b/n64/engine/include/collision/collisionScene.h
@@ -14,7 +14,6 @@
 #include "capsuleSweep.h"
 #include "sphereSweep.h"
 #include <array>
-#include <deque>
 #include <functional>
 #include <cstddef>
 #include <unordered_map>
@@ -22,7 +21,7 @@
 #include <vector>
 
 namespace P64::Coll {
-  constexpr int MAX_OBJ_COLLISION_CANDIDATES = 15;
+  constexpr int INITIAL_CONSTRAINT_CAPACITY = 10;
   constexpr float DEFAULT_FIXED_DT = 1.0f / 50.0f;
   constexpr fm_vec3_t DEFAULT_GRAVITY = {0.0f, -9.8f, 0.0f};
   constexpr uint8_t DEFAULT_VELOCITY_SOLVER_ITERATIONS = 8;
@@ -141,7 +140,7 @@ namespace P64::Coll {
     std::unordered_map<const Object *, RigidBody *> ownerRigidBodies_{};
     std::vector<Collider *> colliders_{};
     std::unordered_map<const Object *, std::vector<Collider *>> ownerColliders_{};
-    std::deque<ContactConstraint> cachedConstraints_{};
+    std::vector<ContactConstraint> cachedConstraints_{};
     std::unordered_map<ContactConstraintKey, int, ContactConstraintKeyHash> cachedConstraintLookup_{};
     std::vector<ContactConstraint *> solverConstraints_{};
 
@@ -241,6 +240,7 @@ namespace P64::Coll {
     std::vector<NodeProxy> meshCandidateScratch_{};
     std::vector<RigidBody *> islandScratch_{};
     std::vector<RigidBody *> islandStackScratch_{};
+    std::vector<RigidBody *> wakeCandidateScratch_{};
     // Monotonic counter for island traversals. Bodies stamped with the current
     // epoch count as "visited" without needing a per-traversal set.
     uint32_t islandVisitEpoch_{0};
@@ -280,7 +280,6 @@ namespace P64::Coll {
     void removeCachedConstraintAt(int index);
     void dispatchCollisionCallbacks();
 
-    void rebuildCachedConstraintLookup();
     void wakeIsland(RigidBody *rigidBody);
     void wakeMovedBody(RigidBody *body);
     void syncExternallyMovedBodies();

--- a/n64/engine/include/collision/contact.h
+++ b/n64/engine/include/collision/contact.h
@@ -99,30 +99,19 @@ namespace P64::Coll {
     return key;
   }
 
-  /// Linked-list node for tracking contacts on a physics object
-  struct Contact {
-    struct ContactConstraint *constraint{nullptr};
-    RigidBody *otherBody{nullptr};
-  };
-
-  /// Single contact point within a contact constraint
+  /// Single contact point within a contact constraint.
+  /// Solver working data lives in per step arrays, accumulated impulses kept here for warm starting
   struct ContactPoint {
     fm_vec3_t point{};
     fm_vec3_t contactA{};
     fm_vec3_t contactB{};
     fm_vec3_t localPointA{};
     fm_vec3_t localPointB{};
-    fm_vec3_t aToContact{};
-    fm_vec3_t bToContact{};
     float penetration{0.0f};
 
     float accumulatedNormalImpulse{0.0f};
     float accumulatedTangentImpulseU{0.0f};
     float accumulatedTangentImpulseV{0.0f};
-    float normalMass{0.0f};
-    float tangentMassU{0.0f};
-    float tangentMassV{0.0f};
-    float velocityBias{0.0f};
 
     bool active{false};
   };
@@ -140,8 +129,6 @@ namespace P64::Coll {
     Object *objectB{nullptr};
 
     fm_vec3_t normal{};
-    fm_vec3_t tangentU{};
-    fm_vec3_t tangentV{};
     fm_vec3_t cachedSeparatingAxis{}; // Cached GJK separating axis for faster convergence
 
     float combinedFriction{0.0f};

--- a/n64/engine/include/collision/contactUtils.h
+++ b/n64/engine/include/collision/contactUtils.h
@@ -65,44 +65,15 @@ namespace P64::Coll {
     return localPoint;
   }
 
-  inline fm_vec3_t contactReferenceOffset(
-    const fm_vec3_t &worldPoint,
-    const RigidBody *rigidBody,
-    const Collider *collider,
-    const MeshCollider *meshCollider) {
-    if(rigidBody) {
-      return worldPoint - rigidBody->worldCenterOfMass();
-    }
-
-    if(meshCollider) {
-      return worldPoint - (meshCollider->ownerObject() ? meshCollider->ownerObject()->pos : VEC3_ZERO);
-    }
-
-    if(collider) {
-      return worldPoint - collider->worldCenter();
-    }
-
-    return VEC3_ZERO;
-  }
-
   inline void refreshContactPointWorldState(
     ContactPoint &point,
-    const ContactConstraint &constraint,
-    bool computeRelativeOffsets = false) {
+    const ContactConstraint &constraint) {
     point.contactA = contactWorldPointFromLocalPoint(point.localPointA, constraint.rigidBodyA, constraint.colliderA, constraint.meshColliderA);
     point.contactB = contactWorldPointFromLocalPoint(point.localPointB, constraint.rigidBodyB, constraint.colliderB, constraint.meshColliderB);
     point.point = (point.contactA + point.contactB) * 0.5f;
 
     const fm_vec3_t diff = point.contactA - point.contactB;
     point.penetration = -fm_vec3_dot(&diff, &constraint.normal);
-
-    if(computeRelativeOffsets) {
-      point.aToContact = contactReferenceOffset(point.contactA, constraint.rigidBodyA, constraint.colliderA, constraint.meshColliderA);
-      point.bToContact = contactReferenceOffset(point.contactB, constraint.rigidBodyB, constraint.colliderB, constraint.meshColliderB);
-    } else {
-      point.aToContact = VEC3_ZERO;
-      point.bToContact = VEC3_ZERO;
-    }
   }
 
 } // namespace P64::Coll

--- a/n64/engine/include/collision/rigidBody.h
+++ b/n64/engine/include/collision/rigidBody.h
@@ -189,7 +189,6 @@ namespace P64::Coll {
     float gravityScale_{1.0f};
     float angularDamping_{0.03f};
     uint32_t transformVersion_{0};
-    NodeProxy aabbTreeNodeId_{NULL_NODE};
     uint16_t sleepCounter_{0};
     bool hasGravity_{true};
     bool isEnabled_{true};

--- a/n64/engine/src/collision/collide.cpp
+++ b/n64/engine/src/collision/collide.cpp
@@ -897,7 +897,6 @@ namespace P64::Coll {
       existing->isActive = true;
       existing->isTrigger = isTrigger;
       existing->normal = orderedResult.normal;
-      vec3CalculateTangents(orderedResult.normal, existing->tangentU, existing->tangentV);
       existing->combinedFriction = combinedFriction;
       existing->combinedBounce = combinedBounce;
       existing->respondsA = respondsA;
@@ -1003,7 +1002,6 @@ namespace P64::Coll {
       rigidBodyB, colliderB, meshColliderB, objectB);
     if(!cc) return nullptr;
     cc->normal = orderedResult.normal;
-    vec3CalculateTangents(orderedResult.normal, cc->tangentU, cc->tangentV);
     cc->combinedFriction = combinedFriction;
     cc->combinedBounce = combinedBounce;
     cc->isActive = true;
@@ -1087,7 +1085,6 @@ namespace P64::Coll {
     cc->isActive = true;
     cc->isTrigger = false;
     cc->normal = normal;
-    vec3CalculateTangents(normal, cc->tangentU, cc->tangentV);
     cc->combinedFriction = combinedFriction;
     cc->combinedBounce = combinedBounce;
     cc->respondsA = respondsA;
@@ -1182,7 +1179,6 @@ namespace P64::Coll {
     cc->isActive = true;
     cc->isTrigger = false;
     cc->normal = normal;
-    vec3CalculateTangents(normal, cc->tangentU, cc->tangentV);
     cc->combinedFriction = combinedFriction;
     cc->combinedBounce = combinedBounce;
     cc->respondsA = respondsA;

--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -99,7 +99,6 @@ namespace P64::Coll {
       if(mirrored) {
         std::swap(event.contacts[i].contactA, event.contacts[i].contactB);
         std::swap(event.contacts[i].localPointA, event.contacts[i].localPointB);
-        std::swap(event.contacts[i].aToContact, event.contacts[i].bToContact);
       }
     }
   }
@@ -141,14 +140,6 @@ namespace P64::Coll {
     return fm_vec3_distance2(&rigidBody->getCompoundScale(), &rigidBody->owner_->scale) > FM_EPSILON * FM_EPSILON;
   }
 
-  void CollisionScene::rebuildCachedConstraintLookup() {
-    cachedConstraintLookup_.clear();
-    for(int i = 0; i < cachedConstraintCount_; ++i) {
-      ContactConstraint &cc = cachedConstraints_[i];
-      cachedConstraintLookup_[cc.key] = i;
-    }
-  }
-
   CollisionScene *collisionSceneGetInstance() {
     return &g_scene;
   }
@@ -174,7 +165,9 @@ namespace P64::Coll {
     meshColliders_.clear();
     cachedConstraintCount_ = 0;
     cachedConstraints_.clear();
+    cachedConstraints_.reserve(INITIAL_CONSTRAINT_CAPACITY);
     cachedConstraintLookup_.clear();
+    cachedConstraintLookup_.reserve(INITIAL_CONSTRAINT_CAPACITY);
     solverConstraints_.clear();
     solverBodies_.clear();
     solverHeaders_.clear();
@@ -331,7 +324,8 @@ namespace P64::Coll {
   void CollisionScene::disableRigidBody(RigidBody* rigidBody) {
     if(!rigidBody || !rigidBody->isEnabled_) return;
 
-    std::vector<RigidBody *> wakeCandidates;
+    std::vector<RigidBody *> &wakeCandidates = wakeCandidateScratch_;
+    wakeCandidates.clear();
 
     removeCachedConstraints([rigidBody](const ContactConstraint &cc) {
       return cc.rigidBodyA == rigidBody || cc.rigidBodyB == rigidBody;
@@ -384,7 +378,8 @@ namespace P64::Coll {
     if(!collider) return;
     Object *owner = collider->owner_;
 
-    std::vector<RigidBody *> wakeCandidates;
+    std::vector<RigidBody *> &wakeCandidates = wakeCandidateScratch_;
+    wakeCandidates.clear();
     removeCachedConstraints([collider](const ContactConstraint &cc) {
       return cc.colliderA == collider || cc.colliderB == collider;
     }, wakeCandidates);
@@ -434,7 +429,8 @@ namespace P64::Coll {
   void CollisionScene::removeMeshCollider(MeshCollider *mesh) {
     if(!mesh) return;
 
-    std::vector<RigidBody *> wakeCandidates;
+    std::vector<RigidBody *> &wakeCandidates = wakeCandidateScratch_;
+    wakeCandidates.clear();
     removeCachedConstraints([mesh](const ContactConstraint &cc) {
       return cc.meshColliderA == mesh || cc.meshColliderB == mesh;
     }, wakeCandidates);
@@ -1179,6 +1175,15 @@ namespace P64::Coll {
     solverFrictionPoints_.clear();
     solverOrder_.clear();
 
+    // avoid repeated growth reallocations while ramping up by reserving enough space
+    const std::size_t constraintUpperBound = solverConstraints_.size();
+    solverBodies_.reserve(rigidBodies_.size() + 1);
+    solverHeaders_.reserve(constraintUpperBound);
+    solverFrictionHeaders_.reserve(constraintUpperBound);
+    solverPoints_.reserve(constraintUpperBound * MAX_CONTACT_POINTS_PER_PAIR);
+    solverFrictionPoints_.reserve(constraintUpperBound * MAX_CONTACT_POINTS_PER_PAIR);
+    solverOrder_.reserve(constraintUpperBound);
+
     solverBodies_.push_back(SolverBody{}); // index 0: always immovable sentinel
 
     // Reset solver indices on all bodies
@@ -1204,11 +1209,15 @@ namespace P64::Coll {
       // constraint only drops out when neither side has a linear nor an angular way to respond
       if(totalInvMass < FM_EPSILON && !aCanRotate && !bCanRotate) continue;
 
+      // Friction tangent basis derived from the contact normal
+      fm_vec3_t tangentU, tangentV;
+      vec3CalculateTangents(cc.normal, tangentU, tangentV);
+
       // Tangent effective masses for friction
-      const float linearU = (cc.respondsA ? constrainedLinearInvMassAlong(a, cc.tangentU) : 0.0f) +
-                (cc.respondsB ? constrainedLinearInvMassAlong(b, cc.tangentU) : 0.0f);
-      const float linearV = (cc.respondsA ? constrainedLinearInvMassAlong(a, cc.tangentV) : 0.0f) +
-                (cc.respondsB ? constrainedLinearInvMassAlong(b, cc.tangentV) : 0.0f);
+      const float linearU = (cc.respondsA ? constrainedLinearInvMassAlong(a, tangentU) : 0.0f) +
+                (cc.respondsB ? constrainedLinearInvMassAlong(b, tangentU) : 0.0f);
+      const float linearV = (cc.respondsA ? constrainedLinearInvMassAlong(a, tangentV) : 0.0f) +
+                (cc.respondsB ? constrainedLinearInvMassAlong(b, tangentV) : 0.0f);
 
       const uint16_t headerIndex = static_cast<uint16_t>(solverHeaders_.size());
       solverHeaders_.push_back(SolverConstraintHeader{});
@@ -1226,19 +1235,19 @@ namespace P64::Coll {
       if(bRespondsLinear) h.linearResponseB = b->constrainLinearWorld(cc.normal * -b->inverseMass_);
 
       // Building friction header
-      fh.tangentU = cc.tangentU;
-      fh.tangentV = cc.tangentV;
+      fh.tangentU = tangentU;
+      fh.tangentV = tangentV;
       fh.friction = cc.combinedFriction;
       // Friction measures only enabled, non-kinematic bodies
       fh.linearMeasureScaleA = (a && a->isEnabled_ && !a->isKinematic_) ? 1.0f : 0.0f;
       fh.linearMeasureScaleB = (b && b->isEnabled_ && !b->isKinematic_) ? 1.0f : 0.0f;
       if(aRespondsLinear) {
-        fh.linearResponseUA = a->constrainLinearWorld(cc.tangentU * a->inverseMass_);
-        fh.linearResponseVA = a->constrainLinearWorld(cc.tangentV * a->inverseMass_);
+        fh.linearResponseUA = a->constrainLinearWorld(tangentU * a->inverseMass_);
+        fh.linearResponseVA = a->constrainLinearWorld(tangentV * a->inverseMass_);
       }
       if(bRespondsLinear) {
-        fh.linearResponseUB = b->constrainLinearWorld(cc.tangentU * -b->inverseMass_);
-        fh.linearResponseVB = b->constrainLinearWorld(cc.tangentV * -b->inverseMass_);
+        fh.linearResponseUB = b->constrainLinearWorld(tangentU * -b->inverseMass_);
+        fh.linearResponseVB = b->constrainLinearWorld(tangentV * -b->inverseMass_);
       }
 
       // Precompute solver points for each contact point in the constraint
@@ -1246,15 +1255,15 @@ namespace P64::Coll {
         ContactPoint &cp = cc.points[j];
         if(!cp.active) continue;
 
-        // Relative vectors from centers of mass (also consumed by collision events)
-        cp.aToContact = a ? cp.contactA - a->worldCenterOfMass() : VEC3_ZERO;
-        cp.bToContact = b ? cp.contactB - b->worldCenterOfMass() : VEC3_ZERO;
+        // Relative vectors from centers of mass
+        const fm_vec3_t aToContact = a ? cp.contactA - a->worldCenterOfMass() : VEC3_ZERO;
+        const fm_vec3_t bToContact = b ? cp.contactB - b->worldCenterOfMass() : VEC3_ZERO;
 
         // Normal effective mass: 1 / (invMassA + invMassB + (rA×n)·I_A^-1·(rA×n) + ...)
         fm_vec3_t raCrossN;
-        fm_vec3_cross(&raCrossN, &cp.aToContact, &cc.normal);
+        fm_vec3_cross(&raCrossN, &aToContact, &cc.normal);
         fm_vec3_t rbCrossN;
-        fm_vec3_cross(&rbCrossN, &cp.bToContact, &cc.normal);
+        fm_vec3_cross(&rbCrossN, &bToContact, &cc.normal);
 
         fm_vec3_t angularResponseA = VEC3_ZERO;
         fm_vec3_t angularResponseB = VEC3_ZERO;
@@ -1291,9 +1300,9 @@ namespace P64::Coll {
         // Tangent effective masses
         {
           fm_vec3_t raCrossU;
-          fm_vec3_cross(&raCrossU, &cp.aToContact, &cc.tangentU);
+          fm_vec3_cross(&raCrossU, &aToContact, &tangentU);
           fm_vec3_t rbCrossU;
-          fm_vec3_cross(&rbCrossU, &cp.bToContact, &cc.tangentU);
+          fm_vec3_cross(&rbCrossU, &bToContact, &tangentU);
           float angU_A = 0.0f;
           if(aCanRotate) {
             fp.angularResponseUA = a->applyConstrainedWorldInertia(raCrossU);
@@ -1313,9 +1322,9 @@ namespace P64::Coll {
         }
         {
           fm_vec3_t raCrossV;
-          fm_vec3_cross(&raCrossV, &cp.aToContact, &cc.tangentV);
+          fm_vec3_cross(&raCrossV, &aToContact, &tangentV);
           fm_vec3_t rbCrossV;
-          fm_vec3_cross(&rbCrossV, &cp.bToContact, &cc.tangentV);
+          fm_vec3_cross(&rbCrossV, &bToContact, &tangentV);
           float angV_A = 0.0f;
           if(aCanRotate) {
             fp.angularResponseVA = a->applyConstrainedWorldInertia(raCrossV);
@@ -1341,12 +1350,12 @@ namespace P64::Coll {
         fm_vec3_t relVel = VEC3_ZERO;
         if(a) {
           fm_vec3_t aCross;
-          fm_vec3_cross(&aCross, &a->angularVelocity_, &cp.aToContact);
+          fm_vec3_cross(&aCross, &a->angularVelocity_, &aToContact);
           relVel = a->linearVelocity_ + aCross;
         }
         if(b) {
           fm_vec3_t bCross;
-          fm_vec3_cross(&bCross, &b->angularVelocity_, &cp.bToContact);
+          fm_vec3_cross(&bCross, &b->angularVelocity_, &bToContact);
           relVel -= (b->linearVelocity_ + bCross);
         }
         const float relVelN = fm_vec3_dot(&relVel, &cc.normal);

--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -165,9 +165,7 @@ namespace P64::Coll {
     meshColliders_.clear();
     cachedConstraintCount_ = 0;
     cachedConstraints_.clear();
-    cachedConstraints_.reserve(INITIAL_CONSTRAINT_CAPACITY);
     cachedConstraintLookup_.clear();
-    cachedConstraintLookup_.reserve(INITIAL_CONSTRAINT_CAPACITY);
     solverConstraints_.clear();
     solverBodies_.clear();
     solverHeaders_.clear();

--- a/n64/engine/src/collision/rigidBody.cpp
+++ b/n64/engine/src/collision/rigidBody.cpp
@@ -142,7 +142,6 @@ namespace P64::Coll {
     owner_ = object;
     position_ = object->pos * getInvGfxScale();
     rotation_ = object->rot;
-    aabbTreeNodeId_ = NULL_NODE;
     constraints_ = Constraint::None;
     sleepCounter_ = 0;
     isSleeping_ = false;


### PR DESCRIPTION
smaller optimizations removing some dead code, reducing struct size, try to avoid reallocations during the solver phase by rightsizing the collections in preparation.

Results in marginal memory savings of a few kB here and there, and maybe a couple microseconds saved too, both scaling with the amount of active contacts
