### PR TITLE
Scene graph tree multi selection / dragging

### DIFF
--- a/src/editor/pages/parts/sceneGraph.cpp
+++ b/src/editor/pages/parts/sceneGraph.cpp
@@ -64,6 +64,8 @@ namespace
     float indentX{0.0f};
     // Whether insertion occurs before instead of after the target object
     bool insertBefore{false};
+    // Boundary below the previous sibling row
+    float previousSiblingRowBottomY{0.0f};
   };
 
   struct AssetDropTask {
@@ -82,7 +84,7 @@ namespace
    * Accepts a prefab or 3D model asset and records where its scene object should be created.
    * @param targetUUID Destination object UUID, or zero to add at the scene root.
    * @param asChild Whether the new instance should become a child of the target.
-   * @param insertBefore Whether sibling insertion should occur before the target.
+   * @param insertBefore Whether sibling insertion should occur before the target (this is the only way to insert as first child when there are already child elements).
    */
   void acceptSceneAssetDrop(uint32_t targetUUID, bool asChild, bool insertBefore = false)
   {
@@ -325,10 +327,52 @@ namespace
 
     // Draw only the line belonging to the destination currently selected by the cursor
     if (hovered && acceptsPayload) {
+      const ImU32 indicatorColor = ImGui::GetColorU32(ImGuiCol_DragDropTarget);
+
+      // Is an outer destination --> Show guide to identify its target previous sibling
+      if (candidateIndex > 0 && !candidate.insertBefore
+          && candidate.previousSiblingRowBottomY > 0.0f) {
+        // Place the vertical guide in the middel future sibling icon start
+        const float connectorX = lineStart.x + 10_px;
+
+        // Split the vertical guide into short strokes so it does not dominate the insertion line
+        const float dashLength = 4_px;
+        const float dashGap = 3_px;
+        const float guideStartY = std::min(candidate.previousSiblingRowBottomY, lineStart.y);
+        const float guideEndY = std::max(candidate.previousSiblingRowBottomY, lineStart.y);
+
+        // Draw every visible stroke and trim the final one to the available height
+        for (float dashStartY = guideStartY; dashStartY < guideEndY;
+             dashStartY += dashLength + dashGap) {
+          const float dashEndY = std::min(dashStartY + dashLength, guideEndY);
+          drawList->AddLine(
+            {connectorX, dashStartY},
+            {connectorX, dashEndY},
+            indicatorColor,
+            thickness
+          );
+        }
+
+        // Mark the row from which the connector originates
+        drawList->AddCircleFilled(
+          {connectorX, candidate.previousSiblingRowBottomY},
+          2.5_px,
+          indicatorColor
+        );
+
+        // End the horizontal connector in the middle of the first icon of the target sibling
+        drawList->AddLine(
+          {connectorX, lineStart.y},
+          lineStart,
+          indicatorColor,
+          thickness
+        );
+      }
+
       drawList->AddLine(
         lineStart,
         lineEnd,
-        ImGui::GetColorU32(ImGuiCol_DragDropTarget),
+        indicatorColor,
         thickness
       );
     }
@@ -822,7 +866,12 @@ namespace
     }
 
     // A leaf or collapsed object only exposes insertion after the object itself
-    std::vector<DropCandidate> tailCandidates{{obj.uuid, nodeIndentX}};
+    std::vector<DropCandidate> tailCandidates{{
+      obj.uuid,
+      nodeIndentX,
+      false,
+      nodeRectMax.y
+    }};
     if(isOpen)
     {
       if (ImGui::BeginPopupContextItem("NodePopup"))
@@ -917,7 +966,12 @@ namespace
         // Add insertion after this object as the next outer level in the shared margin
         // The scene root is excluded because objects cannot become its siblings
         if (obj.parent)
-          tailCandidates.push_back({obj.uuid, nodeIndentX});
+          tailCandidates.push_back({
+            obj.uuid,
+            nodeIndentX,
+            false,
+            nodeRectMax.y
+          });
       }
 
       ImGui::TreePop();

--- a/src/editor/pages/parts/sceneGraph.cpp
+++ b/src/editor/pages/parts/sceneGraph.cpp
@@ -179,6 +179,17 @@ namespace
   }
 
   /**
+   * Checks whether directional navigation has just moved to the last submitted ImGui item.
+   * @return True when the last item has newly received directional navigation focus.
+   */
+  bool wasLastItemFocusedByDirectionalNavigation()
+  {
+    const ImGuiContext* imguiContext = ImGui::GetCurrentContext();
+    return imguiContext->NavJustMovedToId == ImGui::GetItemID()
+      && !imguiContext->NavJustMovedToIsTabbing;
+  }
+
+  /**
    * Starts inline renaming for an object.
    *
    * @param objectUUID UUID of the object to rename
@@ -492,7 +503,11 @@ namespace
     if(dim)ImGui::PopStyleColor();
     ImGui::PopStyleVar(2);
 
-    if(selectable && ImGui::IsItemClicked(ImGuiMouseButton_Left) && !ImGui::IsItemToggledOpen()) {
+    // Directional navigation must update the editor target instead of only moving ImGui's highlight
+    const bool focusedByNavigation = wasLastItemFocusedByDirectionalNavigation();
+
+    if(selectable && (focusedByNavigation
+        || (ImGui::IsItemClicked(ImGuiMouseButton_Left) && !ImGui::IsItemToggledOpen()))) {
       ctx.setNestedSelection(rootUuid, path);
       // Nested prefab targets cannot participate in the flat scene-object selection list
       rangeSelectionAnchorUUID = 0;
@@ -765,6 +780,9 @@ namespace
     ImVec2 nodeRectMin = ImGui::GetItemRectMin();
     ImVec2 nodeRectMax = ImGui::GetItemRectMax();
 
+    // Capture navigation focus before later row controls replace ImGui's last item
+    const bool focusedByNavigation = wasLastItemFocusedByDirectionalNavigation();
+
     // Mark object being edited in prefab-edit mode
     if(ctx.isPrefabEditing(obj.uuid)) {
       ImVec2 bgMax = ImGui::GetItemRectMax();
@@ -855,11 +873,11 @@ namespace
       ImGui::SetCursorPosY(oldCursorPos.y);
     }
 
-    if (nodeIsClicked && canSelect) {
+    if ((nodeIsClicked || focusedByNavigation) && canSelect) {
       pendingObjectClick = {
         .uuid = obj.uuid,
-        .ctrl = ImGui::GetIO().KeyCtrl,
-        .shift = ImGui::GetIO().KeyShift,
+        .ctrl = nodeIsClicked && ImGui::GetIO().KeyCtrl,
+        .shift = nodeIsClicked && ImGui::GetIO().KeyShift,
       };
       //ImGui::SetWindowFocus("Object");
       //ImGui::SetWindowFocus("Graph");

--- a/src/editor/pages/parts/sceneGraph.cpp
+++ b/src/editor/pages/parts/sceneGraph.cpp
@@ -372,6 +372,97 @@ namespace
   }
 
   /**
+   * Collects the movable roots represented by a drag operation.
+   *
+   * Dragging a selected object moves the whole flat selection, except for selected nodes
+   * whose ancestor is also selected. Dragging an unselected object only moves that object.
+   *
+   * @param scene Scene containing the dragged objects.
+   * @param draggedUUID UUID of the object where the drag operation started.
+   * @return UUIDs of the independent roots that should be moved, in scene-tree order.
+   */
+  std::vector<uint32_t> collectDragRoots(Project::Scene &scene, uint32_t draggedUUID)
+  {
+    if (!ctx.isObjectSelected(draggedUUID))
+      return {draggedUUID};
+
+    std::vector<uint32_t> roots{};
+    auto visit = [&roots](Project::Object &obj, bool hasSelectedAncestor, auto &visitRef) -> void {
+      const bool selected = ctx.isObjectSelected(obj.uuid);
+      if (selected && !hasSelectedAncestor)
+        roots.push_back(obj.uuid);
+
+      for (auto &child : obj.children)
+        visitRef(*child, hasSelectedAncestor || selected, visitRef);
+    };
+
+    for (auto &child : scene.getRootObject().children)
+      visit(*child, false, visit);
+
+    return roots;
+  }
+
+  /**
+   * Checks the complete multi-object move before changing the scene.
+   *
+   * @param scene Scene containing the objects and destination.
+   * @param roots UUIDs of the independent roots to move.
+   * @param targetUUID UUID of the destination object or scene root.
+   * @return True when every root can be moved to the destination.
+   */
+  bool canMoveDragRoots(
+    Project::Scene &scene, const std::vector<uint32_t> &roots, uint32_t targetUUID
+  )
+  {
+    if (roots.empty()) return false;
+
+    Project::Object &sceneRoot = scene.getRootObject();
+    auto targetRef = scene.getObjectByUUID(targetUUID);
+    Project::Object* target = targetUUID == sceneRoot.uuid ? &sceneRoot : targetRef.get();
+    if (!target) return false;
+
+    for (uint32_t uuid : roots) {
+      auto obj = scene.getObjectByUUID(uuid);
+      if (!obj || !obj->parent) return false;
+
+      // Reject drops onto a moved root or anywhere inside its subtree
+      for (Project::Object* ancestor = target; ancestor; ancestor = ancestor->parent) {
+        if (ancestor->uuid == uuid)
+          return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Moves all independent roots represented by a drag operation.
+   *
+   * @param scene Scene containing the dragged objects.
+   * @param task Drag-and-drop source, destination and placement mode.
+   * @return True when at least one object was moved.
+   */
+  bool moveDraggedSelection(Project::Scene &scene, const DragDropTask &task)
+  {
+    std::vector<uint32_t> roots = collectDragRoots(scene, task.sourceUUID);
+    if (!canMoveDragRoots(scene, roots, task.targetUUID))
+      return false;
+
+    bool moved = false;
+    if (task.isInsert) {
+      for (uint32_t uuid : roots)
+        moved |= scene.moveObject(uuid, task.targetUUID, true);
+    } else {
+      // Every sibling is inserted after the same target, so process them backwards
+      // to preserve their scene-tree order
+      for (auto it = roots.rbegin(); it != roots.rend(); ++it)
+        moved |= scene.moveObject(*it, task.targetUUID, false);
+    }
+
+    return moved;
+  }
+
+  /**
    * Applies a scene-tree click after all visible rows have been collected for the frame.
    * Shift replaces the selection with the anchored range. Ctrl+Shift adds that range, or
    * removes it when the clicked endpoint was already selected.
@@ -516,7 +607,7 @@ namespace
 
     bool nodeIsClicked = ImGui::IsItemHovered()
       && ImGui::IsMouseReleased(ImGuiMouseButton_Left)
-      && !ImGui::IsMouseDragging(ImGuiMouseButton_Left);
+      && !ImGui::IsMouseDragPastThreshold(ImGuiMouseButton_Left);
     bool nodeIsDoubleClicked = ImGui::IsItemHovered()
       && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)
       && !ImGui::IsMouseDragging(ImGuiMouseButton_Left);
@@ -533,7 +624,11 @@ namespace
     if (obj.parent && ImGui::BeginDragDropSource())
     {
       ImGui::SetDragDropPayload("OBJECT", &obj.uuid, sizeof(obj.uuid));
-      ImGui::TextUnformatted(obj.name.c_str());
+      std::vector<uint32_t> dragRoots = collectDragRoots(scene, obj.uuid);
+      if (dragRoots.size() > 1)
+        ImGui::Text("%zu Objects", dragRoots.size());
+      else
+        ImGui::TextUnformatted(obj.name.c_str());
       ImGui::EndDragDropSource();
     }
 
@@ -788,11 +883,7 @@ void Editor::SceneGraph::draw()
 
   if(dragDropTask.sourceUUID && dragDropTask.targetUUID) {
     //printf("dragDropTarget %08X -> %08X (%d)\n", dragDropTask.sourceUUID, dragDropTask.targetUUID, dragDropTask.isInsert);
-    bool moved = scene->moveObject(
-      dragDropTask.sourceUUID,
-      dragDropTask.targetUUID,
-      dragDropTask.isInsert
-    );
+    bool moved = moveDraggedSelection(*scene, dragDropTask);
 
     // Could move --> Add to history
     if (moved)

--- a/src/editor/pages/parts/sceneGraph.cpp
+++ b/src/editor/pages/parts/sceneGraph.cpp
@@ -49,6 +49,7 @@ namespace
     uint32_t sourceUUID{0};
     uint32_t targetUUID{0};
     bool isInsert{false};
+    bool insertBefore{false};
   };
 
   DragDropTask dragDropTask{};
@@ -61,12 +62,15 @@ namespace
     uint32_t targetUUID{0};
     // Horizontal position where a row inserted at this level would begin
     float indentX{0.0f};
+    // Whether insertion occurs before instead of after the target object
+    bool insertBefore{false};
   };
 
   struct AssetDropTask {
     uint64_t assetUUID{0};
     uint32_t targetUUID{0};
     bool asChild{false};
+    bool insertBefore{false};
   };
 
   AssetDropTask assetDropTask{};
@@ -78,8 +82,9 @@ namespace
    * Accepts a prefab or 3D model asset and records where its scene object should be created.
    * @param targetUUID Destination object UUID, or zero to add at the scene root.
    * @param asChild Whether the new instance should become a child of the target.
+   * @param insertBefore Whether sibling insertion should occur before the target.
    */
-  void acceptSceneAssetDrop(uint32_t targetUUID, bool asChild)
+  void acceptSceneAssetDrop(uint32_t targetUUID, bool asChild, bool insertBefore = false)
   {
     const ImGuiPayload* payload = ImGui::GetDragDropPayload();
     if (!payload || !payload->IsDataType("ASSET")) return;
@@ -93,6 +98,7 @@ namespace
       assetDropTask.assetUUID = assetUUID;
       assetDropTask.targetUUID = targetUUID;
       assetDropTask.asChild = asChild;
+      assetDropTask.insertBefore = insertBefore;
     }
   }
 
@@ -337,11 +343,12 @@ namespace
         dragDropTask.sourceUUID = *static_cast<const uint32_t*>(payload->Data);
         dragDropTask.targetUUID = candidate.targetUUID;
         dragDropTask.isInsert = false;
+        dragDropTask.insertBefore = candidate.insertBefore;
       }
 
       // Route prefab and model assets through the same chosen hierarchy level
       if (!prefabEditObj)
-        acceptSceneAssetDrop(candidate.targetUUID, false);
+        acceptSceneAssetDrop(candidate.targetUUID, false, candidate.insertBefore);
       ImGui::EndDragDropTarget();
     }
     ImGui::PopStyleColor();
