### PR TITLE
docs: Add info about SDL dependencies to build docs

### DIFF
--- a/docs/docs/dev/build.rst
+++ b/docs/docs/dev/build.rst
@@ -1,9 +1,9 @@
 Building the Editor
 ====================================
 
-| Below are instructions to build the editor on either Linux or Windows.
-| Note that due to a small dependency on libdragon, GCC is required for now.
-| On Windows, that means building via MSYS2.
+Below are instructions to build the editor on either Linux, Windows, or MacOS.
+
+Note that due to a small dependency on libdragon, **GCC is required** for now. On Windows, that means **building via MSYS2**.
 
 ====================
 Prerequisites
@@ -11,12 +11,21 @@ Prerequisites
 
 Before building the project, make sure you have the following tools installed:
 
-* CMake
+* CMake 3.28+
 * Ninja
-* GCC with at least C++23 support
-* Git LFS
+* GCC and G++ with at least C++23 support
+* Git and Git-LFS
+* Python 3+
 
-Linux users should follow the conventions of their distribution and package manager for all packages.
+Linux
+--------------------
+
+Linux users should follow the conventions of their distribution and package manager for all prerequisites listed above.
+
+Additionally, Linux users may require installing extra development packages to be able to build SDL3 (which is a dependency of Pyrite64). Please read the `SDL documentation <https://wiki.libsdl.org/SDL3/README-linux#build-dependencies>`__ for more information.
+
+Windows
+--------------------
 
 | Windows users need to make sure a recent version of MSYS2_ is installed.
 | Open an MSYS2 terminal in the ``UCRT64`` environment, and install the UCRT-specific packages for the dependencies:
@@ -29,9 +38,17 @@ Linux users should follow the conventions of their distribution and package mana
   pacman -S mingw-w64-ucrt-x86_64-python
 
 
+MacOS
+--------------------
+
+TODO: to be added
+
 ====================
 Git LFS
 ====================
+
+Installation
+--------------------
 
 On some Linux distributions, Git LFS may require adding an external repository to your package manager per these 
 `instructions <https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md>`__.
@@ -43,6 +60,9 @@ Windows users should already have Git LFS installed as part of Git for Windows. 
   git lfs version
 
 If no version is shown, install Git LFS from their website (https://git-lfs.com/).
+
+Setup
+--------------------
 
 After installing Git LFS, initialize it by running:
 
@@ -89,7 +109,7 @@ Where ``<preset>`` is replaced with the CMake preset name corresponding to your 
 * ``macos-release`` for MacOS systems, release version
 
 | Once the build is finished, a program called ``pyrite64`` (or ``pyrite64.exe``) should be placed in the root directory of the repo.
-| The program itself can be placed anywhere on the system, however the ``./data`` and ``./n64`` directories must stay next to it.
+| The program itself can be placed anywhere on the system, however, the ``./data`` and ``./n64`` directories must stay next to it.
 
 To open the editor, simply execute ``./pyrite64`` (or ``.\pyrite64.exe``).
 


### PR DESCRIPTION
There was a Fedora user who expressed confusion because SDL required additional dependencies so I added a link to SDL documentation regarding Linux to the docs.