### PR TITLE
Fix: handle collider shape changes properly & expose sensible collider api

### DIFF
--- a/docs/docs/manual/editor/components/collBody.md
+++ b/docs/docs/manual/editor/components/collBody.md
@@ -22,6 +22,34 @@ Pair it with a {doc}`Rigid-Body <rigidBody>` for full physics simulation.
 | **Friction** | Surface friction, `0` to `1`. |
 | **Bounce** | Restitution / bounciness, `0` to `1`. |
 
+## Resizing at runtime
+
+The size set here is the *unscaled* half extend, the object's scale is applied on top of it.
+Change it from a script through the component, which re-applies the object scale and refreshes
+the collider's AABB:
+
+```cpp
+auto collBody = obj.getComponent<Comp::CollBody>();
+
+auto halfExtend = collBody->getHalfExtend();
+halfExtend.y += 0.5f; // e.g. the half height of a cylinder/capsule/cone
+collBody->setHalfExtend(halfExtend);
+```
+
+This function can be used regardless of what shape the collider has.
+Shapes that don't use all three axes fold them in, e.g. a cylinder takes its radius from
+`max(x, z)` and its half height from `y`. A sphere will determine its
+radius by the maximum component of the `halfExtend`, etc.
+
+To set the final (already scaled) size directly, or to change the shape type, use the setters on
+{cpp:struct}`P64::Coll::Collider` itself, e.g. `setCylinderShape()`. Note that those get
+overwritten by the component as soon as the object is scaled, `setHalfExtend()` is the permanent
+version. **Offset** has its own setter, `setParentOffset()`, and is not cached by the component.
+
+All of them keep the AABB and the mass properties of an attached {doc}`Rigid-Body <rigidBody>`
+in sync and wake up sleeping bodies the change may touch, writing to a shape directly is not
+possible for that reason.
+
 ## See also
 
 - {doc}`Collision & Physics <../collision>`: general collision & physics docs.

--- a/docs/docs/manual/editor/components/collBody.md
+++ b/docs/docs/manual/editor/components/collBody.md
@@ -22,33 +22,35 @@ Pair it with a {doc}`Rigid-Body <rigidBody>` for full physics simulation.
 | **Friction** | Surface friction, `0` to `1`. |
 | **Bounce** | Restitution / bounciness, `0` to `1`. |
 
-## Resizing at runtime
+## Changing a collider at runtime
 
-The size set here is the *unscaled* half extend, the object's scale is applied on top of it.
-Change it from a script through the component, which re-applies the object scale and refreshes
-the collider's AABB:
+Every value on this page is set on the collider itself, the component only creates it and
+registers it with the collision scene:
 
 ```cpp
-auto collBody = obj.getComponent<Comp::CollBody>();
+auto &coll = obj.getComponent<Comp::CollBody>()->collider;
 
-auto halfExtend = collBody->getHalfExtend();
-halfExtend.y += 0.5f; // e.g. the half height of a cylinder/capsule/cone
-collBody->setHalfExtend(halfExtend);
+auto halfExtend = coll.halfExtend();
+halfExtend.y += 0.5f;                        // e.g. the half height of a cylinder/capsule/cone
+coll.setHalfExtend(halfExtend);
+
+coll.setCylinderShape(0.5f, 2.0f);           // size and shape type in one go
+coll.setShapeType(Coll::ShapeType::Capsule); // keeps the size, folds it into the new shape
+coll.setParentOffset({0.0f, 1.0f, 0.0f});    // moves the shape's center
 ```
 
-This function can be used regardless of what shape the collider has.
-Shapes that don't use all three axes fold them in, e.g. a cylinder takes its radius from
-`max(x, z)` and its half height from `y`. A sphere will determine its
-radius by the maximum component of the `halfExtend`, etc.
+Sizes and offsets are in the object's local space, exactly like the values in the editor: the
+object scale is applied on top of them and stays applied when the object is scaled later on.
+The object-scaled result the collision detection runs on is read-only and named `world...`,
+e.g. {cpp:struct}`P64::Coll::Collider`'s `worldCylinderShape()` or `worldAabb()`.
 
-To set the final (already scaled) size directly, or to change the shape type, use the setters on
-{cpp:struct}`P64::Coll::Collider` itself, e.g. `setCylinderShape()`. Note that those get
-overwritten by the component as soon as the object is scaled, `setHalfExtend()` is the permanent
-version. **Offset** has its own setter, `setParentOffset()`, and is not cached by the component.
+`setHalfExtend()` works for every shape. Shapes that don't use all three axes fold them in, e.g.
+a cylinder takes its radius from `max(x, z)` and its half height from `y`, and a sphere takes its
+radius from the largest component.
 
-All of them keep the AABB and the mass properties of an attached {doc}`Rigid-Body <rigidBody>`
-in sync and wake up sleeping bodies the change may touch, writing to a shape directly is not
-possible for that reason.
+All setters keep the AABB (and with it the broadphase) plus the mass properties of an attached
+{doc}`Rigid-Body <rigidBody>` in sync, and wake up sleeping bodies the change may touch. That is
+why the dimensions cannot be written directly.
 
 ## See also
 

--- a/docs/docs/version/breakingChanges.md
+++ b/docs/docs/version/breakingChanges.md
@@ -164,30 +164,39 @@ The viewport fly and zoom speeds are stored in meters now. Their preference keys
 existing settings fall back to the new defaults. Re-adjust them under *Preferences* if you had
 them customized.
 
-### Resizing colliders in C++
+### Changing colliders in C++
 
-Collider shapes are read-only now, they are resized through setters that also refresh the world
-AABB for accurate collision detection (and the mass properties of an attached rigid body).
+`Coll::Collider` now owns the geometry of a collider and is the only place that changes it.
+Dimensions and the offset are in the object's local space (the same values the editor shows), the
+object-scaled result the collision runs on is derived, read-only and named `world...`.
+
+Writing to a shape used to leave the broadphase with the old size, so the non-const shape
+accessors were replaced by setters that keep the world AABB, the mass properties of an attached
+rigid body and the sleep state in sync:
 
 ```cpp
-// Before, would have been overwritten by the component on next update:
+// Before:
 auto &coll = obj.getComponent<Comp::CollBody>()->collider;
-coll.cylinderShape().halfHeight = 2.0f;
+coll.cylinderShape().halfHeight = 2.0f;             // object-scaled, silently stale broadphase
 
-// Now, permanent (the component keeps applying the object scale on top of it):
-auto collBody = obj.getComponent<Comp::CollBody>();
-auto halfExtend = collBody->getHalfExtend();
+// Now:
+auto halfExtend = coll.halfExtend();                // local, like the editor
 halfExtend.y = 2.0f;
-collBody->setHalfExtend(halfExtend);
-
-// or directly on the collider, in final world size:
-coll.setCylinderShape(coll.cylinderShape().radius, 2.0f);
+coll.setHalfExtend(halfExtend);
+// or, size and type in one call:
+coll.setCylinderShape(coll.halfExtend().x, 2.0f);
 ```
 
-Note that `set{SHAPE}Shape()` will also change the shape type if the collider was not of this shape before.
+Note that `set{SHAPE}Shape()` will also change the shape type if the collider was not of this
+shape before.
 
-`Comp::CollBody::orgScale` became the private `halfExtend_`, use `getHalfExtend()` /
-`setHalfExtend()` instead.
+Reading the object-scaled dimensions, e.g. inside a collision callback, gained a `world` prefix:
+`sphereShape()` became `worldSphereShape()`, `boxShape()` became `worldBoxShape()`, and so on.
+
+`Comp::CollBody` is a plain holder now, it creates the collider from the editor values and
+registers it with the collision scene. `orgScale` and its half extend / shape / scale helpers are
+gone, use the `collider` member for all of it. `Collider::setShapeType()` no longer resets the
+dimensions to zero, it keeps the size and folds it into the new shape.
 
 ## v0.7.0
 

--- a/docs/docs/version/breakingChanges.md
+++ b/docs/docs/version/breakingChanges.md
@@ -164,6 +164,31 @@ The viewport fly and zoom speeds are stored in meters now. Their preference keys
 existing settings fall back to the new defaults. Re-adjust them under *Preferences* if you had
 them customized.
 
+### Resizing colliders in C++
+
+Collider shapes are read-only now, they are resized through setters that also refresh the world
+AABB for accurate collision detection (and the mass properties of an attached rigid body).
+
+```cpp
+// Before, would have been overwritten by the component on next update:
+auto &coll = obj.getComponent<Comp::CollBody>()->collider;
+coll.cylinderShape().halfHeight = 2.0f;
+
+// Now, permanent (the component keeps applying the object scale on top of it):
+auto collBody = obj.getComponent<Comp::CollBody>();
+auto halfExtend = collBody->getHalfExtend();
+halfExtend.y = 2.0f;
+collBody->setHalfExtend(halfExtend);
+
+// or directly on the collider, in final world size:
+coll.setCylinderShape(coll.cylinderShape().radius, 2.0f);
+```
+
+Note that `set{SHAPE}Shape()` will also change the shape type if the collider was not of this shape before.
+
+`Comp::CollBody::orgScale` became the private `halfExtend_`, use `getHalfExtend()` /
+`setHalfExtend()` instead.
+
 ## v0.7.0
 
 This version completely reworked the material system as well as the collision/physics system.<br>