@@ -555,6 +562,10 @@ namespace
     if (task.isInsert) {
       for (uint32_t uuid : roots)
         moved |= scene.moveObject(uuid, task.targetUUID, true);
+    } else if (task.insertBefore) {
+      // Repeated insertion before one target naturally preserves forward tree order
+      for (uint32_t uuid : roots)
+        moved |= scene.moveObject(uuid, task.targetUUID, false, true);
     } else {
       // Every sibling is inserted after the same target, so process them backwards
       // to preserve their scene-tree order
@@ -853,12 +864,6 @@ namespace
         ImGui::EndPopup();
       }
 
-      // The scene root provides the insertion point before its first object
-      if (obj.parent == nullptr && !obj.children.empty() && ImGui::IsDragDropActive()) {
-        // Inserting after the root UUID is the special moveObject case for the first row
-        DrawDropTarget({{obj.uuid, ImGui::GetCursorScreenPos().x}});
-      }
-
       // Build the exact child sequence displayed by the active search filter
       std::vector<Project::Object*> visibleChildren{};
       visibleChildren.reserve(obj.children.size());
@@ -866,6 +871,15 @@ namespace
         // Hidden branches must not create invisible drop destinations
         if (!hasSearchFilter || subtreeMatchesFilter(*child))
           visibleChildren.push_back(child.get());
