### PR TITLE
[FIX] Camera Component now responds to object enable/disable state correctly

### DIFF
--- a/n64/engine/include/scene/components/camera.h
+++ b/n64/engine/include/scene/components/camera.h
@@ -66,6 +66,8 @@ namespace P64::Comp
 
     static void initDelete([[maybe_unused]] Object& obj, Camera* data, InitData* initData);
 
+    static void onEvent(Object& obj, Camera* data, const ObjectEvent& event);
+
     static void update([[maybe_unused]] Object& obj, [[maybe_unused]] Camera* data, [[maybe_unused]] float deltaTime);
 
     static void draw([[maybe_unused]] Object& obj, [[maybe_unused]] Camera* data, [[maybe_unused]] float deltaTime) {

--- a/n64/engine/src/scene/components/camera.cpp
+++ b/n64/engine/src/scene/components/camera.cpp
@@ -18,7 +18,6 @@ void P64::Comp::Camera::initDelete(Object &obj, Camera* data, InitData* initData
   new(data) Camera();
 
   data->mode = initData->mode;
-  SceneManager::getCurrent().addCamera(&data->camera);
   auto &cam = data->camera;
   cam.setScreenArea(initData->vpOffset[0], initData->vpOffset[1], initData->vpSize[0], initData->vpSize[1]);
   cam.fov  = initData->fov;
@@ -33,6 +32,20 @@ void P64::Comp::Camera::initDelete(Object &obj, Camera* data, InitData* initData
   }
 
   cam.setPosRot(obj.pos, obj.rot);
+
+  if(obj.isEnabled()) {
+    SceneManager::getCurrent().addCamera(&cam);
+  }
+}
+
+void P64::Comp::Camera::onEvent(Object &obj, Camera* data, const ObjectEvent &event)
+{
+  if(event.type == EVENT_TYPE_DISABLE) {
+    return SceneManager::getCurrent().removeCamera(&data->camera);
+  }
+  if(event.type == EVENT_TYPE_ENABLE) {
+    return SceneManager::getCurrent().addCamera(&data->camera);
+  }
 }
 
 void P64::Comp::Camera::update(Object &obj, Camera* data, float deltaTime)


### PR DESCRIPTION
Camera Component only adds a camera to the scene if the object is enabled during init.
The component will now also listen for enable/disable events to add or remove the camera from the scene.