--- a/n64/engine/include/collision/colliderShape.h
+++ b/n64/engine/include/collision/colliderShape.h
@@ -23,6 +23,15 @@ namespace P64::Coll {
   struct RigidBody;
 
   struct Collider {
+    // Dimensions of colliders themselves are always in world scale (the object scale is already baked in) and
+    // read-only. To change the size of a collider use one of the setters. Together with
+    // setParentOffset() they keep the world AABB (and with it the broadphase) plus the mass
+    // properties of an attached rigid body in sync, and wake up whatever the change may touch.
+    // Note that a collider created by the 'CollBody' component gets its
+    // size rebuilt from the component whenever the object scale changes, see
+    // 'Comp::CollBody::setHalfExtend()' to resize those permanently.
+
+    /// Changes the shape type, this resets all dimensions back to zero.
     void setShapeType(ShapeType newType) {
       type_ = newType;
       switch(type_) {
@@ -33,21 +42,77 @@ namespace P64::Coll {
         case ShapeType::Cone:     cone_ = {}; break;
         case ShapeType::Pyramid:  pyramid_ = {}; break;
       }
+      markGeometryChanged();
     }
     ShapeType shapeType() const { return type_; }
 
-    SphereShape &sphereShape() { return sphere_; }
     const SphereShape &sphereShape() const { return sphere_; }
-    BoxShape &boxShape() { return box_; }
     const BoxShape &boxShape() const { return box_; }
-    CapsuleShape &capsuleShape() { return capsule_; }
     const CapsuleShape &capsuleShape() const { return capsule_; }
-    CylinderShape &cylinderShape() { return cylinder_; }
     const CylinderShape &cylinderShape() const { return cylinder_; }
-    ConeShape &coneShape() { return cone_; }
     const ConeShape &coneShape() const { return cone_; }
-    PyramidShape &pyramidShape() { return pyramid_; }
     const PyramidShape &pyramidShape() const { return pyramid_; }
+
+    /// Makes this a sphere collider of the given size.
+    void setSphereShape(float radius) {
+      if(type_ == ShapeType::Sphere && sphere_.radius == radius) return;
+      type_ = ShapeType::Sphere;
+      sphere_.radius = radius;
+      markGeometryChanged();
+    }
+
+    /// Makes this a box collider of the given size.
+    void setBoxShape(const fm_vec3_t &halfSize) {
+      if(type_ == ShapeType::Box && box_.halfSize == halfSize) return;
+      type_ = ShapeType::Box;
+      box_.halfSize = halfSize;
+      markGeometryChanged();
+    }
+
+    /// Makes this a capsule collider of the given size ('innerHalfHeight' excludes the round caps).
+    void setCapsuleShape(float radius, float innerHalfHeight) {
+      if(type_ == ShapeType::Capsule && capsule_.radius == radius && capsule_.innerHalfHeight == innerHalfHeight) return;
+      type_ = ShapeType::Capsule;
+      capsule_.radius = radius;
+      capsule_.innerHalfHeight = innerHalfHeight;
+      markGeometryChanged();
+    }
+
+    /// Makes this a cylinder collider of the given size.
+    void setCylinderShape(float radius, float halfHeight) {
+      if(type_ == ShapeType::Cylinder && cylinder_.radius == radius && cylinder_.halfHeight == halfHeight) return;
+      type_ = ShapeType::Cylinder;
+      cylinder_.radius = radius;
+      cylinder_.halfHeight = halfHeight;
+      markGeometryChanged();
+    }
+
+    /// Makes this a cone collider of the given size.
+    void setConeShape(float radius, float halfHeight) {
+      if(type_ == ShapeType::Cone && cone_.radius == radius && cone_.halfHeight == halfHeight) return;
+      type_ = ShapeType::Cone;
+      cone_.radius = radius;
+      cone_.halfHeight = halfHeight;
+      markGeometryChanged();
+    }
+
+    /// Makes this a pyramid collider of the given size.
+    void setPyramidShape(float baseHalfWidthX, float baseHalfWidthZ, float halfHeight) {
+      if(type_ == ShapeType::Pyramid && pyramid_.baseHalfWidthX == baseHalfWidthX && pyramid_.baseHalfWidthZ == baseHalfWidthZ && pyramid_.halfHeight == halfHeight) return;
+      type_ = ShapeType::Pyramid;
+      pyramid_.baseHalfWidthX = baseHalfWidthX;
+      pyramid_.baseHalfWidthZ = baseHalfWidthZ;
+      pyramid_.halfHeight = halfHeight;
+      markGeometryChanged();
+    }
+
+    /// Resizes the current shape from a half-extend box, keeping the shape type the same.
+    /// Axes a shape has no use for are folded in, e.g. a cylinder takes its radius from
+    /// max(x, z) and its half height from y. Negative values are mirrored.
+    void setHalfExtend(const fm_vec3_t &newHalfExtend);
+
+    /// Size of the current shape as a half-extend box.
+    fm_vec3_t halfExtend() const;
 
     void setOwner(P64::Object *newOwner) {
       owner_ = newOwner;
@@ -55,7 +120,13 @@ namespace P64::Coll {
     }
     P64::Object *ownerObject() const { return owner_; }
 
-    void setParentOffset(const fm_vec3_t &newParentOffset) { parentOffset_ = newParentOffset; }
+    /// Moves the shape's center relative to the owner's origin. In the owner's local space,
+    /// the object scale is applied on top of it.
+    void setParentOffset(const fm_vec3_t &newParentOffset) {
+      if(parentOffset_ == newParentOffset) return;
+      parentOffset_ = newParentOffset;
+      markGeometryChanged();
+    }
     const fm_vec3_t &parentOffset() const { return parentOffset_; }
 
     void setBounce(float newBounce) { bounce_ = newBounce; }
@@ -96,6 +167,11 @@ namespace P64::Coll {
   private:
     friend class CollisionScene;
 
+    /// Flags the shape's size or local placement as changed. On the next collision step the
+    /// world AABB (and the mass properties of an attached rigid body) are rebuilt and sleeping
+    /// bodies the change may touch are woken. All shape setters call this.
+    void markGeometryChanged();
+
     union {
       SphereShape sphere_;
       BoxShape box_;
@@ -125,6 +201,8 @@ namespace P64::Coll {
     uint8_t writeMask_{0x00};
     bool hasCachedOwnerTransform_{false};
     bool isTrigger_{false};
+    // set by the shape setters, forces a world AABB rebuild even if the transform didn't change
+    bool geometryDirty_{false};
   };
 
   /// GJK-compatible support wrapper

--- a/n64/engine/include/collision/colliderShape.h
+++ b/n64/engine/include/collision/colliderShape.h
@@ -23,111 +23,81 @@ namespace P64::Coll {
   struct RigidBody;
 
   struct Collider {
-    // Dimensions of colliders themselves are always in world scale (the object scale is already baked in) and
-    // read-only. To change the size of a collider use one of the setters. Together with
-    // setParentOffset() they keep the world AABB (and with it the broadphase) plus the mass
-    // properties of an attached rigid body in sync, and wake up whatever the change may touch.
-    // Note that a collider created by the 'CollBody' component gets its
-    // size rebuilt from the component whenever the object scale changes, see
-    // 'Comp::CollBody::setHalfExtend()' to resize those permanently.
+    // Everything that can be set is in the owner object's local space, exactly like the values in
+    // the editor. The object scale is applied on top of it and stays applied when the object
+    // is scaled later on. The world-scale result is derived and read-only.
 
-    /// Changes the shape type, this resets all dimensions back to zero.
-    void setShapeType(ShapeType newType) {
-      type_ = newType;
-      switch(type_) {
-        case ShapeType::Sphere:   sphere_ = {}; break;
-        case ShapeType::Box:      box_ = {}; break;
-        case ShapeType::Capsule:  capsule_ = {}; break;
-        case ShapeType::Cylinder: cylinder_ = {}; break;
-        case ShapeType::Cone:     cone_ = {}; break;
-        case ShapeType::Pyramid:  pyramid_ = {}; break;
-      }
-      markGeometryChanged();
-    }
+    /// Changes the shape type, the size is kept and folded into the new shape.
+    void setShapeType(ShapeType newType) { setShape(newType, localHalfExtend_); }
     ShapeType shapeType() const { return type_; }
 
-    const SphereShape &sphereShape() const { return sphere_; }
-    const BoxShape &boxShape() const { return box_; }
-    const CapsuleShape &capsuleShape() const { return capsule_; }
-    const CylinderShape &cylinderShape() const { return cylinder_; }
-    const ConeShape &coneShape() const { return cone_; }
-    const PyramidShape &pyramidShape() const { return pyramid_; }
-
-    /// Makes this a sphere collider of the given size.
-    void setSphereShape(float radius) {
-      if(type_ == ShapeType::Sphere && sphere_.radius == radius) return;
-      type_ = ShapeType::Sphere;
-      sphere_.radius = radius;
-      markGeometryChanged();
-    }
-
-    /// Makes this a box collider of the given size.
-    void setBoxShape(const fm_vec3_t &halfSize) {
-      if(type_ == ShapeType::Box && box_.halfSize == halfSize) return;
-      type_ = ShapeType::Box;
-      box_.halfSize = halfSize;
-      markGeometryChanged();
-    }
-
-    /// Makes this a capsule collider of the given size ('innerHalfHeight' excludes the round caps).
-    void setCapsuleShape(float radius, float innerHalfHeight) {
-      if(type_ == ShapeType::Capsule && capsule_.radius == radius && capsule_.innerHalfHeight == innerHalfHeight) return;
-      type_ = ShapeType::Capsule;
-      capsule_.radius = radius;
-      capsule_.innerHalfHeight = innerHalfHeight;
-      markGeometryChanged();
-    }
-
-    /// Makes this a cylinder collider of the given size.
-    void setCylinderShape(float radius, float halfHeight) {
-      if(type_ == ShapeType::Cylinder && cylinder_.radius == radius && cylinder_.halfHeight == halfHeight) return;
-      type_ = ShapeType::Cylinder;
-      cylinder_.radius = radius;
-      cylinder_.halfHeight = halfHeight;
-      markGeometryChanged();
-    }
-
-    /// Makes this a cone collider of the given size.
-    void setConeShape(float radius, float halfHeight) {
-      if(type_ == ShapeType::Cone && cone_.radius == radius && cone_.halfHeight == halfHeight) return;
-      type_ = ShapeType::Cone;
-      cone_.radius = radius;
-      cone_.halfHeight = halfHeight;
-      markGeometryChanged();
-    }
-
-    /// Makes this a pyramid collider of the given size.
-    void setPyramidShape(float baseHalfWidthX, float baseHalfWidthZ, float halfHeight) {
-      if(type_ == ShapeType::Pyramid && pyramid_.baseHalfWidthX == baseHalfWidthX && pyramid_.baseHalfWidthZ == baseHalfWidthZ && pyramid_.halfHeight == halfHeight) return;
-      type_ = ShapeType::Pyramid;
-      pyramid_.baseHalfWidthX = baseHalfWidthX;
-      pyramid_.baseHalfWidthZ = baseHalfWidthZ;
-      pyramid_.halfHeight = halfHeight;
-      markGeometryChanged();
-    }
-
-    /// Resizes the current shape from a half-extend box, keeping the shape type the same.
+    /// Resizes the current shape from a half-extend box, keeping the shape type.
     /// Axes a shape has no use for are folded in, e.g. a cylinder takes its radius from
     /// max(x, z) and its half height from y. Negative values are mirrored.
-    void setHalfExtend(const fm_vec3_t &newHalfExtend);
+    void setHalfExtend(const fm_vec3_t &newHalfExtend) { setShape(type_, newHalfExtend); }
+    /// Size of the collider in the owner's local space, as set by any of the setters.
+    const fm_vec3_t &halfExtend() const { return localHalfExtend_; }
 
-    /// Size of the current shape as a half-extend box.
-    fm_vec3_t halfExtend() const;
-
-    void setOwner(P64::Object *newOwner) {
-      owner_ = newOwner;
-      hasCachedOwnerTransform_ = false;
+    /// @brief Makes this a sphere collider of the given size.
+    /// @param radius The radius of the sphere
+    void setSphereShape(float radius) {
+      setShape(ShapeType::Sphere, fm_vec3_t{{radius, radius, radius}});
     }
-    P64::Object *ownerObject() const { return owner_; }
 
-    /// Moves the shape's center relative to the owner's origin. In the owner's local space,
-    /// the object scale is applied on top of it.
+    /// @brief Makes this a box collider of the given size.
+    /// @param halfSize The half size vector of the box
+    void setBoxShape(const fm_vec3_t &halfSize) {
+      setShape(ShapeType::Box, halfSize);
+    }
+
+    /// @brief Makes this a capsule collider of the given size ('innerHalfHeight' excludes the round caps).
+    /// @param radius The radius of the capsule
+    /// @param innerHalfHeight The half height of the capsule's cylindrical part
+    void setCapsuleShape(float radius, float innerHalfHeight) {
+      setShape(ShapeType::Capsule, fm_vec3_t{{radius, innerHalfHeight, radius}});
+    }
+
+    /// @brief Makes this a cylinder collider of the given size.
+    /// @param radius The radius of the cylinder
+    /// @param halfHeight The half height of the cylinder
+    void setCylinderShape(float radius, float halfHeight) {
+      setShape(ShapeType::Cylinder, fm_vec3_t{{radius, halfHeight, radius}});
+    }
+    /// @brief Makes this a cone collider of the given size.
+    /// @param radius The radius of the cone's base
+    /// @param halfHeight The half height of the cone
+    void setConeShape(float radius, float halfHeight) {
+      setShape(ShapeType::Cone, fm_vec3_t{{radius, halfHeight, radius}});
+    }
+    /// @brief Makes this a pyramid collider of the given size.
+    /// @param baseHalfWidthX Half the width of the base along the X axis
+    /// @param baseHalfWidthZ Half the width of the base along the Z axis
+    /// @param halfHeight Half the height of the pyramid along the Y axis
+    void setPyramidShape(float baseHalfWidthX, float baseHalfWidthZ, float halfHeight) {
+      setShape(ShapeType::Pyramid, fm_vec3_t{{baseHalfWidthX, halfHeight, baseHalfWidthZ}});
+    }
+
+    /// @brief Moves the shape's center relative to the owner's origin, in the owner's local space.
     void setParentOffset(const fm_vec3_t &newParentOffset) {
       if(parentOffset_ == newParentOffset) return;
       parentOffset_ = newParentOffset;
       markGeometryChanged();
     }
     const fm_vec3_t &parentOffset() const { return parentOffset_; }
+
+    // Object-scaled dimensions the collision detection runs on, derived from the setters above.
+    const SphereShape &worldSphereShape() const { return sphere_; }
+    const BoxShape &worldBoxShape() const { return box_; }
+    const CapsuleShape &worldCapsuleShape() const { return capsule_; }
+    const CylinderShape &worldCylinderShape() const { return cylinder_; }
+    const ConeShape &worldConeShape() const { return cone_; }
+    const PyramidShape &worldPyramidShape() const { return pyramid_; }
+
+    void setOwner(P64::Object *newOwner) {
+      owner_ = newOwner;
+      hasCachedOwnerTransform_ = false;
+    }
+    P64::Object *ownerObject() const { return owner_; }
 
     void setBounce(float newBounce) { bounce_ = newBounce; }
     float bounce() const { return bounce_; }
@@ -166,10 +136,33 @@ namespace P64::Coll {
 
   private:
     friend class CollisionScene;
+    
+    /// @brief Applies a new shape type and/or local size, and derives the world-scale shape from it.
+    /// @param newType The new shape type
+    /// @param newLocalHalfExtend The new local half extend encoded in a vector, axes unused by the shape are folded in
+    void setShape(ShapeType newType, const fm_vec3_t &newLocalHalfExtend) {
+      if(type_ == newType && localHalfExtend_ == newLocalHalfExtend) return;
+      type_ = newType;
+      localHalfExtend_ = newLocalHalfExtend;
+      refreshWorldShape();
+    }
 
-    /// Flags the shape's size or local placement as changed. On the next collision step the
-    /// world AABB (and the mass properties of an attached rigid body) are rebuilt and sleeping
-    /// bodies the change may touch are woken. All shape setters call this.
+
+    /// @brief Whether the geometry of the collider changed since this was last called, resets the flag.
+    /// Used by the collision scene to wake up what the geometry change may affect.
+    /// @return true if the geometry changed since the last call, false otherwise
+    bool consumeGeometryChanged() {
+      const bool changed = geometryDirty_;
+      geometryDirty_ = false;
+      return changed;
+    }
+
+    /// @brief Rebuilds the object-scaled shape from the local half extend, called whenever either changes.
+    void refreshWorldShape();
+
+    /// @brief Flags the size or local placement as changed. On the next collision step the world AABB
+    /// (and the mass properties of an attached rigid body) are rebuilt and sleeping bodies the
+    /// change may touch are woken. Called by refreshWorldShape() and the offset setter.
     void markGeometryChanged();
 
     union {
@@ -188,6 +181,8 @@ namespace P64::Coll {
     Matrix3x3 inverseRotationMatrix_{Matrix3x3::identity()};
     AABB worldAabb_{};
     fm_vec3_t worldCenter_{};
+    // authored size in the owner's local space, the shape union above is this * the object scale
+    fm_vec3_t localHalfExtend_{};
     fm_vec3_t parentOffset_{};
     fm_vec3_t lastOwnerPosition_{};
     fm_quat_t lastOwnerRotation_{QUAT_IDENTITY};
@@ -201,11 +196,14 @@ namespace P64::Coll {
     uint8_t writeMask_{0x00};
     bool hasCachedOwnerTransform_{false};
     bool isTrigger_{false};
-    // set by the shape setters, forces a world AABB rebuild even if the transform didn't change
+    // forces a world AABB rebuild even if the transform didn't change, consumed by the collision scene
     bool geometryDirty_{false};
   };
 
-  /// GJK-compatible support wrapper
+  /// @brief GJK-compatible support wrapper
+  /// @param data The collider data
+  /// @param direction The direction to query
+  /// @param output The resulting support point
   void colliderGjkSupport(const void *data, const fm_vec3_t &direction, fm_vec3_t &output);
 
 } // namespace P64::Coll

--- a/n64/engine/include/collision/collisionScene.h
+++ b/n64/engine/include/collision/collisionScene.h
@@ -282,6 +282,7 @@ namespace P64::Coll {
 
     void wakeIsland(RigidBody *rigidBody);
     void wakeMovedBody(RigidBody *body);
+    void wakeChangedCollider(Collider *collider);
     void syncExternallyMovedBodies();
     void updateSleepStates();
     void refreshContacts();

--- a/n64/engine/include/scene/components/collBody.h
+++ b/n64/engine/include/scene/components/collBody.h
@@ -12,35 +12,14 @@
 
 namespace P64::Comp
 {
+  /// Component that attaches a primitive-shape collider to an object and registers it with the collision scene.
+  /// Everything about the collider itself (size, shape, offset, masks, ...) is set on
+  /// 'collider' directly, see 'Coll::Collider'.
   struct CollBody
   {
     static constexpr uint32_t ID = 5;
 
     Coll::Collider collider{};
-
-    /// Resizes the collider. Like the half extend set in the editor this is in the object's
-    /// local space, the object scale gets applied on top of it and stays applied when the
-    /// object is scaled later on. Shapes that don't use all three axes fold them in,
-    /// see 'Coll::Collider::setHalfExtend()'.
-    void setHalfExtend(const fm_vec3_t &newHalfExtend) {
-      halfExtend_ = newHalfExtend;
-      applyObjectScale(appliedScale_);
-    }
-    /// Unscaled half extend, multiply with the object scale to get the collider's world size.
-    const fm_vec3_t &getHalfExtend() const { return halfExtend_; }
-
-    /// Changes the shape type and keeps the current half extend, unlike the collider's own
-    /// setShapeType() which resets the dimensions of the new shape to zero.
-    void setShapeType(Coll::ShapeType type) {
-      collider.setShapeType(type);
-      applyObjectScale(appliedScale_);
-    }
-
-    /// Rebuilds the collider size from the half extend scaled by the given object scale.
-    void applyObjectScale(const fm_vec3_t &objectScale) {
-      appliedScale_ = objectScale;
-      collider.setHalfExtend(halfExtend_ * objectScale);
-    }
 
     static uint32_t getAllocSize([[maybe_unused]] uint16_t* initData)
     {
@@ -50,12 +29,5 @@ namespace P64::Comp
     static void initDelete([[maybe_unused]] Object& obj, CollBody* data, void* initData);
 
     static void onEvent(Object& obj, CollBody* data, const ObjectEvent& event);
-
-    static void update(Object& obj, CollBody* data, float deltaTime);
-
-  private:
-    fm_vec3_t halfExtend_{};
-    // object scale the collider size was last built with, used to detect scale changes
-    fm_vec3_t appliedScale_{{1.0f, 1.0f, 1.0f}};
   };
 }

--- a/n64/engine/include/scene/components/collBody.h
+++ b/n64/engine/include/scene/components/collBody.h
@@ -17,7 +17,30 @@ namespace P64::Comp
     static constexpr uint32_t ID = 5;
 
     Coll::Collider collider{};
-    fm_vec3_t orgScale{};
+
+    /// Resizes the collider. Like the half extend set in the editor this is in the object's
+    /// local space, the object scale gets applied on top of it and stays applied when the
+    /// object is scaled later on. Shapes that don't use all three axes fold them in,
+    /// see 'Coll::Collider::setHalfExtend()'.
+    void setHalfExtend(const fm_vec3_t &newHalfExtend) {
+      halfExtend_ = newHalfExtend;
+      applyObjectScale(appliedScale_);
+    }
+    /// Unscaled half extend, multiply with the object scale to get the collider's world size.
+    const fm_vec3_t &getHalfExtend() const { return halfExtend_; }
+
+    /// Changes the shape type and keeps the current half extend, unlike the collider's own
+    /// setShapeType() which resets the dimensions of the new shape to zero.
+    void setShapeType(Coll::ShapeType type) {
+      collider.setShapeType(type);
+      applyObjectScale(appliedScale_);
+    }
+
+    /// Rebuilds the collider size from the half extend scaled by the given object scale.
+    void applyObjectScale(const fm_vec3_t &objectScale) {
+      appliedScale_ = objectScale;
+      collider.setHalfExtend(halfExtend_ * objectScale);
+    }
 
     static uint32_t getAllocSize([[maybe_unused]] uint16_t* initData)
     {
@@ -29,5 +52,10 @@ namespace P64::Comp
     static void onEvent(Object& obj, CollBody* data, const ObjectEvent& event);
 
     static void update(Object& obj, CollBody* data, float deltaTime);
+
+  private:
+    fm_vec3_t halfExtend_{};
+    // object scale the collider size was last built with, used to detect scale changes
+    fm_vec3_t appliedScale_{{1.0f, 1.0f, 1.0f}};
   };
 }

--- a/n64/engine/src/collision/collide.cpp
+++ b/n64/engine/src/collision/collide.cpp
@@ -145,8 +145,8 @@ namespace P64::Coll {
     if(!a || !b) return false;
     if(a->shapeType() != ShapeType::Sphere || b->shapeType() != ShapeType::Sphere) return false;
 
-    float rA = a->sphereShape().radius;
-    float rB = b->sphereShape().radius;
+    float rA = a->worldSphereShape().radius;
+    float rB = b->worldSphereShape().radius;
     float combinedRadius = rA + rB;
 
     fm_vec3_t diff = a->worldCenter() - b->worldCenter();
@@ -180,8 +180,8 @@ namespace P64::Coll {
     if(!sphere || !box) return false;
     if(sphere->shapeType() != ShapeType::Sphere || box->shapeType() != ShapeType::Box) return false;
 
-    float radius = sphere->sphereShape().radius;
-    fm_vec3_t halfSize = box->boxShape().halfSize;
+    float radius = sphere->worldSphereShape().radius;
+    fm_vec3_t halfSize = box->worldBoxShape().halfSize;
 
     // Transform sphere center to box local space
     const Matrix3x3 &boxRot = box->rotationMatrix();
@@ -240,9 +240,9 @@ namespace P64::Coll {
     if(!sphere || !capsule) return false;
     if(sphere->shapeType() != ShapeType::Sphere || capsule->shapeType() != ShapeType::Capsule) return false;
 
-    float rS = sphere->sphereShape().radius;
-    float rC = capsule->capsuleShape().radius;
-    float hh = capsule->capsuleShape().innerHalfHeight;
+    float rS = sphere->worldSphereShape().radius;
+    float rC = capsule->worldCapsuleShape().radius;
+    float hh = capsule->worldCapsuleShape().innerHalfHeight;
 
     // Capsule axis endpoints in world space
     fm_vec3_t localUp = fm_vec3_t{{0.0f, hh, 0.0f}};
@@ -292,10 +292,10 @@ namespace P64::Coll {
     if(!capsuleA || !capsuleB) return false;
     if(capsuleA->shapeType() != ShapeType::Capsule || capsuleB->shapeType() != ShapeType::Capsule) return false;
 
-    float rA = capsuleA->capsuleShape().radius;
-    float rB = capsuleB->capsuleShape().radius;
-    float hhA = capsuleA->capsuleShape().innerHalfHeight;
-    float hhB = capsuleB->capsuleShape().innerHalfHeight;
+    float rA = capsuleA->worldCapsuleShape().radius;
+    float rB = capsuleB->worldCapsuleShape().radius;
+    float hhA = capsuleA->worldCapsuleShape().innerHalfHeight;
+    float hhB = capsuleB->worldCapsuleShape().innerHalfHeight;
 
     // Capsule A axis endpoints in world space
     fm_vec3_t localUpA = fm_vec3_t{{0.0f, hhA, 0.0f}};
@@ -1254,8 +1254,8 @@ namespace P64::Coll {
       std::swap(aReadsB, bReadsA);
     }
 
-    const SatObb obbA{colliderA->worldCenter(), colliderA->rotationMatrix(), colliderA->boxShape().halfSize};
-    const SatObb obbB{colliderB->worldCenter(), colliderB->rotationMatrix(), colliderB->boxShape().halfSize};
+    const SatObb obbA{colliderA->worldCenter(), colliderA->rotationMatrix(), colliderA->worldBoxShape().halfSize};
+    const SatObb obbB{colliderB->worldCenter(), colliderB->rotationMatrix(), colliderB->worldBoxShape().halfSize};
 
     // Trigger pairs and probe queries (CCD substeps) only need a boolean overlap answer
     const bool isTriggerContact = colliderA->isTrigger() || colliderB->isTrigger();
@@ -1338,7 +1338,7 @@ namespace P64::Coll {
 
     // --- Analytical Box-Triangle fast path (SAT) ---
     if(colliderProxyMeshSpace->collider->shapeType() == ShapeType::Box && !isTriggerContact) {
-      const BoxShape &box = colliderProxyMeshSpace->collider->boxShape();
+      const BoxShape &box = colliderProxyMeshSpace->collider->worldBoxShape();
       const fm_vec3_t v0 = tri.localVertex(0);
       const fm_vec3_t v1 = tri.localVertex(1);
       const fm_vec3_t v2 = tri.localVertex(2);
@@ -1363,7 +1363,7 @@ namespace P64::Coll {
 
     // --- Analytical Sphere-Triangle fast path (closest-point distance test) ---
     if(colliderProxyMeshSpace->collider->shapeType() == ShapeType::Sphere && !isTriggerContact) {
-      const SphereShape &sphere = colliderProxyMeshSpace->collider->sphereShape();
+      const SphereShape &sphere = colliderProxyMeshSpace->collider->worldSphereShape();
       const fm_vec3_t v0 = tri.localVertex(0);
       const fm_vec3_t v1 = tri.localVertex(1);
       const fm_vec3_t v2 = tri.localVertex(2);
@@ -1479,10 +1479,10 @@ namespace P64::Coll {
       if(mesh.hasScale()) {
         fm_vec3_t inverseScaleVec = vec3ReciprocalScaleComponents(mesh.ownerObject()->scale);
         Matrix3x3 inverseScale = diagonalMatrix(inverseScaleVec);
-        colliderInMeshSpace.effectiveRadius = max(inverseScaleVec.x, max(inverseScaleVec.y, inverseScaleVec.z)) * collider->sphereShape().radius;
+        colliderInMeshSpace.effectiveRadius = max(inverseScaleVec.x, max(inverseScaleVec.y, inverseScaleVec.z)) * collider->worldSphereShape().radius;
         colliderInMeshSpace.shapeToSpace = matrix3Mul(inverseScale, relativeRotation);
       } else {
-        colliderInMeshSpace.effectiveRadius = collider->sphereShape().radius;
+        colliderInMeshSpace.effectiveRadius = collider->worldSphereShape().radius;
         colliderInMeshSpace.shapeToSpace = relativeRotation;
       }
 

--- a/n64/engine/src/collision/colliderShape.cpp
+++ b/n64/engine/src/collision/colliderShape.cpp
@@ -5,9 +5,44 @@
  */
 #include "collision/colliderShape.h"
 #include "collision/meshCollider.h"
+#include "collision/rigidBody.h"
 #include "scene/object.h"
 
 using namespace P64::Coll;
+
+void Collider::markGeometryChanged() {
+  geometryDirty_ = true;
+  // size and offset of a shape feed into the center of mass and inertia tensor of a compound body
+  if(rigidBody_) rigidBody_->markCompoundPropertiesDirty();
+}
+
+void Collider::setHalfExtend(const fm_vec3_t &newHalfExtend) {
+  const float x = fabsf(newHalfExtend.x);
+  const float y = fabsf(newHalfExtend.y);
+  const float z = fabsf(newHalfExtend.z);
+  const float radius = fmaxf(x, z);
+
+  switch(type_) {
+    case ShapeType::Sphere:   setSphereShape(fmaxf(x, fmaxf(y, z))); break;
+    case ShapeType::Box:      setBoxShape(fm_vec3_t{{x, y, z}}); break;
+    case ShapeType::Capsule:  setCapsuleShape(radius, y); break;
+    case ShapeType::Cylinder: setCylinderShape(radius, y); break;
+    case ShapeType::Cone:     setConeShape(radius, y); break;
+    case ShapeType::Pyramid:  setPyramidShape(x, z, y); break;
+  }
+}
+
+fm_vec3_t Collider::halfExtend() const {
+  switch(type_) {
+    case ShapeType::Sphere:   return fm_vec3_t{{sphere_.radius, sphere_.radius, sphere_.radius}};
+    case ShapeType::Box:      return box_.halfSize;
+    case ShapeType::Capsule:  return fm_vec3_t{{capsule_.radius, capsule_.innerHalfHeight, capsule_.radius}};
+    case ShapeType::Cylinder: return fm_vec3_t{{cylinder_.radius, cylinder_.halfHeight, cylinder_.radius}};
+    case ShapeType::Cone:     return fm_vec3_t{{cone_.radius, cone_.halfHeight, cone_.radius}};
+    case ShapeType::Pyramid:  return fm_vec3_t{{pyramid_.baseHalfWidthX, pyramid_.halfHeight, pyramid_.baseHalfWidthZ}};
+  }
+  __builtin_unreachable();
+}
 
 fm_vec3_t Collider::support(const fm_vec3_t &dir) const {
   switch(type_) {
@@ -90,7 +125,7 @@ void Collider::syncOwnerTransform() {
 }
 
 bool Collider::syncFromRigidBody(const fm_vec3_t& rbPosition, const fm_quat_t& rbRotation) {
-  if(hasCachedOwnerTransform_) {
+  if(hasCachedOwnerTransform_ && !geometryDirty_) {
     const float posDeltaSq = fm_vec3_distance2(&rbPosition, &lastOwnerPosition_);
     const float rotSim = fabsf(quatDot(rbRotation, lastOwnerRotation_));
     if(posDeltaSq <= FM_EPSILON * FM_EPSILON && rotSim >= 1.0f - FM_EPSILON) {
@@ -98,6 +133,7 @@ bool Collider::syncFromRigidBody(const fm_vec3_t& rbPosition, const fm_quat_t& r
     }
   }
 
+  geometryDirty_ = false;
   lastOwnerPosition_ = rbPosition;
   lastOwnerRotation_ = rbRotation;
   lastOwnerScale_ = owner_ ? owner_->scale : fm_vec3_t{{1,1,1}};
@@ -119,9 +155,11 @@ bool Collider::syncWorldState() {
   if(!owner_) return false;
 
   const bool transformChanged = !hasCachedOwnerTransform_ || hasOwnerTransformChanged();
-  if(!transformChanged) return false;
+  // a resized or moved shape needs a new AABB too, even if the object itself didn't move
+  if(!transformChanged && !geometryDirty_) return false;
 
-  syncOwnerTransform();
+  geometryDirty_ = false;
+  if(transformChanged) syncOwnerTransform();
   worldCenter_ = lastOwnerPosition_ + matrix3Vec3Mul(rotationMatrix_, parentOffset_ * lastOwnerScale_);
 
   const AABB local = boundingBox(&lastOwnerRotation_);

--- a/n64/engine/src/collision/colliderShape.cpp
+++ b/n64/engine/src/collision/colliderShape.cpp
@@ -16,32 +16,40 @@ void Collider::markGeometryChanged() {
   if(rigidBody_) rigidBody_->markCompoundPropertiesDirty();
 }
 
-void Collider::setHalfExtend(const fm_vec3_t &newHalfExtend) {
-  const float x = fabsf(newHalfExtend.x);
-  const float y = fabsf(newHalfExtend.y);
-  const float z = fabsf(newHalfExtend.z);
+void Collider::refreshWorldShape() {
+  const fm_vec3_t scale = owner_ ? owner_->scale : fm_vec3_t{{1.0f, 1.0f, 1.0f}};
+  const float x = fabsf(localHalfExtend_.x * scale.x);
+  const float y = fabsf(localHalfExtend_.y * scale.y);
+  const float z = fabsf(localHalfExtend_.z * scale.z);
   const float radius = fmaxf(x, z);
 
   switch(type_) {
-    case ShapeType::Sphere:   setSphereShape(fmaxf(x, fmaxf(y, z))); break;
-    case ShapeType::Box:      setBoxShape(fm_vec3_t{{x, y, z}}); break;
-    case ShapeType::Capsule:  setCapsuleShape(radius, y); break;
-    case ShapeType::Cylinder: setCylinderShape(radius, y); break;
-    case ShapeType::Cone:     setConeShape(radius, y); break;
-    case ShapeType::Pyramid:  setPyramidShape(x, z, y); break;
+    case ShapeType::Sphere:
+      sphere_.radius = fmaxf(x, fmaxf(y, z));
+    break;
+    case ShapeType::Box:
+      box_.halfSize = fm_vec3_t{{x, y, z}};
+    break;
+    case ShapeType::Capsule:
+      capsule_.radius = radius;
+      capsule_.innerHalfHeight = y;
+    break;
+    case ShapeType::Cylinder:
+      cylinder_.radius = radius;
+      cylinder_.halfHeight = y;
+    break;
+    case ShapeType::Cone:
+      cone_.radius = radius;
+      cone_.halfHeight = y;
+    break;
+    case ShapeType::Pyramid:
+      pyramid_.baseHalfWidthX = x;
+      pyramid_.baseHalfWidthZ = z;
+      pyramid_.halfHeight = y;
+    break;
   }
-}
 
-fm_vec3_t Collider::halfExtend() const {
-  switch(type_) {
-    case ShapeType::Sphere:   return fm_vec3_t{{sphere_.radius, sphere_.radius, sphere_.radius}};
-    case ShapeType::Box:      return box_.halfSize;
-    case ShapeType::Capsule:  return fm_vec3_t{{capsule_.radius, capsule_.innerHalfHeight, capsule_.radius}};
-    case ShapeType::Cylinder: return fm_vec3_t{{cylinder_.radius, cylinder_.halfHeight, cylinder_.radius}};
-    case ShapeType::Cone:     return fm_vec3_t{{cone_.radius, cone_.halfHeight, cone_.radius}};
-    case ShapeType::Pyramid:  return fm_vec3_t{{pyramid_.baseHalfWidthX, pyramid_.halfHeight, pyramid_.baseHalfWidthZ}};
-  }
-  __builtin_unreachable();
+  markGeometryChanged();
 }
 
 fm_vec3_t Collider::support(const fm_vec3_t &dir) const {
@@ -125,7 +133,9 @@ void Collider::syncOwnerTransform() {
 }
 
 bool Collider::syncFromRigidBody(const fm_vec3_t& rbPosition, const fm_quat_t& rbRotation) {
-  if(hasCachedOwnerTransform_ && !geometryDirty_) {
+  const bool scaleChanged = owner_ && owner_->scale != lastOwnerScale_;
+
+  if(hasCachedOwnerTransform_ && !geometryDirty_ && !scaleChanged) {
     const float posDeltaSq = fm_vec3_distance2(&rbPosition, &lastOwnerPosition_);
     const float rotSim = fabsf(quatDot(rbRotation, lastOwnerRotation_));
     if(posDeltaSq <= FM_EPSILON * FM_EPSILON && rotSim >= 1.0f - FM_EPSILON) {
@@ -133,10 +143,10 @@ bool Collider::syncFromRigidBody(const fm_vec3_t& rbPosition, const fm_quat_t& r
     }
   }
 
-  geometryDirty_ = false;
   lastOwnerPosition_ = rbPosition;
   lastOwnerRotation_ = rbRotation;
   lastOwnerScale_ = owner_ ? owner_->scale : fm_vec3_t{{1,1,1}};
+  if(scaleChanged) refreshWorldShape();
   rotationMatrix_ = quatToMatrix3(lastOwnerRotation_);
   inverseRotationMatrix_ = quatToMatrix3(quatConjugate(lastOwnerRotation_));
   hasCachedOwnerTransform_ = true;
@@ -158,8 +168,11 @@ bool Collider::syncWorldState() {
   // a resized or moved shape needs a new AABB too, even if the object itself didn't move
   if(!transformChanged && !geometryDirty_) return false;
 
-  geometryDirty_ = false;
+  const bool scaleChanged = owner_->scale != lastOwnerScale_;
+
   if(transformChanged) syncOwnerTransform();
+  // the shape is object-scaled, so a scaled object needs it rebuilt
+  if(scaleChanged) refreshWorldShape();
   worldCenter_ = lastOwnerPosition_ + matrix3Vec3Mul(rotationMatrix_, parentOffset_ * lastOwnerScale_);
 
   const AABB local = boundingBox(&lastOwnerRotation_);

--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -209,15 +209,15 @@ namespace P64::Coll {
 
     const fm_vec3_t fallbackInertia = rigidBody->getDefaultLocalInertiaTensor();
 
-    const std::vector<Collider *> *ownerColliders = findCollidersForOwner(rigidBody->owner_);
-    if(!ownerColliders || ownerColliders->empty()) {
+    const std::vector<Collider *> &ownerColliders = rigidBody->attachedColliders_;
+    if(ownerColliders.empty()) {
       rigidBody->applyCompoundProperties(rigidBody->localCenterOfMassOffset_, fallbackInertia, rigidBody->owner_->scale);
       return;
     }
 
     int count = 0;
     fm_vec3_t worldCenterSum = VEC3_ZERO;
-    for(Collider *collider : *ownerColliders) {
+    for (Collider *collider : ownerColliders) {
       if(!collider) continue;
       worldCenterSum = worldCenterSum + collider->worldCenter_;
       ++count;
@@ -242,7 +242,7 @@ namespace P64::Coll {
     const float massPerCollider = rigidBody->getMass() * invCount;
     fm_vec3_t compoundInertia = VEC3_ZERO;
 
-    for(Collider *collider : *ownerColliders) {
+    for (Collider *collider : ownerColliders) {
       if(!collider) continue;
 
       fm_vec3_t colliderInertia = collider->inertiaTensor(massPerCollider);
@@ -707,17 +707,45 @@ namespace P64::Coll {
   // Wake everything a moved body can affect. Kinematic bodies are not part of
   // sleep islands, so wake whatever rests on them instead.
   void CollisionScene::wakeMovedBody(RigidBody *body) {
+
+    // If the body is a dynamic non-kinematic body, wake its island. Otherwise, wake any bodies that are in contact with it.
     if(shouldTrackSleepState(body)) {
       wakeIsland(body);
       return;
     }
 
+    // Wake any bodies that are in contact with the moved non-dynamic body.
     for(int i = 0; i < cachedConstraintCount_; ++i) {
       const ContactConstraint &cc = cachedConstraints_[i];
       if(!cc.isActive || cc.isTrigger) continue;
       RigidBody *other = nullptr;
       if(cc.rigidBodyA == body)      other = cc.rigidBodyB;
       else if(cc.rigidBodyB == body) other = cc.rigidBodyA;
+      if(other) wakeIsland(other);
+    }
+  }
+
+  // Same idea as wakeMovedBody(), but triggered by a collider whose size or offset changed
+  // instead of a moved body: it could now overlap or no longer support its neighbours, so they
+  // have to re-evaluate.
+  // The collider may not have a rigid body at all, in which case we wake any bodies that are in contact with it.
+  void CollisionScene::wakeChangedCollider(Collider *collider) {
+    if(!collider) return;
+
+    // If the collider has a dynamic non-kinematic rigid body, wake its island. Otherwise, wake any bodies that are in contact with it.
+    RigidBody *body = collider->rigidBody_;
+    if(shouldTrackSleepState(body)) {
+      wakeIsland(body);
+      return;
+    }
+
+    // Wake any bodies that are in contact with the changed collider.
+    for(int i = 0; i < cachedConstraintCount_; ++i) {
+      const ContactConstraint &cc = cachedConstraints_[i];
+      if(!cc.isActive || cc.isTrigger) continue;
+      if(cc.colliderA != collider && cc.colliderB != collider) continue;
+
+      RigidBody *other = cc.colliderA == collider ? cc.rigidBodyB : cc.rigidBodyA;
       if(other) wakeIsland(other);
     }
   }
@@ -2157,10 +2185,13 @@ namespace P64::Coll {
       if(!collider) continue;
 
       const fm_vec3_t previousCenter = collider->worldCenter_;
+      const bool geometryChanged = collider->geometryDirty_;
 
       RigidBody *rb = collider->rigidBody_;
       const bool changed = rb ? collider->syncFromRigidBody(rb->position_, rb->rotation_)
                               : collider->syncWorldState();
+
+      if(geometryChanged) wakeChangedCollider(collider);
 
       if(!changed || collider->aabbTreeNodeId_ == NULL_NODE) continue;
 

--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -2180,18 +2180,18 @@ namespace P64::Coll {
     ticksWakePrep = get_ticks() - stageStart;
 
     stageStart = get_ticks();
-    // Refresh collider world state
+
+    // Refresh collider world state and move AABB tree nodes if needed. Wake any rigidbodies who are affected by changes
     for(Collider *collider : colliders_) {
       if(!collider) continue;
 
       const fm_vec3_t previousCenter = collider->worldCenter_;
-      const bool geometryChanged = collider->geometryDirty_;
 
       RigidBody *rb = collider->rigidBody_;
       const bool changed = rb ? collider->syncFromRigidBody(rb->position_, rb->rotation_)
                               : collider->syncWorldState();
 
-      if(geometryChanged) wakeChangedCollider(collider);
+      if(collider->consumeGeometryChanged()) wakeChangedCollider(collider);
 
       if(!changed || collider->aabbTreeNodeId_ == NULL_NODE) continue;
 

--- a/n64/engine/src/collision/raycast.cpp
+++ b/n64/engine/src/collision/raycast.cpp
@@ -52,7 +52,7 @@ namespace P64::Coll {
 
   bool ray_sphere_intersection(const Raycast &ray, const Collider *coll, RaycastHit &hit) {
     const Object *owner = coll->ownerObject();
-    return ray_sphere_intersection(ray, coll->worldCenter(), coll->sphereShape().radius, owner ? owner->id : 0, hit);
+    return ray_sphere_intersection(ray, coll->worldCenter(), coll->worldSphereShape().radius, owner ? owner->id : 0, hit);
   }
 
   bool ray_box_intersection(const Raycast &ray, const Collider *coll, RaycastHit &hit) {
@@ -60,7 +60,7 @@ namespace P64::Coll {
     localRay.origin = coll->toLocalSpace(ray.origin);
     localRay.dir = coll->rotateToLocal(ray.dir);
 
-    AABB local_box = coll->boxShape().boundingBox(nullptr); // Box AABB in local space
+    AABB local_box = coll->worldBoxShape().boundingBox(nullptr); // Box AABB in local space
 
     float tMin = -INFINITY;
     float tMax = INFINITY;
@@ -135,7 +135,7 @@ namespace P64::Coll {
     fm_vec3_t rayDirXZ = {localRay.dir.x, 0.0f, localRay.dir.z};
     float a = fm_vec3_dot(&rayDirXZ, &rayDirXZ);
     float b = 2.0f * fm_vec3_dot(&rayOriginXZ, &rayDirXZ);
-    float c = fm_vec3_dot(&rayOriginXZ, &rayOriginXZ) - coll->capsuleShape().radius * coll->capsuleShape().radius;
+    float c = fm_vec3_dot(&rayOriginXZ, &rayOriginXZ) - coll->worldCapsuleShape().radius * coll->worldCapsuleShape().radius;
 
     float discriminant = b * b - 4.0f * a * c;
     float tCylinder = std::numeric_limits<float>::max();
@@ -150,7 +150,7 @@ namespace P64::Coll {
 
       if( t > 0.0f && t < ray.maxDistance) {
         fm_vec3_t hitPoint = localRay.origin + localRay.dir * t;
-        if(fabsf(hitPoint.y) <= coll->capsuleShape().innerHalfHeight) {
+        if(fabsf(hitPoint.y) <= coll->worldCapsuleShape().innerHalfHeight) {
           tCylinder = t;
           cylinderNormal = {hitPoint.x, 0.0f, hitPoint.z};
           vec3NormalizeOrFallback(cylinderNormal, (-localRay.dir));
@@ -160,12 +160,12 @@ namespace P64::Coll {
     }
 
     // Next check intersection with the hemispherical ends
-  fm_vec3_t capCenterTop = {0.0f, coll->capsuleShape().innerHalfHeight, 0.0f};
-  fm_vec3_t capCenterBottom = {0.0f, -coll->capsuleShape().innerHalfHeight, 0.0f};
+  fm_vec3_t capCenterTop = {0.0f, coll->worldCapsuleShape().innerHalfHeight, 0.0f};
+  fm_vec3_t capCenterBottom = {0.0f, -coll->worldCapsuleShape().innerHalfHeight, 0.0f};
 
     RaycastHit capHitTop, capHitBottom;
-  bool hitTop = ray_sphere_intersection(localRay, capCenterTop, coll->capsuleShape().radius, 0, capHitTop);
-  bool hitBottom = ray_sphere_intersection(localRay, capCenterBottom, coll->capsuleShape().radius, 0, capHitBottom);
+  bool hitTop = ray_sphere_intersection(localRay, capCenterTop, coll->worldCapsuleShape().radius, 0, capHitTop);
+  bool hitBottom = ray_sphere_intersection(localRay, capCenterBottom, coll->worldCapsuleShape().radius, 0, capHitBottom);
 
     // Determine closest valid hit
     float tSphere = std::numeric_limits<float>::max();
@@ -226,7 +226,7 @@ namespace P64::Coll {
     fm_vec3_t rayDirXZ = {localRay.dir.x, 0.0f, localRay.dir.z};
     float a = fm_vec3_dot(&rayDirXZ, &rayDirXZ);
     float b = 2.0f * fm_vec3_dot(&rayOriginXZ, &rayDirXZ);
-    float c = fm_vec3_dot(&rayOriginXZ, &rayOriginXZ) - coll->cylinderShape().radius * coll->cylinderShape().radius;
+    float c = fm_vec3_dot(&rayOriginXZ, &rayOriginXZ) - coll->worldCylinderShape().radius * coll->worldCylinderShape().radius;
 
     float discriminant = b * b - 4.0f * a * c;
     float tCylinder = std::numeric_limits<float>::max();
@@ -242,7 +242,7 @@ namespace P64::Coll {
         if(t < 0.0f || t > ray.maxDistance) continue;
 
         fm_vec3_t hitPoint = localRay.origin + localRay.dir * t;
-        if(fabsf(hitPoint.y) <= coll->cylinderShape().halfHeight) {
+        if(fabsf(hitPoint.y) <= coll->worldCylinderShape().halfHeight) {
 
             tCylinder = t;
             cylinderNormal = {hitPoint.x, 0.0f, hitPoint.z};
@@ -257,7 +257,7 @@ namespace P64::Coll {
     fm_vec3_t capNormal = {};
 
     for(int i = 0; i < 2; ++i) {
-      float y = i == 0 ? coll->cylinderShape().halfHeight : -coll->cylinderShape().halfHeight;
+      float y = i == 0 ? coll->worldCylinderShape().halfHeight : -coll->worldCylinderShape().halfHeight;
       fm_vec3_t capNormalLocal = {0.0f, i == 0 ? 1.0f : -1.0f, 0.0f};
 
       // Check if ray is parallel to cap plane
@@ -269,7 +269,7 @@ namespace P64::Coll {
       if(t > 0.0f && t < ray.maxDistance && t < tCap){
         fm_vec3_t hitPoint = localRay.origin + localRay.dir * t;
         float distsq = hitPoint.x * hitPoint.x + hitPoint.z * hitPoint.z;
-        if(distsq <= coll->cylinderShape().radius * coll->cylinderShape().radius) {
+        if(distsq <= coll->worldCylinderShape().radius * coll->worldCylinderShape().radius) {
           tCap = t;
           capNormal = capNormalLocal;
         }
@@ -311,9 +311,9 @@ namespace P64::Coll {
     localRay.dir = coll->rotateToLocal(ray.dir);
 
     // Conse parameters
-    float h = coll->coneShape().halfHeight * 2.0f;
-    float tan_theta_sq = h > 0.0f ? (coll->coneShape().radius / h) * (coll->coneShape().radius / h) : 0.0f;
-    fm_vec3_t apex = {0.0f, coll->coneShape().halfHeight, 0.0f};
+    float h = coll->worldConeShape().halfHeight * 2.0f;
+    float tan_theta_sq = h > 0.0f ? (coll->worldConeShape().radius / h) * (coll->worldConeShape().radius / h) : 0.0f;
+    fm_vec3_t apex = {0.0f, coll->worldConeShape().halfHeight, 0.0f};
 
     fm_vec3_t co = localRay.origin - apex;
 
@@ -336,7 +336,7 @@ namespace P64::Coll {
         if(t < 0.0f || t > ray.maxDistance || t >= tSide) continue;
 
         fm_vec3_t hitPoint = localRay.origin + localRay.dir * t;
-        if(hitPoint.y >= -coll->coneShape().halfHeight && hitPoint.y <= coll->coneShape().halfHeight) {
+        if(hitPoint.y >= -coll->worldConeShape().halfHeight && hitPoint.y <= coll->worldConeShape().halfHeight) {
           tSide = t;
 
           // Calculate normal
@@ -344,7 +344,7 @@ namespace P64::Coll {
           float axisToHitLen = sqrtf(axisToHit.x * axisToHit.x + axisToHit.z * axisToHit.z);
           if(axisToHitLen > FM_EPSILON) {
              axisToHit = axisToHit / axisToHitLen;
-             float coneAngle = atanf(coll->coneShape().radius / h);
+             float coneAngle = atanf(coll->worldConeShape().radius / h);
              sideNormal = {
               axisToHit.x,
               sinf(coneAngle),
@@ -363,10 +363,10 @@ namespace P64::Coll {
     fm_vec3_t baseNormal = {0.0f, -1.0f, 0.0f};
 
     if(fabsf(localRay.dir.y) > FM_EPSILON) {
-      float t = ( -coll->coneShape().halfHeight - localRay.origin.y) / localRay.dir.y;
+      float t = ( -coll->worldConeShape().halfHeight - localRay.origin.y) / localRay.dir.y;
       if(t > 0.0f && t < ray.maxDistance && t < tBase) {
         fm_vec3_t hitPoint = localRay.origin + localRay.dir * t;
-        if(hitPoint.x * hitPoint.x + hitPoint.z * hitPoint.z <= coll->coneShape().radius * coll->coneShape().radius) {
+        if(hitPoint.x * hitPoint.x + hitPoint.z * hitPoint.z <= coll->worldConeShape().radius * coll->worldConeShape().radius) {
           tBase = t;
         }
       }
@@ -403,9 +403,9 @@ namespace P64::Coll {
     localRay.origin = coll->toLocalSpace(ray.origin);
     localRay.dir = coll->rotateToLocal(ray.dir);
 
-    const float halfHeight = coll->pyramidShape().halfHeight;
-    const float baseHalfWidthX = coll->pyramidShape().baseHalfWidthX;
-    const float baseHalfWidthZ = coll->pyramidShape().baseHalfWidthZ;
+    const float halfHeight = coll->worldPyramidShape().halfHeight;
+    const float baseHalfWidthX = coll->worldPyramidShape().baseHalfWidthX;
+    const float baseHalfWidthZ = coll->worldPyramidShape().baseHalfWidthZ;
 
     const fm_vec3_t apex = {0.0f, halfHeight, 0.0f};
     const fm_vec3_t v0 = {-baseHalfWidthX, -halfHeight, -baseHalfWidthZ};

--- a/n64/engine/src/scene/components/collBody.cpp
+++ b/n64/engine/src/scene/components/collBody.cpp
@@ -39,16 +39,14 @@ namespace P64::Comp
 
     new(data) CollBody();
 
-    data->collider.setShapeType(static_cast<P64::Coll::ShapeType>(initData->type));
+    data->collider.setOwner(&obj);
     data->collider.setFriction(initData->friction);
     data->collider.setBounce(initData->bounce);
-    data->collider.setOwner(&obj);
     data->collider.setParentOffset(initData->offset);
     data->collider.setTrigger(initData->isTrigger);
     data->collider.setCollisionMask(initData->maskRead, initData->maskWrite);
-
-    data->halfExtend_ = initData->halfExtend;
-    data->applyObjectScale(obj.scale);
+    data->collider.setShapeType(static_cast<P64::Coll::ShapeType>(initData->type));
+    data->collider.setHalfExtend(initData->halfExtend);
 
     if (obj.isEnabled()) {
       coll.addCollider(&data->collider);
@@ -65,10 +63,4 @@ namespace P64::Comp
     }
   }
 
-  void CollBody::update(Object &obj, CollBody* data, [[maybe_unused]] float deltaTime)
-  {
-    // The size only needs to be updated if the object got scaled, every other resize goes through setHalfExtend() and is applied right away.
-    if(data->appliedScale_ == obj.scale) return;
-    data->applyObjectScale(obj.scale);
-  }
 }

--- a/n64/engine/src/scene/components/collBody.cpp
+++ b/n64/engine/src/scene/components/collBody.cpp
@@ -39,48 +39,17 @@ namespace P64::Comp
 
     new(data) CollBody();
 
-    data->orgScale = initData->halfExtend;
-
-    data->collider = {};
     data->collider.setShapeType(static_cast<P64::Coll::ShapeType>(initData->type));
     data->collider.setFriction(initData->friction);
     data->collider.setBounce(initData->bounce);
     data->collider.setOwner(&obj);
     data->collider.setParentOffset(initData->offset);
-
-    fm_vec3_t scaledHalfExtend = initData->halfExtend * obj.scale;
-    scaledHalfExtend.x = fabsf(scaledHalfExtend.x);
-    scaledHalfExtend.y = fabsf(scaledHalfExtend.y);
-    scaledHalfExtend.z = fabsf(scaledHalfExtend.z);
-
     data->collider.setTrigger(initData->isTrigger);
     data->collider.setCollisionMask(initData->maskRead, initData->maskWrite);
-    switch(data->collider.shapeType())
-    {
-      case P64::Coll::ShapeType::Sphere:
-        data->collider.sphereShape().radius = fmaxf(scaledHalfExtend.x, fmaxf(scaledHalfExtend.y, scaledHalfExtend.z));
-      break;
-      case P64::Coll::ShapeType::Box:
-        data->collider.boxShape().halfSize = scaledHalfExtend;
-      break;
-      case P64::Coll::ShapeType::Cylinder:
-        data->collider.cylinderShape().radius = fmaxf(scaledHalfExtend.x, scaledHalfExtend.z);
-        data->collider.cylinderShape().halfHeight = scaledHalfExtend.y;
-      break;
-      case P64::Coll::ShapeType::Capsule:
-        data->collider.capsuleShape().radius = fmaxf(scaledHalfExtend.x, scaledHalfExtend.z);
-        data->collider.capsuleShape().innerHalfHeight = scaledHalfExtend.y;
-      break;
-      case P64::Coll::ShapeType::Cone:
-        data->collider.coneShape().radius = fmaxf(scaledHalfExtend.x, scaledHalfExtend.z);
-        data->collider.coneShape().halfHeight = scaledHalfExtend.y;
-      break;
-      case P64::Coll::ShapeType::Pyramid:
-        data->collider.pyramidShape().baseHalfWidthX = scaledHalfExtend.x;
-        data->collider.pyramidShape().baseHalfWidthZ = scaledHalfExtend.z;
-        data->collider.pyramidShape().halfHeight = scaledHalfExtend.y;
-      break;
-    }
+
+    data->halfExtend_ = initData->halfExtend;
+    data->applyObjectScale(obj.scale);
+
     if (obj.isEnabled()) {
       coll.addCollider(&data->collider);
     }
@@ -96,38 +65,10 @@ namespace P64::Comp
     }
   }
 
-  void CollBody::update(Object &obj, CollBody* data, float deltaTime)
+  void CollBody::update(Object &obj, CollBody* data, [[maybe_unused]] float deltaTime)
   {
-    fm_vec3_t scaledHalfExtend = data->orgScale * obj.scale;
-    scaledHalfExtend.x = fabsf(scaledHalfExtend.x);
-    scaledHalfExtend.y = fabsf(scaledHalfExtend.y);
-    scaledHalfExtend.z = fabsf(scaledHalfExtend.z);
-
-    switch(data->collider.shapeType())
-    {
-      case P64::Coll::ShapeType::Sphere:
-        data->collider.sphereShape().radius = fmaxf(scaledHalfExtend.x, fmaxf(scaledHalfExtend.y, scaledHalfExtend.z));
-      break;
-      case P64::Coll::ShapeType::Box:
-        data->collider.boxShape().halfSize = scaledHalfExtend;
-      break;
-      case P64::Coll::ShapeType::Cylinder:
-        data->collider.cylinderShape().radius = fmaxf(scaledHalfExtend.x, scaledHalfExtend.z);
-        data->collider.cylinderShape().halfHeight = scaledHalfExtend.y;
-      break;
-      case P64::Coll::ShapeType::Capsule:
-        data->collider.capsuleShape().radius = fmaxf(scaledHalfExtend.x, scaledHalfExtend.z);
-        data->collider.capsuleShape().innerHalfHeight = scaledHalfExtend.y;
-      break;
-      case P64::Coll::ShapeType::Cone:
-        data->collider.coneShape().radius = fmaxf(scaledHalfExtend.x, scaledHalfExtend.z);
-        data->collider.coneShape().halfHeight = scaledHalfExtend.y;
-      break;
-      case P64::Coll::ShapeType::Pyramid:
-        data->collider.pyramidShape().baseHalfWidthX = scaledHalfExtend.x;
-        data->collider.pyramidShape().baseHalfWidthZ = scaledHalfExtend.z;
-        data->collider.pyramidShape().halfHeight = scaledHalfExtend.y;
-      break;
-    }
+    // The size only needs to be updated if the object got scaled, every other resize goes through setHalfExtend() and is applied right away.
+    if(data->appliedScale_ == obj.scale) return;
+    data->applyObjectScale(obj.scale);
   }
 }

--- a/n64/engine/src/scene/scene.cpp
+++ b/n64/engine/src/scene/scene.cpp
@@ -267,6 +267,8 @@ void P64::Scene::update(float deltaTime)
 
     for (uint32_t i=0; i<obj->compCount; ++i) {
       const auto &compDef = COMP_TABLE[compRefs[i].type];
+      if(!compDef.update) continue;
+
       char* dataPtr = (char*)obj + compRefs[i].offset;
       compDef.update(*obj, dataPtr, deltaTime);
     }


### PR DESCRIPTION
Move relevant shape settings and shape ownership away from collBody component and into collider.
Make sure changes in collider geometry actually take effect and affect the collision scene as would be expected
Documented breaking changes and component usage