+      }
+
+      // The margin before the first visible child inserts at the beginning of this parent
+      if (!visibleChildren.empty()) {
+        DrawDropTarget({{
+          visibleChildren.front()->uuid,
+          ImGui::GetCursorScreenPos().x,
+          true
+        }});
       }
 
       // The final visible child carries the complete tail chain back to its ancestors
@@ -1062,7 +1076,7 @@ void Editor::SceneGraph::draw()
           // It is being set as a child of another object --> Set same global position
           if (target && target->parent)
             position = target->parent->pos.resolve(target->parent->propOverrides);
-          scene->moveObject(added->uuid, assetDropTask.targetUUID, false);
+          scene->moveObject(added->uuid, assetDropTask.targetUUID, false, assetDropTask.insertBefore);
         }
         // Apply the position after moving the object to its final place in the tree
         added->pos.resolve(added->propOverrides) = position;

--- a/src/editor/pages/parts/sceneGraph.cpp
+++ b/src/editor/pages/parts/sceneGraph.cpp
@@ -6,7 +6,6 @@
 #include "assetsBrowser.h"
 
 #include <algorithm>
-#include <cmath>
 #include <string>
 #include "imgui.h"
 #include "misc/cpp/imgui_stdlib.h"
@@ -217,12 +216,26 @@ namespace
     // Extend the shared hit zone to the usable right edge of the scene graph
     const float rightX = ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
 
