### PR TITLE
chg: trigger rebuilds on header changes if needed

### DIFF
--- a/data/build/baseMakefile.mk
+++ b/data/build/baseMakefile.mk
@@ -13,8 +13,12 @@ export N64_INST={{N64_INST}}
 include $(N64_INST)/include/n64.mk
 include $(N64_INST)/include/t3d.mk
 
+# recursive wildcard
+rwildcard = $(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(subst *,%,$2),$d))
+
 N64_CXXFLAGS += -std=gnu++20 -fno-exceptions -O3 -Isrc -Isrc/user \
-	-I$(ENGINE_DIR)/include
+	-I$(ENGINE_DIR)/include \
+	-MP
 
 # Allow custom attributes, otherwise GCC (rightfully) complains unknown ones
 $(BUILD_DIR)/src/user/%.o: N64_CXXFLAGS += -Wno-attributes
@@ -67,6 +71,7 @@ clean:
 p64:
 	{{P64_SELF_PATH}} --cli --cmd build {{PROJECT_SELF_PATH}}
 
--include $(wildcard $(BUILD_DIR)/src/*.d)
+# header dependencies (.d files are emitted next to each .o, in all subdirs)
+-include $(call rwildcard,$(BUILD_DIR)/src,*.d)
 
 .PHONY: all clean

--- a/src/build/projectBuilder.cpp
+++ b/src/build/projectBuilder.cpp
@@ -177,9 +177,9 @@ bool Build::buildProject(const std::string &configPath)
     {"{{SCENE_MAP}}", sceneMapStr},
     {"{{SCENE_COUNT}}", std::to_string(scenes.size())}
   });
-  Utils::FS::saveTextFile(project.getPath() + "/src/p64/sceneTable.h", sceneTableHeader);
+  Utils::FS::saveTextFileIfChanged(project.getPath() + "/src/p64/sceneTable.h", sceneTableHeader);
 
-  Utils::FS::saveTextFile(project.getPath() + "/src/p64/sceneTable.cpp",
+  Utils::FS::saveTextFileIfChanged(project.getPath() + "/src/p64/sceneTable.cpp",
     "#include \"sceneTable.h\"\n"
     "\n"
     "namespace P64::SceneManager {\n"
@@ -200,7 +200,7 @@ bool Build::buildProject(const std::string &configPath)
     Utils::FS::loadTextFile("data/scripts/assetTable.h"),
     "{{ASSET_MAP}}", sceneCtx.assetFileMap
   );
-  Utils::FS::saveTextFile(project.getPath() + "/src/p64/assetTable.h", assetTableCode);
+  Utils::FS::saveTextFileIfChanged(project.getPath() + "/src/p64/assetTable.h", assetTableCode);
 
   // Asset table
   Utils::BinaryFile fileList{};

--- a/src/build/scriptBuilder.cpp
+++ b/src/build/scriptBuilder.cpp
@@ -90,7 +90,7 @@ void Build::buildScripts(Project::Project &project, SceneCtx &sceneCtx)
   src = Utils::replaceAll(src, "__GRAPH_DEF__", graphDecl);
 
 
-  Utils::FS::saveTextFile(pathTable, src);
+  Utils::FS::saveTextFileIfChanged(pathTable, src);
 }
 
 void Build::buildGlobalScripts(Project::Project &project, SceneCtx &sceneCtx)
@@ -178,5 +178,5 @@ void Build::buildGlobalScripts(Project::Project &project, SceneCtx &sceneCtx)
   auto src = Utils::FS::loadTextFile("data/scripts/globalScriptTable.cpp");
   src = Utils::replaceAll(src, "__CODE_DECL__", srcDecl);
   src = Utils::replaceAll(src, "__CODE_HOOKS__", srcHook);
-  Utils::FS::saveTextFile(pathTable, src);
+  Utils::FS::saveTextFileIfChanged(pathTable, src);
 }

--- a/src/utils/fs.h
+++ b/src/utils/fs.h
@@ -38,6 +38,13 @@ namespace Utils::FS
     return true;
   }
 
+  // Only writes if the content differs, this keeps the timestamp stable for generated
+  // source/header files, so make doesn't rebuild everything that includes them.
+  inline bool saveTextFileIfChanged(const fs::path &path, const std::string &content) {
+    if(fs::exists(path) && loadTextFile(path) == content)return true;
+    return saveTextFile(path, content);
+  }
+
   std::vector<std::string> scanDirs(const std::string &basePath);
 
   void ensureFile(const fs::path &path, const fs::path &pathTemplate);


### PR DESCRIPTION
basemakefile now recursively includes dependencies, added MP flag to N64_CXXFLAGS to emit phony targets and prevent build failure if header was deleted or renamed, now only save script, scene and asset tables if their content changed since they are included in userscript.h and full regeneration would trigger rebuild of all scripts every time

# Please read before submitting!

PRs in general are welcome,
however large portions of this project are still in developement and may change at any point.<br>
Submitting new features or larger changes have a good chance of not being merged and/or resulting in conflitcs.<br>
If you plan on working on something that isn't a small change, <br>
please talk about it first in the discord / create an issue or draft.<br>