+    // Match the right edge used by the row controls instead of the complete window width
+    const ImGuiStyle &style = ImGui::GetStyle();
+    const float rowControlsWidth = 16_px * 2 + style.ItemInnerSpacing.x;
+    const float controlsEndX = rightX - calcRightControlAreaWidth() + rowControlsWidth;
+
+    // Reuse original margin position and advance it by one hierarchy level
+    const float iconStartOffset = style.IndentSpacing - 4_px;
+
     // The last candidate is always the least-indented and outermost destination
     const float outerX = candidates.back().indentX;
 
-    // Start at the outermost indentation so every explicit level remains reachable
+    // Shared margins begin at their outermost visual line while a terminal node keeps
+    // the wider target that reaches into the indentation gutter
+    const float overlayLeftX = candidates.size() == 1
+      ? outerX - 4_px
+      : outerX + iconStartOffset;
+
+    // Keep the terminal-node exception without offsetting multi-level hit zones
     ImVec2 overlayStart{
-      outerX - 4_px,
+      overlayLeftX,
       cursorScreen.y - (hitHeight / 2) + 3_px
     };
 
@@ -235,22 +248,28 @@ namespace
 
     // A chain with several candidates needs vertical or horizontal disambiguation
     if (candidates.size() > 1) {
-      // To the right of the deepest indentation all candidates occupy the same space
-      if (mousePos.x > candidates.front().indentX) {
+      // Use the same horizontal position as the deepest visible insertion line
+      const float deepestLineStartX = candidates.front().indentX + iconStartOffset;
+
+      // To the right of the deepest line all candidates occupy the same space
+      if (mousePos.x > deepestLineStartX) {
         // The upper half stays inside the deepest parent while the lower half escapes it
         candidateIndex = mousePos.y < (overlayStart.y + overlayEnd.y) * 0.5f
           ? 0
           : candidates.size() - 1;
       } else {
-        // Inside the indentation gutter select the hierarchy level nearest to the cursor
-        float closestDistance = FLT_MAX;
+        // Start with the outermost level for the left edge of the shared margin
+        candidateIndex = candidates.size() - 1;
+
+        // Each level owns the interval from its visible line to the next deeper line
         for (size_t i = 0; i < candidates.size(); ++i) {
-          // Compare against the position where a row at this level would begin
-          float distance = std::abs(mousePos.x - candidates[i].indentX);
-          if (distance < closestDistance) {
-            // Retain both the nearest distance and its corresponding destination
-            closestDistance = distance;
+          // Calculate the exact left edge shown by this candidate's indicator
+          const float candidateLineStartX = candidates[i].indentX + iconStartOffset;
+
+          // The first line to the left of the cursor is the deepest valid level
+          if (mousePos.x >= candidateLineStartX) {
             candidateIndex = i;
+            break;
           }
         }
       }
@@ -259,13 +278,21 @@ namespace
     // Resolve the destination before drawing and accepting the payload
     const DropCandidate &candidate = candidates[candidateIndex];
 
-    // Indent the preview line to make the selected hierarchy level visible
-    ImVec2 lineStart{candidate.indentX - 4_px, overlayStart.y};
-    ImVec2 lineEnd{rightX, overlayStart.y};
+    // Start where row icons would begin after the space reserved for the tree arrow
+    ImVec2 lineStart{
+      candidate.indentX + iconStartOffset,
+      overlayStart.y
+    };
+
+    // Stop where row button group ends so the indicator reads as an insertion line
+    ImVec2 lineEnd{controlsEndX, overlayStart.y};
 
     // Keep the outermost line for asset drops in the empty area below the tree
-    lastInsertLineStart = {outerX - 4_px, overlayStart.y};
-    lastInsertLineEnd = {rightX, overlayStart.y};
+    lastInsertLineStart = {
+      outerX + iconStartOffset,
+      overlayStart.y
+    };
+    lastInsertLineEnd = {controlsEndX, overlayStart.y};
     hasInsertLine = true;
 
     // Move the cursor temporarily to create an overlapping hit zone

--- a/src/editor/pages/parts/sceneGraph.cpp
+++ b/src/editor/pages/parts/sceneGraph.cpp
@@ -506,8 +506,14 @@ namespace
     // Directional navigation must update the editor target instead of only moving ImGui's highlight
     const bool focusedByNavigation = wasLastItemFocusedByDirectionalNavigation();
 
-    if(selectable && (focusedByNavigation
-        || (ImGui::IsItemClicked(ImGuiMouseButton_Left) && !ImGui::IsItemToggledOpen()))) {
+    const bool nodeIsClicked = ImGui::IsItemClicked(ImGuiMouseButton_Left)
+      && !ImGui::IsItemToggledOpen();
+
+    // Modified clicks bypass the regular TreeNode button focus handling
+    if (nodeIsClicked && (ImGui::GetIO().KeyCtrl || ImGui::GetIO().KeyShift))
+      ImGui::SetFocusID(ImGui::GetItemID(), ImGui::GetCurrentWindow());
+
+    if(selectable && (focusedByNavigation || nodeIsClicked)) {
       ctx.setNestedSelection(rootUuid, path);
       // Nested prefab targets cannot participate in the flat scene-object selection list
       rangeSelectionAnchorUUID = 0;
@@ -797,6 +803,11 @@ namespace
     bool nodeIsDoubleClicked = ImGui::IsItemHovered()
       && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)
       && !ImGui::IsMouseDragging(ImGuiMouseButton_Left);
+
+    // Make a modified click the starting point for subsequent arrow-key navigation
+    if (nodeIsClicked && (ImGui::GetIO().KeyCtrl || ImGui::GetIO().KeyShift))
+      ImGui::SetFocusID(ImGui::GetItemID(), ImGui::GetCurrentWindow());
+
     if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
       ImGui::OpenPopup("NodePopup");
     }

--- a/src/editor/pages/parts/sceneGraph.cpp
+++ b/src/editor/pages/parts/sceneGraph.cpp
@@ -24,6 +24,20 @@ namespace
   std::string renameBuffer{};
   bool startingRename{false};
 
+  // Range selection is based on the rows actually drawn in the scene graph, so collapsed
+  // branches and objects hidden by the search filter do not become selected unexpectedly.
+  uint32_t rangeSelectionAnchorUUID{0};
+  Project::Scene* rangeSelectionScene{nullptr};
+  std::vector<uint32_t> visibleObjectUUIDs{};
+
+  struct PendingObjectClick {
+    uint32_t uuid{0};
+    bool ctrl{false};
+    bool shift{false};
+  };
+
+  PendingObjectClick pendingObjectClick{};
+
   // Filters the tree by object name; empty means no filtering
   std::string searchFilter{};
 
@@ -326,6 +340,8 @@ namespace
 
     if(selectable && ImGui::IsItemClicked(ImGuiMouseButton_Left) && !ImGui::IsItemToggledOpen()) {
       ctx.setNestedSelection(rootUuid, path);
+      // Nested prefab targets cannot participate in the flat scene-object selection list
+      rangeSelectionAnchorUUID = 0;
     }
 
     if(isOpen) {
@@ -353,6 +369,72 @@ namespace
         return true;
     }
     return false;
+  }
+
+  /**
+   * Applies a scene-tree click after all visible rows have been collected for the frame.
+   * Shift replaces the selection with the anchored range. Ctrl+Shift adds that range, or
+   * removes it when the clicked endpoint was already selected.
+   */
+  void applyObjectClickSelection(const PendingObjectClick &click)
+  {
+    if (!click.uuid) return;
+
+    auto selectSingleOrToggle = [&click]() {
+      if (click.ctrl)
+        ctx.toggleObjectSelection(click.uuid);
+      else
+        ctx.setObjectSelection(click.uuid);
+      rangeSelectionAnchorUUID = click.uuid;
+    };
+
+    if (!click.shift || !rangeSelectionAnchorUUID) {
+      selectSingleOrToggle();
+      return;
+    }
+
+    auto anchorIt = std::find(
+      visibleObjectUUIDs.begin(), visibleObjectUUIDs.end(), rangeSelectionAnchorUUID
+    );
+    auto clickedIt = std::find(
+      visibleObjectUUIDs.begin(), visibleObjectUUIDs.end(), click.uuid
+    );
+
+    // A stale or currently hidden anchor cannot define a visible range, so treat this as
+    // a fresh click and give the next Shift+Click a useful anchor
+    if (anchorIt == visibleObjectUUIDs.end() || clickedIt == visibleObjectUUIDs.end()) {
+      selectSingleOrToggle();
+      return;
+    }
+
+    auto first = std::min(anchorIt, clickedIt);
+    auto last = std::max(anchorIt, clickedIt) + 1;
+    std::vector<uint32_t> range(first, last);
+
+    if (!click.ctrl) {
+      ctx.setObjectSelectionList(range, click.uuid);
+      return;
+    }
+
+    std::vector<uint32_t> selection = ctx.getSelectedObjectUUIDs();
+    const bool removeRange = ctx.isObjectSelected(click.uuid);
+    if (removeRange) {
+      selection.erase(
+        std::remove_if(selection.begin(), selection.end(), [&range](uint32_t uuid) {
+          return std::find(range.begin(), range.end(), uuid) != range.end();
+        }),
+        selection.end()
+      );
+    } else {
+      for (uint32_t uuid : range) {
+        if (std::find(selection.begin(), selection.end(), uuid) == selection.end())
+          selection.push_back(uuid);
+      }
+    }
+
+    // When adding, the clicked row becomes primary; when removing, retain the current
+    // primary if possible while Context falls back to the final remaining item otherwise
+    ctx.setObjectSelectionList(selection, removeRange ? ctx.selObjectUUID : click.uuid);
   }
 
   void drawObjectNode(
@@ -407,6 +489,8 @@ namespace
     // While editing a prefab, only that instance may be selected here. Its own definition
     // is handled by drawPrefabDefNode. All other scene objects are dimmed and inert.
     bool canSelect = !prefabEditObj || (&obj == prefabEditObj);
+    if (canSelect)
+      visibleObjectUUIDs.push_back(obj.uuid);
 
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0.f, 3_px));
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.f, 0.f));
@@ -509,12 +593,11 @@ namespace
     }
 
     if (nodeIsClicked && canSelect) {
-      bool isCtrlDown = ImGui::GetIO().KeyCtrl;
-      if (isCtrlDown) {
-        ctx.toggleObjectSelection(obj.uuid);
-      } else {
-        ctx.setObjectSelection(obj.uuid);
-      }
+      pendingObjectClick = {
+        .uuid = obj.uuid,
+        .ctrl = ImGui::GetIO().KeyCtrl,
+        .shift = ImGui::GetIO().KeyShift,
+      };
       //ImGui::SetWindowFocus("Object");
       //ImGui::SetWindowFocus("Graph");
     }
@@ -605,6 +688,12 @@ void Editor::SceneGraph::draw()
   deleteObj = nullptr;
   deleteSelection = false;
   prefabEditObj = Editor::SelectionUtils::getPrefabEditObject(*scene);
+  visibleObjectUUIDs.clear();
+  pendingObjectClick = {};
+  if (rangeSelectionScene != scene) {
+    rangeSelectionScene = scene;
+    rangeSelectionAnchorUUID = 0;
+  }
   bool isFocus = ImGui::IsWindowFocused();
   // While rename is active, shortcuts stay disabled, so the text field can own the keyboard input
   bool isRenaming = renameObjectUUID != 0;
@@ -644,6 +733,8 @@ void Editor::SceneGraph::draw()
   } else {
     drawObjectNode(*scene, root, keyDelete);
   }
+
+  applyObjectClickSelection(pendingObjectClick);
 
   // Use the remaining tree space as a drop target for root-level prefab or model objects
   if (!prefabEditObj && ImGui::IsDragDropActive()) {
@@ -692,6 +783,7 @@ void Editor::SceneGraph::draw()
       && ImGui::IsMouseClicked(ImGuiMouseButton_Left)
       && !ImGui::IsAnyItemHovered()) {
     ctx.clearObjectSelection();
+    rangeSelectionAnchorUUID = 0;
   }
 
   if(dragDropTask.sourceUUID && dragDropTask.targetUUID) {

--- a/src/editor/pages/parts/sceneGraph.cpp
+++ b/src/editor/pages/parts/sceneGraph.cpp
@@ -6,6 +6,7 @@
 #include "assetsBrowser.h"
 
 #include <algorithm>
+#include <cmath>
 #include <string>
 #include "imgui.h"
 #include "misc/cpp/imgui_stdlib.h"
@@ -52,6 +53,16 @@ namespace
   };
 
   DragDropTask dragDropTask{};
+
+  /**
+   * A possible sibling insertion point represented by a shared drop margin.
+   */
+  struct DropCandidate {
+    // Object after which the dragged roots would be inserted
+    uint32_t targetUUID{0};
+    // Horizontal position where a row inserted at this level would begin
+    float indentX{0.0f};
+  };
 
   struct AssetDropTask {
     uint64_t assetUUID{0};
@@ -183,35 +194,95 @@ namespace
     }
   }
 
-  bool DrawDropTarget(uint32_t& dragDropTarget, uint32_t uuid, float thickness = 2.0f, float hitHeight = 8.0f)
+  /**
+   * Draws an insertion margin that can represent several hierarchy levels.
+   *
+   * The indentation selects an explicit level. To the right of the deepest indentation,
+   * the upper half selects the deepest destination and the lower half the outermost one.
+   *
+   * @param candidates Destinations ordered from the deepest to the outermost level.
+   * @param thickness Thickness of the insertion preview line.
+   * @param hitHeight Height of the interactive insertion margin.
+   */
+  void DrawDropTarget(const std::vector<DropCandidate> &candidates, float thickness = 2.0f, float hitHeight = 8.0f)
   {
-    // Only show when drag-drop is active
-    if (!ImGui::IsDragDropActive())
-      return false;
+    // Avoid creating an invisible item when there is no active payload or destination
+    if (!ImGui::IsDragDropActive() || candidates.empty())
+      return;
 
-    bool res = false;
+    // Keep the current layout cursor because the hit zone is drawn as an overlay
     ImDrawList* drawList = ImGui::GetWindowDrawList();
     ImVec2 cursorScreen = ImGui::GetCursorScreenPos();
-    float fullWidth = ImGui::GetContentRegionAvail().x;
 
-    // Compute overlay position
+    // Extend the shared hit zone to the usable right edge of the scene graph
+    const float rightX = ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
+
+    // The last candidate is always the least-indented and outermost destination
+    const float outerX = candidates.back().indentX;
+
+    // Start at the outermost indentation so every explicit level remains reachable
     ImVec2 overlayStart{
-      cursorScreen.x - 4_px,
+      outerX - 4_px,
       cursorScreen.y - (hitHeight / 2) + 3_px
     };
-    ImVec2 overlayEnd = ImVec2(cursorScreen.x + fullWidth, cursorScreen.y + hitHeight);
-    lastInsertLineStart = {overlayStart.x, overlayStart.y};
-    lastInsertLineEnd = {overlayEnd.x, overlayStart.y};
+
+    // Cover the complete insertion margin without consuming layout space
+    ImVec2 overlayEnd{rightX, overlayStart.y + hitHeight};
+
+    // Default to the deepest destination for a margin without ambiguity
+    const ImVec2 mousePos = ImGui::GetMousePos();
+    size_t candidateIndex = 0;
+
+    // A chain with several candidates needs vertical or horizontal disambiguation
+    if (candidates.size() > 1) {
+      // To the right of the deepest indentation all candidates occupy the same space
+      if (mousePos.x > candidates.front().indentX) {
+        // The upper half stays inside the deepest parent while the lower half escapes it
+        candidateIndex = mousePos.y < (overlayStart.y + overlayEnd.y) * 0.5f
+          ? 0
+          : candidates.size() - 1;
+      } else {
+        // Inside the indentation gutter select the hierarchy level nearest to the cursor
+        float closestDistance = FLT_MAX;
+        for (size_t i = 0; i < candidates.size(); ++i) {
+          // Compare against the position where a row at this level would begin
+          float distance = std::abs(mousePos.x - candidates[i].indentX);
+          if (distance < closestDistance) {
+            // Retain both the nearest distance and its corresponding destination
+            closestDistance = distance;
+            candidateIndex = i;
+          }
+        }
+      }
+    }
+
+    // Resolve the destination before drawing and accepting the payload
+    const DropCandidate &candidate = candidates[candidateIndex];
+
+    // Indent the preview line to make the selected hierarchy level visible
+    ImVec2 lineStart{candidate.indentX - 4_px, overlayStart.y};
+    ImVec2 lineEnd{rightX, overlayStart.y};
+
+    // Keep the outermost line for asset drops in the empty area below the tree
+    lastInsertLineStart = {outerX - 4_px, overlayStart.y};
+    lastInsertLineEnd = {rightX, overlayStart.y};
     hasInsertLine = true;
 
-    // Push a dummy cursor to draw hit zone *without affecting layout*
+    // Move the cursor temporarily to create an overlapping hit zone
     ImGui::SetCursorScreenPos(overlayStart);
-    ImGui::PushID(("drop_overlay_" + std::to_string(uuid)).c_str());
-    ImGui::InvisibleButton("##dropzone", ImVec2(fullWidth, hitHeight));
+
+    // The outer target UUID uniquely identifies this boundary in the current tree
+    ImGui::PushID(("drop_overlay_" + std::to_string(candidates.back().targetUUID)).c_str());
+
+    // Register the complete shared margin as one ImGui item
+    ImGui::InvisibleButton("##dropzone", overlayEnd - overlayStart);
     bool hovered = ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem);
 
+    // Object payloads are always valid for the hierarchy move validation performed later
     const ImGuiPayload* activePayload = ImGui::GetDragDropPayload();
     bool acceptsPayload = activePayload && activePayload->IsDataType("OBJECT");
+
+    // Asset payloads only participate when they can create scene objects
     if (activePayload && activePayload->IsDataType("ASSET")) {
       uint64_t assetUUID = *static_cast<const uint64_t*>(activePayload->Data);
       auto asset = ctx.project->getAssets().getEntryByUUID(assetUUID);
@@ -219,34 +290,39 @@ namespace
         || asset->type == Project::FileType::MODEL_3D);
     }
 
+    // Draw only the line belonging to the destination currently selected by the cursor
     if (hovered && acceptsPayload) {
       drawList->AddLine(
-          ImVec2(overlayStart.x, overlayStart.y),
-          ImVec2(overlayEnd.x, overlayStart.y),
-          ImGui::GetColorU32(ImGuiCol_DragDropTarget),
-          thickness
+        lineStart,
+        lineEnd,
+        ImGui::GetColorU32(ImGuiCol_DragDropTarget),
+        thickness
       );
     }
 
+    // Suppress ImGui's full rectangular target highlight in favour of the insertion line
     ImGui::PushStyleColor(ImGuiCol_DragDropTarget, ImVec4(0,0,0,0));
-    // Accept drag payload
     if (ImGui::BeginDragDropTarget())
     {
+      // Record an object move as a sibling insertion after the chosen target
       if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("OBJECT"))
       {
-        dragDropTarget = *((uint32_t*)payload->Data);
-        res = true;
+        dragDropTask.sourceUUID = *static_cast<const uint32_t*>(payload->Data);
+        dragDropTask.targetUUID = candidate.targetUUID;
+        dragDropTask.isInsert = false;
       }
+
+      // Route prefab and model assets through the same chosen hierarchy level
       if (!prefabEditObj)
-        acceptSceneAssetDrop(uuid, false);
+        acceptSceneAssetDrop(candidate.targetUUID, false);
       ImGui::EndDragDropTarget();
     }
     ImGui::PopStyleColor();
 
     ImGui::PopID();
 
+    // Restore the cursor so the following tree row keeps its original position
     ImGui::SetCursorScreenPos(cursorScreen);
-    return res;
   }
 
   /**
@@ -528,7 +604,16 @@ namespace
     ctx.setObjectSelectionList(selection, removeRange ? ctx.selObjectUUID : click.uuid);
   }
 
-  void drawObjectNode(
+  /**
+   * Draws a scene object and returns the destinations available after its visible subtree.
+   *
+   * @param scene Scene containing the object.
+   * @param obj Object to draw.
+   * @param keyDelete Whether the delete shortcut was pressed this frame.
+   * @param parentEnabled Whether every ancestor of the object is enabled.
+   * @return Drop destinations ordered from the deepest visible node to the object itself.
+   */
+  std::vector<DropCandidate> drawObjectNode(
     Project::Scene &scene, Project::Object &obj, bool keyDelete,
     bool parentEnabled = true
   )
@@ -536,7 +621,7 @@ namespace
     bool hasSearchFilter = !searchFilter.empty();
     // Searching and this branch has no match anywhere --> Hide it entirely
     if (hasSearchFilter && !subtreeMatchesFilter(obj))
-      return;
+      return {};
 
     bool selfMatchesFilter = !hasSearchFilter || ImTable::labelMatchesFilter(obj.name.c_str(), searchFilter);
 
@@ -587,6 +672,7 @@ namespace
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.f, 0.f));
 
     std::string nameID = getNodeIcons(obj) + obj.name + "##" + std::to_string(obj.uuid);
+    const float nodeIndentX = ImGui::GetCursorScreenPos().x;
 
     // Set style disabled when editing a prefab or the element or an ancestor is disabled
     const bool dimNode = !canSelect || !parentEnabled || !obj.enabled;
@@ -697,6 +783,8 @@ namespace
       //ImGui::SetWindowFocus("Graph");
     }
 
+    // A leaf or collapsed object only exposes insertion after the object itself
+    std::vector<DropCandidate> tailCandidates{{obj.uuid, nodeIndentX}};
     if(isOpen)
     {
       if (ImGui::BeginPopupContextItem("NodePopup"))
@@ -740,22 +828,36 @@ namespace
 
       // The scene root provides the insertion point before its first object
       if (obj.parent == nullptr && !obj.children.empty() && ImGui::IsDragDropActive()) {
-        if (DrawDropTarget(dragDropTask.sourceUUID, obj.uuid)) {
-          dragDropTask.targetUUID = obj.uuid;
-        }
+        // Inserting after the root UUID is the special moveObject case for the first row
+        DrawDropTarget({{obj.uuid, ImGui::GetCursorScreenPos().x}});
       }
 
-      for(size_t i = 0; i < obj.children.size(); ++i) {
-        auto &child = obj.children[i];
-        drawObjectNode(scene, *child, keyDelete, parentEnabled && obj.enabled);
+      // Build the exact child sequence displayed by the active search filter
+      std::vector<Project::Object*> visibleChildren{};
+      visibleChildren.reserve(obj.children.size());
+      for (auto &child : obj.children) {
+        // Hidden branches must not create invisible drop destinations
+        if (!hasSearchFilter || subtreeMatchesFilter(*child))
+          visibleChildren.push_back(child.get());
+      }
 
-        // Nested lists leave their final boundary to the parent's sibling line
-        bool needsInsertLine = (i + 1 < obj.children.size()) || obj.parent == nullptr;
-        if (needsInsertLine && ImGui::IsDragDropActive()) {
-          if (DrawDropTarget(dragDropTask.sourceUUID, child->uuid)) {
-            dragDropTask.targetUUID = child->uuid;
-          }
-        }
+      // The final visible child carries the complete tail chain back to its ancestors
+      std::vector<DropCandidate> lastChildTail{};
+      for (size_t i = 0; i < visibleChildren.size(); ++i) {
+        // Recursively collect every valid level after this child's visible subtree
+        std::vector<DropCandidate> childTail = drawObjectNode(
+          scene, *visibleChildren[i], keyDelete, parentEnabled && obj.enabled
+        );
+
+        // Remember the most recent non-empty chain for the margin after this object
+        if (!childTail.empty())
+          lastChildTail = childTail;
+
+        // Non-final children own their following margin directly
+        // Root children also own it because no ancestor will draw a margin for the root
+        bool needsInsertLine = (i + 1 < visibleChildren.size()) || obj.parent == nullptr;
+        if (needsInsertLine)
+          DrawDropTarget(childTail);
       }
 
       // Prefab definition tree showing nested prefab content under the instance. Nodes are
@@ -767,8 +869,20 @@ namespace
         }
       }
 
+      // An expanded object ending in a visible child inherits that child's deeper levels
+      if (!lastChildTail.empty()) {
+        tailCandidates = std::move(lastChildTail);
+
+        // Add insertion after this object as the next outer level in the shared margin
+        // The scene root is excluded because objects cannot become its siblings
+        if (obj.parent)
+          tailCandidates.push_back({obj.uuid, nodeIndentX});
+      }
+
       ImGui::TreePop();
     }
+
+    return tailCandidates;
   }
 }
 

--- a/src/project/scene/scene.cpp
+++ b/src/project/scene/scene.cpp
@@ -196,7 +196,7 @@ void Project::Scene::removeAllObjects() {
   root.children.clear();
 }
 
-bool Project::Scene::moveObject(uint32_t uuidObject, uint32_t uuidTarget, bool asChild)
+bool Project::Scene::moveObject(uint32_t uuidObject, uint32_t uuidTarget, bool asChild, bool insertBefore)
 {
   if(uuidObject == uuidTarget) {
     return false;
@@ -242,7 +242,7 @@ bool Project::Scene::moveObject(uint32_t uuidObject, uint32_t uuidTarget, bool a
       // Add as sibling to target
       auto parent = target->parent;
       if (parent) {
-        // insert after target
+        // Insert before or after the target
         auto &siblings = parent->children;
         auto it = std::find_if(
           siblings.begin(), siblings.end(),
@@ -250,7 +250,7 @@ bool Project::Scene::moveObject(uint32_t uuidObject, uint32_t uuidTarget, bool a
         );
         if (it != siblings.end())
         {
-          siblings.insert(it + 1, obj);
+          siblings.insert(insertBefore ? it : it + 1, obj);
           obj->parent = parent;
         }
       }

--- a/src/project/scene/scene.h
+++ b/src/project/scene/scene.h
@@ -89,7 +89,16 @@ namespace Project
       void removeObject(Object &obj);
       void removeAllObjects();
 
-      bool moveObject(uint32_t uuidObject, uint32_t uuidTarget, bool asChild);
+      /**
+       * Moves an object relative to another scene object or the scene root.
+       *
+       * @param uuidObject UUID of the object to move.
+       * @param uuidTarget UUID of the destination object or scene root.
+       * @param asChild Whether to append the object as a child of the destination.
+       * @param insertBefore Whether sibling insertion should occur before the destination (this is the only way to insert as first child when there are already child elements).
+       * @return True when the object was moved.
+       */
+      bool moveObject(uint32_t uuidObject, uint32_t uuidTarget, bool asChild, bool insertBefore = false);
 
       std::shared_ptr<Object> getObjectByUUID(uint32_t uuid) {
         if (objectsMap.contains(uuid)) {


### PR DESCRIPTION
## Summary
Many improvements related to multi selection and the scene graph in general.

## Changes
- Allow to multi-select with Shift+Click. Also works with Ctrl in addition to add a range.
- Allow to drag-drop several objects at a time.
- Allow to drop after the last child when there is an element higher in the hierarchy below.
- Allow to choose the depth where the nodes will be moved, when dropping after the last element of a branch. Displays a vertical line to show the target previous sibling
- Allow to drop as the first child, when there are already any children.
- Navigating using the arrow keys now changes the focused object.

<img width="360" height="218" alt="Tree multi select" src="https://github.com/user-attachments/assets/f8065ea1-93af-4620-ba9b-4e679b9b4dac" />
