### PR TITLE
chg: Optimizations in collision detection

### DIFF
--- a/docs/docs/version/breakingChanges.md
+++ b/docs/docs/version/breakingChanges.md
@@ -198,6 +198,16 @@ registers it with the collision scene. `orgScale` and its half extend / shape / 
 gone, use the `collider` member for all of it. `Collider::setShapeType()` no longer resets the
 dimensions to zero, it keeps the size and folds it into the new shape.
 
+### Bugfix in Ray, Capsule & SphereCasts
+
+Previously Ray and Shapecasts would not take into consideration if the Cast-Readmask and a mesh colliders write mask would match,
+thus all mesh colliders were always matched if they were hit, regardless of what the mask said.
+This can affect existing projects if you are using Raycasts or Shapecasts or using the CharacterBody Component which uses those under the hood.
+If e.g. your Level geometry does not set the write mask bits that the CharacterBody reads your character might fall through the geometry.
+The fix here is to set the masks accordingly.<br>
+
+Note that it is strongly recommended to only use the mask bits you actually need per collider to avoid unnecessary collision tests.
+
 ## v0.7.0
 
 This version completely reworked the material system as well as the collision/physics system.<br>

--- a/n64/engine/include/collision/aabb.h
+++ b/n64/engine/include/collision/aabb.h
@@ -46,6 +46,15 @@ namespace P64::Coll {
       return (p.x >= box.min.x) && (p.x <= box.max.x) && (p.y >= box.min.y) && (p.y <= box.max.y) && (p.z >= box.min.z) && (p.z <= box.max.z);
   }
 
+  /// @brief Determines if two AABBs are identical
+  /// @param a 
+  /// @param b 
+  /// @return 
+  inline bool aabbIdentical(const AABB &a, const AABB &b)
+  {
+      return a.min == b.min && a.max == b.max;
+  }
+
   /// @brief Returns the union of two AABBs that contains them both
   /// @param a 
   /// @param b 

--- a/n64/engine/include/collision/aabbTree.h
+++ b/n64/engine/include/collision/aabbTree.h
@@ -16,8 +16,12 @@ namespace P64::Coll {
   using NodeProxy = int16_t;
   constexpr NodeProxy NULL_NODE = -1;
   // Multiplier for how much to fatten AABBs when inserting/moving nodes. This helps avoid frequent reinsertion for small movements.
-  constexpr float AABB_DISPLACEMENT_MULTIPLIER = 10.0f;
-  constexpr int AABB_QUERY_STACK_SIZE = 256;
+  constexpr float AABBTREE_DISPLACEMENT_MULTIPLIER = 10.0f;
+  // Fattening margin as a fraction of the aabb's own size.
+  constexpr float AABBTREE_MARGIN_RATIO = 0.1f;
+  // Absolute floor for that margin on dynamic trees.
+  constexpr float AABBTREE_MIN_MARGIN = 0.05f;
+  constexpr int AABBTREE_QUERY_STACK_SIZE = 256;
 
   // Forward declare Raycast for ray queries
   struct Raycast;
@@ -40,7 +44,10 @@ namespace P64::Coll {
     AABBTree() = default;
     ~AABBTree();
 
-    void init(int capacity);
+    /// @brief Initializes the tree with a given capacity and minimum margin for fattening AABBs.
+    /// @param capacity initial number of nodes to allocate; will grow as needed.
+    /// @param minMargin absolute floor for the fattening margin; leave at 0 for static trees.
+    void init(int capacity, float minMargin = 0.0f);
     void destroy();
 
     NodeProxy createNode(const AABB &bounds, void *data);
@@ -77,12 +84,14 @@ namespace P64::Coll {
     NodeProxy root{NULL_NODE};
 
   private:
+    fm_vec3_t fattenExtent(const AABB &bounds) const;
     NodeProxy allocateNode();
     void freeNode(NodeProxy node);
     NodeProxy insertLeaf(NodeProxy leaf);
     void rotateNode(NodeProxy node);
 
     std::unique_ptr<AABBTreeNode[]> nodes_;
+    float minMargin_{0.0f};
     int16_t nodeCount_{0};
     int16_t nodeCapacity_{0};
     NodeProxy freeList_{NULL_NODE};

--- a/n64/engine/include/collision/aabbTree.h
+++ b/n64/engine/include/collision/aabbTree.h
@@ -47,9 +47,20 @@ namespace P64::Coll {
     bool moveNode(NodeProxy node, const AABB &aabb, const fm_vec3_t &displacement);
     void removeLeaf(NodeProxy leaf, bool freeIt);
 
-    [[nodiscard]] void *getNodeData(NodeProxy node) const;
-    [[nodiscard]] const AABB *getNodeBounds(NodeProxy node) const;
-    [[nodiscard]] bool isLeaf(NodeProxy node) const;
+    [[nodiscard]] void *getNodeData(NodeProxy node) const {
+      assert(node >= 0 && node < nodeCapacity_);
+      return nodes_[node].data;
+    }
+
+    [[nodiscard]] const AABB *getNodeBounds(NodeProxy node) const {
+      assert(node >= 0 && node < nodeCapacity_);
+      return &nodes_[node].bounds;
+    }
+
+    [[nodiscard]] bool isLeaf(NodeProxy node) const {
+      assert(node >= 0 && node < nodeCapacity_);
+      return nodes_[node].left == NULL_NODE && nodes_[node].right == NULL_NODE;
+    }
 
     int queryBounds(const AABB &queryBox, NodeProxy *results, int maxResults) const;
     int queryPoint(const fm_vec3_t &point, NodeProxy *results, int maxResults) const;

--- a/n64/engine/include/collision/colliderShape.h
+++ b/n64/engine/include/collision/colliderShape.h
@@ -122,6 +122,8 @@ namespace P64::Coll {
 
     fm_vec3_t support(const fm_vec3_t &dir) const;
     AABB boundingBox(const fm_quat_t *rotation) const;
+    /// Same box as the quaternion overload, for callers that already hold the rotation matrix.
+    AABB boundingBox(const Matrix3x3 &rotation) const;
     fm_vec3_t inertiaTensor(float mass) const;
     fm_vec3_t toWorldSpace(const fm_vec3_t &localPoint) const;
     fm_vec3_t toLocalSpace(const fm_vec3_t &worldPoint) const;

--- a/n64/engine/include/collision/collisionScene.h
+++ b/n64/engine/include/collision/collisionScene.h
@@ -226,6 +226,10 @@ namespace P64::Coll {
 
     // Multiple mesh colliders
     std::vector<MeshCollider *> meshColliders_{};
+    // OR of every mesh collider's read/write mask, refreshed each step in updateMeshColliderWorldStates().
+    // Lets detectAllContacts() reject a collider before querying the mesh tree at all.
+    uint8_t meshReadMaskUnion_{0};
+    uint8_t meshWriteMaskUnion_{0};
 
     float fixedDt_{DEFAULT_FIXED_DT};
     fm_vec3_t gravity_{DEFAULT_GRAVITY};

--- a/n64/engine/include/collision/matrix3x3.h
+++ b/n64/engine/include/collision/matrix3x3.h
@@ -14,12 +14,58 @@ namespace P64::Coll {
     }
   };
 
-  fm_vec3_t matrix3Vec3Mul(const Matrix3x3 &mat, const fm_vec3_t &v);
+  inline fm_vec3_t matrix3Vec3Mul(const Matrix3x3 &mat, const fm_vec3_t &v) {
+    return fm_vec3_t{{
+      mat.m[0][0] * v.x + mat.m[0][1] * v.y + mat.m[0][2] * v.z,
+      mat.m[1][0] * v.x + mat.m[1][1] * v.y + mat.m[1][2] * v.z,
+      mat.m[2][0] * v.x + mat.m[2][1] * v.y + mat.m[2][2] * v.z
+    }};
+  }
+
+  inline Matrix3x3 matrix3Mul(const Matrix3x3 &a, const Matrix3x3 &b) {
+    Matrix3x3 r{};
+    for(int i = 0; i < 3; ++i) {
+      for(int j = 0; j < 3; ++j) {
+        r.m[i][j] = a.m[i][0] * b.m[0][j]
+                   + a.m[i][1] * b.m[1][j]
+                   + a.m[i][2] * b.m[2][j];
+      }
+    }
+    return r;
+  }
+
+  inline Matrix3x3 matrix3Transpose(const Matrix3x3 &m) {
+    Matrix3x3 r{};
+    for(int i = 0; i < 3; ++i) {
+      for(int j = 0; j < 3; ++j) {
+        r.m[i][j] = m.m[j][i];
+      }
+    }
+    return r;
+  }
+
+  inline Matrix3x3 quatToMatrix3(const fm_quat_t &q) {
+    float xx = q.x * q.x, yy = q.y * q.y, zz = q.z * q.z;
+    float xy = q.x * q.y, xz = q.x * q.z, yz = q.y * q.z;
+    float wx = q.w * q.x, wy = q.w * q.y, wz = q.w * q.z;
+
+    Matrix3x3 r{};
+    r.m[0][0] = 1.0f - 2.0f * (yy + zz);
+    r.m[0][1] = 2.0f * (xy - wz);
+    r.m[0][2] = 2.0f * (xz + wy);
+
+    r.m[1][0] = 2.0f * (xy + wz);
+    r.m[1][1] = 1.0f - 2.0f * (xx + zz);
+    r.m[1][2] = 2.0f * (yz - wx);
+
+    r.m[2][0] = 2.0f * (xz - wy);
+    r.m[2][1] = 2.0f * (yz + wx);
+    r.m[2][2] = 1.0f - 2.0f * (xx + yy);
+    return r;
+  }
+
   float matrix3Determinant(const Matrix3x3 &matrix);
   Matrix3x3 matrix3Inverse(const Matrix3x3 &matrix);
-  Matrix3x3 matrix3Mul(const Matrix3x3 &a, const Matrix3x3 &b);
-  Matrix3x3 matrix3Transpose(const Matrix3x3 &m);
-  Matrix3x3 quatToMatrix3(const fm_quat_t &q);
   inline Matrix3x3 diagonalMatrix(const fm_vec3_t &diag) {
     Matrix3x3 result{};
     result.m[0][0] = diag.x;

--- a/n64/engine/include/collision/meshCollider.h
+++ b/n64/engine/include/collision/meshCollider.h
@@ -101,15 +101,16 @@ namespace P64::Coll {
     /// Transform a world-space AABB into a conservative local-space AABB for tree queries
     AABB worldAabbToLocal(const AABB &worldAabb) const;
 
+    // These are cached properties for the owner transform to avoid comparing the same stuff multiple times in the step
+    // They are taken once per step in syncOwnerTransform()
     /// Returns true if the mesh has a non-identity transform
-    bool hasTransform() const;
-
+    bool hasTransform() const { return hasTransform_; }
     /// Returns true if the mesh has a non-identity rotation
-    bool hasRotation() const;
+    bool hasRotation() const { return hasRotation_; }
     /// Returns true if the mesh has a non-zero position
-    bool hasPosition() const;
+    bool hasPosition() const { return hasPosition_; }
     /// Returns true if the mesh has a non-uniform (1,1,1) scale
-    bool hasScale() const;
+    bool hasScale() const { return hasScale_; }
 
     bool readsCollider(const Collider *other) const;
     bool readsMeshCollider(const MeshCollider *other) const;
@@ -163,6 +164,10 @@ namespace P64::Coll {
     uint8_t writeMask_{0x00};
     bool hasCachedOwnerTransform_{false};
     bool transformChanged_{false};
+    bool hasRotation_{false};
+    bool hasPosition_{false};
+    bool hasScale_{false};
+    bool hasTransform_{false};
   };
 
 } // namespace P64::Coll

--- a/n64/engine/include/collision/rigidBody.h
+++ b/n64/engine/include/collision/rigidBody.h
@@ -215,6 +215,13 @@ namespace P64::Coll {
     bool hasAngularConstraints_{false};
     bool compoundPropertiesDirty_{true};
 
+    // Inputs updateWorldInertia() last ran on, so it can early out if nothing changed.
+    fm_quat_t worldInertiaCacheRotation_{};
+    fm_vec3_t worldInertiaCachePosition_{};
+    fm_vec3_t worldInertiaCacheLocalInv_{};
+    fm_vec3_t worldInertiaCacheLocalCom_{};
+    bool worldInertiaCacheValid_{false};
+
     /// Index into the CollisionScene's per-step solver body array (-1 = not participating).
     /// Only valid while the scene builds and runs the contact solvers.
     int16_t solverIndex_{-1};

--- a/n64/engine/include/collision/shapes.h
+++ b/n64/engine/include/collision/shapes.h
@@ -8,6 +8,7 @@
 #include "vecMath.h"
 #include <cmath>
 #include "aabb.h"
+#include "matrix3x3.h"
 
 namespace P64::Coll {
 
@@ -25,6 +26,10 @@ namespace P64::Coll {
     }
 
     AABB boundingBox(const fm_quat_t * /*rotation*/) const {
+      return {fm_vec3_t{{-radius, -radius, -radius}}, fm_vec3_t{{radius, radius, radius}}};
+    }
+
+    AABB boundingBox(const Matrix3x3 & /*rotation*/) const {
       return {fm_vec3_t{{-radius, -radius, -radius}}, fm_vec3_t{{radius, radius, radius}}};
     }
 
@@ -49,6 +54,8 @@ namespace P64::Coll {
     }
 
     AABB boundingBox(const fm_quat_t *q) const;
+    /// Same box as the quaternion overload, for callers that already hold the rotation matrix.
+    AABB boundingBox(const Matrix3x3 &rotation) const;
     fm_vec3_t inertiaTensor(float mass) const;
   };
 
@@ -69,6 +76,8 @@ namespace P64::Coll {
     }
 
     AABB boundingBox(const fm_quat_t *q) const;
+    /// Same box as the quaternion overload, for callers that already hold the rotation matrix.
+    AABB boundingBox(const Matrix3x3 &rotation) const;
     fm_vec3_t inertiaTensor(float mass) const;
   };
 
@@ -81,6 +90,8 @@ namespace P64::Coll {
 
     fm_vec3_t support(const fm_vec3_t &dir) const;
     AABB boundingBox(const fm_quat_t *q) const;
+    /// Same box as the quaternion overload, for callers that already hold the rotation matrix.
+    AABB boundingBox(const Matrix3x3 &rotation) const;
     fm_vec3_t inertiaTensor(float mass) const;
   };
 
@@ -94,6 +105,8 @@ namespace P64::Coll {
 
     fm_vec3_t support(const fm_vec3_t &dir) const;
     AABB boundingBox(const fm_quat_t *q) const;
+    /// Same box as the quaternion overload, for callers that already hold the rotation matrix.
+    AABB boundingBox(const Matrix3x3 &rotation) const;
     fm_vec3_t inertiaTensor(float mass) const;
   };
 
@@ -109,6 +122,8 @@ namespace P64::Coll {
 
     fm_vec3_t support(const fm_vec3_t &dir) const;
     AABB boundingBox(const fm_quat_t *q) const;
+    /// Same box as the quaternion overload, for callers that already hold the rotation matrix.
+    AABB boundingBox(const Matrix3x3 &rotation) const;
     fm_vec3_t inertiaTensor(float mass) const;
   };
 

--- a/n64/engine/src/collision/aabbTree.cpp
+++ b/n64/engine/src/collision/aabbTree.cpp
@@ -183,21 +183,6 @@ void AABBTree::removeLeaf(NodeProxy leaf, bool freeIt) {
   if(freeIt) freeNode(leaf);
 }
 
-void *AABBTree::getNodeData(NodeProxy node) const {
-  assert(node >= 0 && node < nodeCapacity_);
-  return nodes_[node].data;
-}
-
-const AABB *AABBTree::getNodeBounds(NodeProxy node) const {
-  assert(node >= 0 && node < nodeCapacity_);
-  return &nodes_[node].bounds;
-}
-
-bool AABBTree::isLeaf(NodeProxy node) const {
-  assert(node >= 0 && node < nodeCapacity_);
-  return nodes_[node].left == NULL_NODE && nodes_[node].right == NULL_NODE;
-}
-
 // ── Leaf insertion (SAH) ────────────────────────────────────────────
 
 NodeProxy AABBTree::insertLeaf(NodeProxy leaf) {
@@ -364,6 +349,7 @@ void AABBTree::rotateNode(NodeProxy node) {
 
 int AABBTree::queryBounds(const AABB &queryBox, NodeProxy *results, int maxResults) const {
   if(root == NULL_NODE) return 0;
+  if(!aabbOverlap(nodes_[root].bounds, queryBox)) return 0;
 
   NodeProxy stack[AABB_QUERY_STACK_SIZE];
   int stackCount = 0;
@@ -372,18 +358,21 @@ int AABBTree::queryBounds(const AABB &queryBox, NodeProxy *results, int maxResul
   stack[stackCount++] = root;
 
   while(stackCount > 0 && resultCount < maxResults) {
-    NodeProxy current = stack[--stackCount];
-    if(current == NULL_NODE) continue;
+    const NodeProxy current = stack[--stackCount];
+    const AABBTreeNode &node = nodes_[current];
 
-    if(!aabbOverlap(nodes_[current].bounds, queryBox)) continue;
-
-    if(isLeaf(current)) {
+    if(node.left == NULL_NODE && node.right == NULL_NODE) {
       results[resultCount++] = current;
-    } else {
-      if(stackCount < AABB_QUERY_STACK_SIZE - 1) {
-        stack[stackCount++] = nodes_[current].left;
-        stack[stackCount++] = nodes_[current].right;
-      }
+      continue;
+    }
+
+    if(node.left != NULL_NODE && stackCount < AABB_QUERY_STACK_SIZE &&
+       aabbOverlap(nodes_[node.left].bounds, queryBox)) {
+      stack[stackCount++] = node.left;
+    }
+    if(node.right != NULL_NODE && stackCount < AABB_QUERY_STACK_SIZE &&
+       aabbOverlap(nodes_[node.right].bounds, queryBox)) {
+      stack[stackCount++] = node.right;
     }
   }
   return resultCount;
@@ -391,6 +380,7 @@ int AABBTree::queryBounds(const AABB &queryBox, NodeProxy *results, int maxResul
 
 int AABBTree::queryPoint(const fm_vec3_t &point, NodeProxy *results, int maxResults) const {
   if(root == NULL_NODE) return 0;
+  if(!aabbContainsPoint(nodes_[root].bounds, point)) return 0;
 
   NodeProxy stack[AABB_QUERY_STACK_SIZE];
   int stackCount = 0;
@@ -399,18 +389,21 @@ int AABBTree::queryPoint(const fm_vec3_t &point, NodeProxy *results, int maxResu
   stack[stackCount++] = root;
 
   while(stackCount > 0 && resultCount < maxResults) {
-    NodeProxy current = stack[--stackCount];
-    if(current == NULL_NODE) continue;
+    const NodeProxy current = stack[--stackCount];
+    const AABBTreeNode &node = nodes_[current];
 
-    if(!aabbContainsPoint(nodes_[current].bounds, point)) continue;
-
-    if(isLeaf(current)) {
+    if(node.left == NULL_NODE && node.right == NULL_NODE) {
       results[resultCount++] = current;
-    } else {
-      if(stackCount < AABB_QUERY_STACK_SIZE - 1) {
-        stack[stackCount++] = nodes_[current].left;
-        stack[stackCount++] = nodes_[current].right;
-      }
+      continue;
+    }
+
+    if(node.left != NULL_NODE && stackCount < AABB_QUERY_STACK_SIZE &&
+       aabbContainsPoint(nodes_[node.left].bounds, point)) {
+      stack[stackCount++] = node.left;
+    }
+    if(node.right != NULL_NODE && stackCount < AABB_QUERY_STACK_SIZE &&
+       aabbContainsPoint(nodes_[node.right].bounds, point)) {
+      stack[stackCount++] = node.right;
     }
   }
   return resultCount;
@@ -419,6 +412,7 @@ int AABBTree::queryPoint(const fm_vec3_t &point, NodeProxy *results, int maxResu
 int AABBTree::queryRay(const Raycast &ray, NodeProxy *results, int maxResults) const
 {
   if(root == NULL_NODE) return 0;
+  if(!aabbIntersectsRay(nodes_[root].bounds, ray)) return 0;
 
   NodeProxy stack[AABB_QUERY_STACK_SIZE];
   int stackCount = 0;
@@ -427,18 +421,21 @@ int AABBTree::queryRay(const Raycast &ray, NodeProxy *results, int maxResults) c
   stack[stackCount++] = root;
 
   while(stackCount > 0 && resultCount < maxResults) {
-    NodeProxy current = stack[--stackCount];
-    if(current == NULL_NODE) continue;
+    const NodeProxy current = stack[--stackCount];
+    const AABBTreeNode &node = nodes_[current];
 
-    if(!aabbIntersectsRay(nodes_[current].bounds, ray)) continue;
-
-    if(isLeaf(current)) {
+    if(node.left == NULL_NODE && node.right == NULL_NODE) {
       results[resultCount++] = current;
-    } else {
-      if(stackCount < AABB_QUERY_STACK_SIZE - 1) {
-        stack[stackCount++] = nodes_[current].left;
-        stack[stackCount++] = nodes_[current].right;
-      }
+      continue;
+    }
+
+    if(node.left != NULL_NODE && stackCount < AABB_QUERY_STACK_SIZE &&
+       aabbIntersectsRay(nodes_[node.left].bounds, ray)) {
+      stack[stackCount++] = node.left;
+    }
+    if(node.right != NULL_NODE && stackCount < AABB_QUERY_STACK_SIZE &&
+       aabbIntersectsRay(nodes_[node.right].bounds, ray)) {
+      stack[stackCount++] = node.right;
     }
   }
   return resultCount;

--- a/n64/engine/src/collision/aabbTree.cpp
+++ b/n64/engine/src/collision/aabbTree.cpp
@@ -17,8 +17,9 @@ AABBTree::~AABBTree() {
   destroy();
 }
 
-void AABBTree::init(int capacity) {
+void AABBTree::init(int capacity, float minMargin) {
   assert(capacity > 0);
+  minMargin_ = minMargin;
   assert(capacity <= std::numeric_limits<int16_t>::max());
   nodeCapacity_ = static_cast<int16_t>(capacity);
   nodeCount_ = 0;
@@ -102,10 +103,20 @@ void AABBTree::freeNode(NodeProxy node) {
 
 // ── Public API ──────────────────────────────────────────────────────
 
+// Fatten the AABB so small moves don't cause reinsertion
+// a fraction of the box's own size, but not less than the trees floor.
+fm_vec3_t AABBTree::fattenExtent(const AABB &bounds) const {
+  const fm_vec3_t size = bounds.max - bounds.min;
+  return fm_vec3_t{{
+    fmaxf(size.x * AABBTREE_MARGIN_RATIO, minMargin_),
+    fmaxf(size.y * AABBTREE_MARGIN_RATIO, minMargin_),
+    fmaxf(size.z * AABBTREE_MARGIN_RATIO, minMargin_)
+  }};
+}
+
 NodeProxy AABBTree::createNode(const AABB &bounds, void *data) {
   NodeProxy id = allocateNode();
-  // Fatten the AABB by some margin so small moves don't cause reinsertion.
-  fm_vec3_t extent = (bounds.max - bounds.min) * 0.1f;
+  const fm_vec3_t extent = fattenExtent(bounds);
   nodes_[id].bounds.min = bounds.min - extent;
   nodes_[id].bounds.max = bounds.max + extent;
   nodes_[id].data = data;
@@ -125,12 +136,12 @@ bool AABBTree::moveNode(NodeProxy node, const AABB &aabb, const fm_vec3_t &displ
   removeLeaf(node, false);
 
   // Recompute fattened bounds.
-  fm_vec3_t extent = (aabb.max - aabb.min) * 0.1f;
+  const fm_vec3_t extent = fattenExtent(aabb);
   nodes_[node].bounds.min = aabb.min - extent;
   nodes_[node].bounds.max = aabb.max + extent;
 
   // Extend in the direction of movement.
-  fm_vec3_t disp = displacement * AABB_DISPLACEMENT_MULTIPLIER;
+  fm_vec3_t disp = displacement * AABBTREE_DISPLACEMENT_MULTIPLIER;
   aabbExtendDirection(nodes_[node].bounds, disp, nodes_[node].bounds);
 
   insertLeaf(node);
@@ -162,13 +173,16 @@ void AABBTree::removeLeaf(NodeProxy leaf, bool freeIt) {
     nodes_[sibling].parent = grandParent;
     freeNode(parent);
 
-    // Walk up and refit ancestor bounds.
+    // Walk up and refit ancestor bounds. Once a node's refit leaves its bounds unchanged, every
+    // ancestor above it is unchanged too and we can stop
     NodeProxy idx = grandParent;
     while(idx != NULL_NODE) {
       NodeProxy l = nodes_[idx].left;
       NodeProxy r = nodes_[idx].right;
       if(l != NULL_NODE && r != NULL_NODE) {
-        nodes_[idx].bounds = aabbUnion(nodes_[l].bounds, nodes_[r].bounds);
+        const AABB refitted = aabbUnion(nodes_[l].bounds, nodes_[r].bounds);
+        if(aabbIdentical(refitted, nodes_[idx].bounds)) break;
+        nodes_[idx].bounds = refitted;
       }
       idx = nodes_[idx].parent;
     }
@@ -194,16 +208,17 @@ NodeProxy AABBTree::insertLeaf(NodeProxy leaf) {
 
   // Stage 1 — find the best sibling using a branch-and-bound SAH walk.
   AABB leafBounds = nodes_[leaf].bounds;
+  const float leafArea = aabbArea(leafBounds);
   NodeProxy bestSibling = root;
   float bestCost = aabbArea(aabbUnion(nodes_[root].bounds, leafBounds));
 
   // Candidate stack for the branch-and-bound search.
   struct Candidate { NodeProxy index; float inheritedCost; };
-  Candidate stack[AABB_QUERY_STACK_SIZE];
+  Candidate stack[AABBTREE_QUERY_STACK_SIZE];
   int stackCount = 0;
 
   auto pushCandidate = [&](NodeProxy idx, float inherited) {
-    if(idx != NULL_NODE && stackCount < AABB_QUERY_STACK_SIZE) {
+    if(idx != NULL_NODE && stackCount < AABBTREE_QUERY_STACK_SIZE) {
       stack[stackCount++] = {idx, inherited};
     }
   };
@@ -226,7 +241,7 @@ NodeProxy AABBTree::insertLeaf(NodeProxy leaf) {
 
     // Lower bound on cost for children of this candidate.
     float childInherited = inherited + directCost - aabbArea(nodes_[candidate].bounds);
-    float lowerBound = aabbArea(leafBounds) + childInherited;
+    float lowerBound = leafArea + childInherited;
     if(lowerBound < bestCost && !isLeaf(candidate)) {
       pushCandidate(nodes_[candidate].left, childInherited);
       pushCandidate(nodes_[candidate].right, childInherited);
@@ -289,23 +304,25 @@ void AABBTree::rotateNode(NodeProxy node) {
   float costs[4];
   int numCandidates = 0;
 
-  auto tryRotation = [&](NodeProxy parent, NodeProxy swapWith, NodeProxy child, NodeProxy other) {
+  auto tryRotation = [&](NodeProxy parent, float parentArea, NodeProxy swapWith, NodeProxy child, NodeProxy other) {
     if(child == NULL_NODE) return;
     // Cost of the new parent after the swap = union of (swapWith, other).
     AABB newBounds = aabbUnion(nodes_[swapWith].bounds, nodes_[other].bounds);
-    float costReduction = aabbArea(nodes_[parent].bounds) - aabbArea(newBounds);
+    float costReduction = parentArea - aabbArea(newBounds);
     candidates[numCandidates] = {parent, child, other, swapWith};
     costs[numCandidates] = costReduction;
     ++numCandidates;
   };
 
   if(!isLeaf(right)) {
-    tryRotation(right, left, nodes_[right].left, nodes_[right].right);
-    tryRotation(right, left, nodes_[right].right, nodes_[right].left);
+    const float rightArea = aabbArea(nodes_[right].bounds);
+    tryRotation(right, rightArea, left, nodes_[right].left, nodes_[right].right);
+    tryRotation(right, rightArea, left, nodes_[right].right, nodes_[right].left);
   }
   if(!isLeaf(left)) {
-    tryRotation(left, right, nodes_[left].left, nodes_[left].right);
-    tryRotation(left, right, nodes_[left].right, nodes_[left].left);
+    const float leftArea = aabbArea(nodes_[left].bounds);
+    tryRotation(left, leftArea, right, nodes_[left].left, nodes_[left].right);
+    tryRotation(left, leftArea, right, nodes_[left].right, nodes_[left].left);
   }
 
   // Pick the rotation with the greatest cost reduction.
@@ -351,7 +368,7 @@ int AABBTree::queryBounds(const AABB &queryBox, NodeProxy *results, int maxResul
   if(root == NULL_NODE) return 0;
   if(!aabbOverlap(nodes_[root].bounds, queryBox)) return 0;
 
-  NodeProxy stack[AABB_QUERY_STACK_SIZE];
+  NodeProxy stack[AABBTREE_QUERY_STACK_SIZE];
   int stackCount = 0;
   int resultCount = 0;
 
@@ -366,11 +383,11 @@ int AABBTree::queryBounds(const AABB &queryBox, NodeProxy *results, int maxResul
       continue;
     }
 
-    if(node.left != NULL_NODE && stackCount < AABB_QUERY_STACK_SIZE &&
+    if(node.left != NULL_NODE && stackCount < AABBTREE_QUERY_STACK_SIZE &&
        aabbOverlap(nodes_[node.left].bounds, queryBox)) {
       stack[stackCount++] = node.left;
     }
-    if(node.right != NULL_NODE && stackCount < AABB_QUERY_STACK_SIZE &&
+    if(node.right != NULL_NODE && stackCount < AABBTREE_QUERY_STACK_SIZE &&
        aabbOverlap(nodes_[node.right].bounds, queryBox)) {
       stack[stackCount++] = node.right;
     }
@@ -382,7 +399,7 @@ int AABBTree::queryPoint(const fm_vec3_t &point, NodeProxy *results, int maxResu
   if(root == NULL_NODE) return 0;
   if(!aabbContainsPoint(nodes_[root].bounds, point)) return 0;
 
-  NodeProxy stack[AABB_QUERY_STACK_SIZE];
+  NodeProxy stack[AABBTREE_QUERY_STACK_SIZE];
   int stackCount = 0;
   int resultCount = 0;
 
@@ -397,11 +414,11 @@ int AABBTree::queryPoint(const fm_vec3_t &point, NodeProxy *results, int maxResu
       continue;
     }
 
-    if(node.left != NULL_NODE && stackCount < AABB_QUERY_STACK_SIZE &&
+    if(node.left != NULL_NODE && stackCount < AABBTREE_QUERY_STACK_SIZE &&
        aabbContainsPoint(nodes_[node.left].bounds, point)) {
       stack[stackCount++] = node.left;
     }
-    if(node.right != NULL_NODE && stackCount < AABB_QUERY_STACK_SIZE &&
+    if(node.right != NULL_NODE && stackCount < AABBTREE_QUERY_STACK_SIZE &&
        aabbContainsPoint(nodes_[node.right].bounds, point)) {
       stack[stackCount++] = node.right;
     }
@@ -414,7 +431,7 @@ int AABBTree::queryRay(const Raycast &ray, NodeProxy *results, int maxResults) c
   if(root == NULL_NODE) return 0;
   if(!aabbIntersectsRay(nodes_[root].bounds, ray)) return 0;
 
-  NodeProxy stack[AABB_QUERY_STACK_SIZE];
+  NodeProxy stack[AABBTREE_QUERY_STACK_SIZE];
   int stackCount = 0;
   int resultCount = 0;
 
@@ -429,11 +446,11 @@ int AABBTree::queryRay(const Raycast &ray, NodeProxy *results, int maxResults) c
       continue;
     }
 
-    if(node.left != NULL_NODE && stackCount < AABB_QUERY_STACK_SIZE &&
+    if(node.left != NULL_NODE && stackCount < AABBTREE_QUERY_STACK_SIZE &&
        aabbIntersectsRay(nodes_[node.left].bounds, ray)) {
       stack[stackCount++] = node.left;
     }
-    if(node.right != NULL_NODE && stackCount < AABB_QUERY_STACK_SIZE &&
+    if(node.right != NULL_NODE && stackCount < AABBTREE_QUERY_STACK_SIZE &&
        aabbIntersectsRay(nodes_[node.right].bounds, ray)) {
       stack[stackCount++] = node.right;
     }

--- a/n64/engine/src/collision/colliderShape.cpp
+++ b/n64/engine/src/collision/colliderShape.cpp
@@ -76,6 +76,18 @@ AABB Collider::boundingBox(const fm_quat_t *rotation) const {
   __builtin_unreachable();
 }
 
+AABB Collider::boundingBox(const Matrix3x3 &rotation) const {
+  switch(type_) {
+    case ShapeType::Sphere:   return sphere_.boundingBox(rotation);
+    case ShapeType::Box:      return box_.boundingBox(rotation);
+    case ShapeType::Capsule:  return capsule_.boundingBox(rotation);
+    case ShapeType::Cylinder: return cylinder_.boundingBox(rotation);
+    case ShapeType::Cone:     return cone_.boundingBox(rotation);
+    case ShapeType::Pyramid:  return pyramid_.boundingBox(rotation);
+  }
+  __builtin_unreachable();
+}
+
 fm_vec3_t Collider::inertiaTensor(float mass) const {
   switch(type_) {
     case ShapeType::Sphere:   return sphere_.inertiaTensor(mass);
@@ -128,7 +140,8 @@ void Collider::syncOwnerTransform() {
   }
 
   rotationMatrix_ = quatToMatrix3(lastOwnerRotation_);
-  inverseRotationMatrix_ = quatToMatrix3(quatConjugate(lastOwnerRotation_));
+  // A rotation matrix's inverse is its transpose
+  inverseRotationMatrix_ = matrix3Transpose(rotationMatrix_);
   hasCachedOwnerTransform_ = true;
 }
 
@@ -148,12 +161,13 @@ bool Collider::syncFromRigidBody(const fm_vec3_t& rbPosition, const fm_quat_t& r
   lastOwnerScale_ = owner_ ? owner_->scale : fm_vec3_t{{1,1,1}};
   if(scaleChanged) refreshWorldShape();
   rotationMatrix_ = quatToMatrix3(lastOwnerRotation_);
-  inverseRotationMatrix_ = quatToMatrix3(quatConjugate(lastOwnerRotation_));
+  inverseRotationMatrix_ = matrix3Transpose(rotationMatrix_);
   hasCachedOwnerTransform_ = true;
 
   worldCenter_ = lastOwnerPosition_ + matrix3Vec3Mul(rotationMatrix_, parentOffset_ * lastOwnerScale_);
 
-  const AABB local = boundingBox(&lastOwnerRotation_);
+  // Pass the matrix we just built: the quaternion overload would rebuild it from lastOwnerRotation_
+  const AABB local = boundingBox(rotationMatrix_);
   worldAabb_.min = local.min + worldCenter_;
   worldAabb_.max = local.max + worldCenter_;
   ++worldStateVersion_;
@@ -175,7 +189,7 @@ bool Collider::syncWorldState() {
   if(scaleChanged) refreshWorldShape();
   worldCenter_ = lastOwnerPosition_ + matrix3Vec3Mul(rotationMatrix_, parentOffset_ * lastOwnerScale_);
 
-  const AABB local = boundingBox(&lastOwnerRotation_);
+  const AABB local = boundingBox(rotationMatrix_);
   worldAabb_.min = local.min + worldCenter_;
   worldAabb_.max = local.max + worldCenter_;
   ++worldStateVersion_;

--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -189,8 +189,8 @@ namespace P64::Coll {
     ticksFinalize = 0;
     ticksTotal = 0;
 
-    colliderAABBTree.init(32); // Initial capacity (will grow as needed)
-    meshColliderAABBTree.init(32);
+    colliderAABBTree.init(32, AABBTREE_MIN_MARGIN); // Initial capacity (will grow as needed)
+    meshColliderAABBTree.init(32, AABBTREE_MIN_MARGIN);
   }
 
   RigidBody *CollisionScene::findRigidBodyByOwner(const Object *owner) const {
@@ -1689,20 +1689,19 @@ namespace P64::Coll {
       mesh->transformChanged_ = mesh->hasOwnerTransformChanged();
       if(!mesh->transformChanged_ && mesh->hasCachedOwnerTransform_) continue;
 
-      fm_vec3_t prevOwnerPhysicsPos = mesh->owner_ ? mesh->owner_->pos : VEC3_ZERO;
+      // Movement since the last update, used to extend the tree box along the direction of travel so
+      // a moving mesh does not fall out of it again next step.
+      fm_vec3_t ownerDisplacement = VEC3_ZERO;
+      if (mesh->owner_ && mesh->hasCachedOwnerTransform_) {
+        ownerDisplacement = mesh->owner_->pos - mesh->lastOwnerPosition_;
+      }
 
       // Snapshot first: recalculateWorldAabb() branches on the cached has*() properties
       mesh->syncOwnerTransform();
       mesh->recalculateWorldAabb();
 
       if (mesh->aabbTreeNodeId_ != NULL_NODE) {
-        if (mesh->owner_) {
-          fm_vec3_t ownerPhysicsPos = mesh->owner_->pos;
-          const fm_vec3_t disp = ownerPhysicsPos - prevOwnerPhysicsPos;
-          meshColliderAABBTree.moveNode(mesh->aabbTreeNodeId_, mesh->worldAabb_, disp);
-        } else {
-          meshColliderAABBTree.moveNode(mesh->aabbTreeNodeId_, mesh->worldAabb_, VEC3_ZERO);
-        }
+        meshColliderAABBTree.moveNode(mesh->aabbTreeNodeId_, mesh->worldAabb_, ownerDisplacement);
       }
     }
   }

--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -162,6 +162,8 @@ namespace P64::Coll {
     colliders_.clear();
     ownerColliders_.clear();
     meshColliders_.clear();
+    meshReadMaskUnion_ = 0;
+    meshWriteMaskUnion_ = 0;
     cachedConstraintCount_ = 0;
     cachedConstraints_.clear();
     cachedConstraintLookup_.clear();
@@ -415,8 +417,8 @@ namespace P64::Coll {
     if(!mesh) return;
 
     mesh->computeLocalRootAabb();
-    mesh->recalculateWorldAabb();
     mesh->syncOwnerTransform();
+    mesh->recalculateWorldAabb();
 
     meshColliders_.push_back(mesh);
 
@@ -1142,6 +1144,11 @@ namespace P64::Coll {
 
       if (!collider->isTrigger_ && rigidBodyA && rigidBodyA->isSleeping_) continue;
 
+      // If this fails for the union off all mesh masks then we can skip the mesh query entirely
+      // since there can be no interaction with any mesh collider.
+      if ((collider->readMask_ & meshWriteMaskUnion_) == 0 &&
+          (meshReadMaskUnion_ & collider->writeMask_) == 0) continue;
+
       const int candidateCount = meshColliderAABBTree.queryBounds(
           collider->worldAabb_,
           candidateMeshColliders.data(),
@@ -1666,17 +1673,27 @@ namespace P64::Coll {
 
   /// @brief Recalculate the world-space AABBs of all Mesh Colliders in the Collision Scene.
   void CollisionScene::updateMeshColliderWorldStates() {
+    // Rebuilt from scratch each step so runtime changes to a mesh's masks are picked up without the
+    // scene having to observe every setCollisionMask() call. detectAllContacts() uses these to skip
+    // mesh-tree queries for colliders that cannot match any mesh.
+    meshReadMaskUnion_ = 0;
+    meshWriteMaskUnion_ = 0;
+
     for(std::size_t i = 0; i < meshColliders_.size(); ++i) {
       MeshCollider *mesh = meshColliders_[i];
       if(!mesh) continue;
+
+      meshReadMaskUnion_ |= mesh->readMask_;
+      meshWriteMaskUnion_ |= mesh->writeMask_;
 
       mesh->transformChanged_ = mesh->hasOwnerTransformChanged();
       if(!mesh->transformChanged_ && mesh->hasCachedOwnerTransform_) continue;
 
       fm_vec3_t prevOwnerPhysicsPos = mesh->owner_ ? mesh->owner_->pos : VEC3_ZERO;
 
-      mesh->recalculateWorldAabb();
+      // Snapshot first: recalculateWorldAabb() branches on the cached has*() properties
       mesh->syncOwnerTransform();
+      mesh->recalculateWorldAabb();
 
       if (mesh->aabbTreeNodeId_ != NULL_NODE) {
         if (mesh->owner_) {

--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -1722,6 +1722,8 @@ namespace P64::Coll {
       for(int m = 0; m < meshCount; ++m) {
         const MeshCollider* mesh = static_cast<const MeshCollider*>(meshColliderAABBTree.getNodeData(meshCandidates[m]));
         if(!mesh || mesh->triangleCount_ == 0) continue;
+        // ray only hits what it reads.
+        if((mesh->writeMask_ & ray.readMask) == 0) continue;
         Raycast localRay = ray;
         if(mesh->hasScale()) {
           const fm_vec3_t &scale = mesh->owner_->scale;
@@ -1763,7 +1765,6 @@ namespace P64::Coll {
           currentHit.distance = fm_vec3_len(&hitDelta);
           currentHit.hitObjectId = mesh->owner_ ? mesh->owner_->id : 0;
 
-          hit.didHit = true;
           if(currentHit.didHit && currentHit.distance < hit.distance && currentHit.distance <= ray.maxDistance) {
             hit = currentHit;
           }
@@ -1883,6 +1884,7 @@ namespace P64::Coll {
         const MeshCollider* mesh = static_cast<const MeshCollider*>(
           meshColliderAABBTree.getNodeData(meshCandidates[m]));
         if (!mesh || mesh->triangleCount() == 0 || !mesh->ownerObject()) continue;
+        if ((mesh->writeMask() & readMask) == 0) continue;
 
         AABB localSweptBox = mesh->worldAabbToLocal(sweptBox);
         int triCount = mesh->queryTriangleNodes(localSweptBox, triCandidates, MAX_TRI);
@@ -2050,6 +2052,7 @@ namespace P64::Coll {
         const MeshCollider* mesh = static_cast<const MeshCollider*>(
                 meshColliderAABBTree.getNodeData(meshCandidates[m]));
         if (!mesh || mesh->triangleCount() == 0 || !mesh->ownerObject()) continue;
+        if ((mesh->writeMask() & readMask) == 0) continue;
 
         AABB localSweptBox = mesh->worldAabbToLocal(sweptBox);
         int triCount = mesh->queryTriangleNodes(localSweptBox, triCandidates, MAX_TRI);

--- a/n64/engine/src/collision/meshCollider.cpp
+++ b/n64/engine/src/collision/meshCollider.cpp
@@ -83,7 +83,7 @@ namespace P64::Coll {
     fm_vec3_t worldNormal = localNormal;
     if(owner_) {
       worldNormal = worldNormal * vec3ReciprocalScaleComponents(owner_->scale);
-      if(hasRotation()) {
+      if(hasRotation_) {
         worldNormal = owner_->rot * worldNormal;
       }
     }
@@ -103,29 +103,28 @@ namespace P64::Coll {
   // ── MeshCollider transform ────────────────────────────────────────
 
   fm_vec3_t MeshCollider::toWorldSpace(const fm_vec3_t &localPoint) const {
-    fm_vec3_t position = owner_ ? owner_->pos : VEC3_ZERO;
-    fm_quat_t rotation = owner_ ? owner_->rot : QUAT_IDENTITY;
-    fm_vec3_t scale = owner_ ? owner_->scale : fm_vec3_t{{1.0f, 1.0f, 1.0f}};
-    fm_vec3_t scaled = localPoint * scale;
-    if(!quatIsIdentical(&rotation, &QUAT_IDENTITY)) {
-      scaled = rotation * scaled;
+    if(!owner_) return localPoint;
+    fm_vec3_t p = localPoint * owner_->scale;
+    if(hasRotation_) {
+      p = owner_->rot * p;
     }
-    if(fm_vec3_len2(&position) > FM_EPSILON * FM_EPSILON) {
-      scaled = scaled + position;
+    if(hasPosition_) {
+      p = p + owner_->pos;
     }
-    return scaled;
+    return p;
   }
 
   fm_vec3_t MeshCollider::toLocalSpace(const fm_vec3_t &worldPoint) const {
     fm_vec3_t p = worldPoint;
-    fm_vec3_t scale = owner_ ? owner_->scale : fm_vec3_t{{1.0f, 1.0f, 1.0f}};
-    if(hasPosition()) {
+    if(!owner_) return p;
+    if(hasPosition_) {
       p = p - owner_->pos;
     }
-    if(hasRotation()) {
+    if(hasRotation_) {
       p = quatConjugate(owner_->rot) * p;
     }
-    if(hasScale()) {
+    if(hasScale_) {
+      const fm_vec3_t &scale = owner_->scale;
       if(fabsf(scale.x) > FM_EPSILON) p.x /= scale.x;
       if(fabsf(scale.y) > FM_EPSILON) p.y /= scale.y;
       if(fabsf(scale.z) > FM_EPSILON) p.z /= scale.z;
@@ -135,41 +134,21 @@ namespace P64::Coll {
 
   fm_vec3_t MeshCollider::rotateToWorld(const fm_vec3_t &localDir) const {
     fm_vec3_t worldDirection = localDir;
-    if(hasScale() && owner_) 
+    if(hasScale_ && owner_)
       worldDirection = worldDirection * owner_->scale;
-    if(hasRotation()) 
+    if(hasRotation_)
       worldDirection = owner_->rot * worldDirection;
     return worldDirection;
   }
 
   fm_vec3_t MeshCollider::rotateToLocal(const fm_vec3_t &worldDir) const {
     fm_vec3_t localDirection = worldDir;
-    if(hasRotation()) 
+    if(hasRotation_)
       localDirection = quatConjugate(owner_->rot) * worldDir;
-    if (hasScale())
+    if(hasScale_)
       localDirection = localDirection * vec3ReciprocalScaleComponents(owner_->scale);
 
     return localDirection;
-  }
-
-  bool MeshCollider::hasTransform() const {
-    return (hasRotation() || hasPosition() || hasScale());
-  }
-
-  bool MeshCollider::hasRotation() const {
-    if(!owner_) return false;
-    return !quatIsIdentical(&owner_->rot, &QUAT_IDENTITY);
-  }
-
-  bool MeshCollider::hasPosition() const {
-    if(!owner_) return false;
-    fm_vec3_t ownerPhysicsPos = owner_->pos;
-    return fm_vec3_len2(&ownerPhysicsPos) > FM_EPSILON * FM_EPSILON;
-  }
-
-  bool MeshCollider::hasScale() const {
-    if(!owner_) return false;
-    return (fabsf(owner_->scale.x - 1.0f) > FM_EPSILON) || (fabsf(owner_->scale.y - 1.0f) > FM_EPSILON) || (fabsf(owner_->scale.z - 1.0f) > FM_EPSILON);
   }
 
   bool MeshCollider::readsCollider(const Collider *other) const {
@@ -202,6 +181,17 @@ namespace P64::Coll {
       lastOwnerRotation_ = owner_->rot;
       lastOwnerScale_ = owner_->scale;
     }
+
+    // Cached because they are used frequently in the hot loops. They only say
+    // whether a transform component is present, so lagging behind the owner potentially transforming by at most
+    // one physics step is harmless. Anything that needs the actual transform reads the owner.
+    hasRotation_ = owner_ && !quatIsIdentical(&lastOwnerRotation_, &QUAT_IDENTITY);
+    hasPosition_ = owner_ && fm_vec3_len2(&lastOwnerPosition_) > FM_EPSILON * FM_EPSILON;
+    hasScale_ = owner_ && ((fabsf(lastOwnerScale_.x - 1.0f) > FM_EPSILON) ||
+                           (fabsf(lastOwnerScale_.y - 1.0f) > FM_EPSILON) ||
+                           (fabsf(lastOwnerScale_.z - 1.0f) > FM_EPSILON));
+    hasTransform_ = hasRotation_ || hasPosition_ || hasScale_;
+
     inverseRotationMatrix_ = quatToMatrix3(quatConjugate(lastOwnerRotation_));
     hasCachedOwnerTransform_ = true;
     ++worldTransformVersion_;
@@ -227,49 +217,68 @@ namespace P64::Coll {
   }
 
   void MeshCollider::recalculateWorldAabb() {
-    // Transform all 8 corners of the local AABB to world space and take the enclosing AABB
-    fm_vec3_t corners[8] = {
-      fm_vec3_t{{localRootAabb_.min.x, localRootAabb_.min.y, localRootAabb_.min.z}},
-      fm_vec3_t{{localRootAabb_.max.x, localRootAabb_.min.y, localRootAabb_.min.z}},
-      fm_vec3_t{{localRootAabb_.min.x, localRootAabb_.max.y, localRootAabb_.min.z}},
-      fm_vec3_t{{localRootAabb_.max.x, localRootAabb_.max.y, localRootAabb_.min.z}},
-      fm_vec3_t{{localRootAabb_.min.x, localRootAabb_.min.y, localRootAabb_.max.z}},
-      fm_vec3_t{{localRootAabb_.max.x, localRootAabb_.min.y, localRootAabb_.max.z}},
-      fm_vec3_t{{localRootAabb_.min.x, localRootAabb_.max.y, localRootAabb_.max.z}},
-      fm_vec3_t{{localRootAabb_.max.x, localRootAabb_.max.y, localRootAabb_.max.z}},
-    };
+    // The AABB of an affine-transformed box:
+    // For M = R * diag(scale) this is the min/max over the 8 transformed corners
+    // (Ericson, Real-Time Collision Detection 4.2.6)
+    const fm_vec3_t localCenter = (localRootAabb_.min + localRootAabb_.max) * 0.5f;
+    const fm_vec3_t localHalf   = (localRootAabb_.max - localRootAabb_.min) * 0.5f;
 
-    fm_vec3_t worldMin = toWorldSpace(corners[0]);
-    fm_vec3_t worldMax = worldMin;
-    for(int i = 1; i < 8; ++i) {
-      fm_vec3_t w = toWorldSpace(corners[i]);
-      worldMin = vec3Min(worldMin, w);
-      worldMax = vec3Max(worldMax, w);
+    const fm_vec3_t worldCenter = toWorldSpace(localCenter);
+    const fm_vec3_t scale = owner_ ? owner_->scale : fm_vec3_t{{1.0f, 1.0f, 1.0f}};
+
+    fm_vec3_t worldHalf;
+    if(hasRotation_) {
+      const Matrix3x3 r = quatToMatrix3(owner_->rot);
+      worldHalf = fm_vec3_t{{
+        fabsf(r.m[0][0] * scale.x) * localHalf.x + fabsf(r.m[0][1] * scale.y) * localHalf.y + fabsf(r.m[0][2] * scale.z) * localHalf.z,
+        fabsf(r.m[1][0] * scale.x) * localHalf.x + fabsf(r.m[1][1] * scale.y) * localHalf.y + fabsf(r.m[1][2] * scale.z) * localHalf.z,
+        fabsf(r.m[2][0] * scale.x) * localHalf.x + fabsf(r.m[2][1] * scale.y) * localHalf.y + fabsf(r.m[2][2] * scale.z) * localHalf.z
+      }};
+    } else {
+      worldHalf = fm_vec3_t{{
+        fabsf(scale.x) * localHalf.x,
+        fabsf(scale.y) * localHalf.y,
+        fabsf(scale.z) * localHalf.z
+      }};
     }
-    worldAabb_ = {worldMin, worldMax};
+
+    worldAabb_ = {worldCenter - worldHalf, worldCenter + worldHalf};
   }
 
   AABB MeshCollider::worldAabbToLocal(const AABB &worldAabb) const {
-    // Transform all 8 corners of the world AABB into local space
-    fm_vec3_t corners[8] = {
-      fm_vec3_t{{worldAabb.min.x, worldAabb.min.y, worldAabb.min.z}},
-      fm_vec3_t{{worldAabb.max.x, worldAabb.min.y, worldAabb.min.z}},
-      fm_vec3_t{{worldAabb.min.x, worldAabb.max.y, worldAabb.min.z}},
-      fm_vec3_t{{worldAabb.max.x, worldAabb.max.y, worldAabb.min.z}},
-      fm_vec3_t{{worldAabb.min.x, worldAabb.min.y, worldAabb.max.z}},
-      fm_vec3_t{{worldAabb.max.x, worldAabb.min.y, worldAabb.max.z}},
-      fm_vec3_t{{worldAabb.min.x, worldAabb.max.y, worldAabb.max.z}},
-      fm_vec3_t{{worldAabb.max.x, worldAabb.max.y, worldAabb.max.z}},
-    };
+    // Same |M| construction as recalculateWorldAabb(), on the inverse map M^-1 = diag(1/scale) * R^T.
+    // Identical box to transforming all 8 corners through toLocalSpace().
+    const fm_vec3_t center = (worldAabb.min + worldAabb.max) * 0.5f;
+    const fm_vec3_t half   = (worldAabb.max - worldAabb.min) * 0.5f;
 
-    fm_vec3_t localMin = toLocalSpace(corners[0]);
-    fm_vec3_t localMax = localMin;
-    for(int i = 1; i < 8; ++i) {
-      fm_vec3_t l = toLocalSpace(corners[i]);
-      localMin = vec3Min(localMin, l);
-      localMax = vec3Max(localMax, l);
+    const fm_vec3_t localCenter = toLocalSpace(center);
+
+    // Degenerate axes stay at 1 so they pass through
+    fm_vec3_t invScale{{1.0f, 1.0f, 1.0f}};
+    if(hasScale_ && owner_) {
+      const fm_vec3_t &scale = owner_->scale;
+      if(fabsf(scale.x) > FM_EPSILON) invScale.x = 1.0f / scale.x;
+      if(fabsf(scale.y) > FM_EPSILON) invScale.y = 1.0f / scale.y;
+      if(fabsf(scale.z) > FM_EPSILON) invScale.z = 1.0f / scale.z;
     }
-    return {localMin, localMax};
+
+    fm_vec3_t localHalf;
+    if(hasRotation_) {
+      const Matrix3x3 ri = quatToMatrix3(quatConjugate(owner_->rot));
+      localHalf = fm_vec3_t{{
+        fabsf(invScale.x) * (fabsf(ri.m[0][0]) * half.x + fabsf(ri.m[0][1]) * half.y + fabsf(ri.m[0][2]) * half.z),
+        fabsf(invScale.y) * (fabsf(ri.m[1][0]) * half.x + fabsf(ri.m[1][1]) * half.y + fabsf(ri.m[1][2]) * half.z),
+        fabsf(invScale.z) * (fabsf(ri.m[2][0]) * half.x + fabsf(ri.m[2][1]) * half.y + fabsf(ri.m[2][2]) * half.z)
+      }};
+    } else {
+      localHalf = fm_vec3_t{{
+        fabsf(invScale.x) * half.x,
+        fabsf(invScale.y) * half.y,
+        fabsf(invScale.z) * half.z
+      }};
+    }
+
+    return {localCenter - localHalf, localCenter + localHalf};
   }
 
   // ── Load Mesh Collider from Raw Data and build AABB Tree ────────────────────────────────────────
@@ -353,6 +362,8 @@ namespace P64::Coll {
     }
 
     collider->computeLocalRootAabb();
+    // syncOwnerTransform() first because recalculateWorldAabb() depends on the cached has*() properties
+    collider->syncOwnerTransform();
     collider->recalculateWorldAabb();
   }
 

--- a/n64/engine/src/collision/rigidBody.cpp
+++ b/n64/engine/src/collision/rigidBody.cpp
@@ -56,14 +56,6 @@ namespace P64::Coll {
 
   // ── Matrix utilities ──────────────────────────────────────────────
 
-  fm_vec3_t matrix3Vec3Mul(const Matrix3x3 &mat, const fm_vec3_t &v) {
-    return fm_vec3_t{{
-      mat.m[0][0] * v.x + mat.m[0][1] * v.y + mat.m[0][2] * v.z,
-      mat.m[1][0] * v.x + mat.m[1][1] * v.y + mat.m[1][2] * v.z,
-      mat.m[2][0] * v.x + mat.m[2][1] * v.y + mat.m[2][2] * v.z
-    }};
-  }
-
   float matrix3Determinant(const Matrix3x3 &matrix) {
     return matrix.m[0][0] * (matrix.m[1][1] * matrix.m[2][2] - matrix.m[1][2] * matrix.m[2][1])
          - matrix.m[0][1] * (matrix.m[1][0] * matrix.m[2][2] - matrix.m[1][2] * matrix.m[2][0])
@@ -90,49 +82,7 @@ namespace P64::Coll {
     return inverse;
   }
 
-  Matrix3x3 matrix3Mul(const Matrix3x3 &a, const Matrix3x3 &b) {
-    Matrix3x3 r{};
-    for(int i = 0; i < 3; ++i) {
-      for(int j = 0; j < 3; ++j) {
-        r.m[i][j] = a.m[i][0] * b.m[0][j]
-                   + a.m[i][1] * b.m[1][j]
-                   + a.m[i][2] * b.m[2][j];
-      }
-    }
-    return r;
-  }
-
-  Matrix3x3 matrix3Transpose(const Matrix3x3 &m) {
-    Matrix3x3 r{};
-    for(int i = 0; i < 3; ++i) {
-      for(int j = 0; j < 3; ++j) {
-        r.m[i][j] = m.m[j][i];
-      }
-    }
-    return r;
-  }
-
-  Matrix3x3 quatToMatrix3(const fm_quat_t &q) {
-    float xx = q.x * q.x, yy = q.y * q.y, zz = q.z * q.z;
-    float xy = q.x * q.y, xz = q.x * q.z, yz = q.y * q.z;
-    float wx = q.w * q.x, wy = q.w * q.y, wz = q.w * q.z;
-
-    Matrix3x3 r{};
-    r.m[0][0] = 1.0f - 2.0f * (yy + zz);
-    r.m[0][1] = 2.0f * (xy - wz);
-    r.m[0][2] = 2.0f * (xz + wy);
-
-    r.m[1][0] = 2.0f * (xy + wz);
-    r.m[1][1] = 1.0f - 2.0f * (xx + zz);
-    r.m[1][2] = 2.0f * (yz - wx);
-
-    r.m[2][0] = 2.0f * (xz - wy);
-    r.m[2][1] = 2.0f * (yz + wx);
-    r.m[2][2] = 1.0f - 2.0f * (xx + yy);
-    return r;
-  }
-
-  // ── RigidBody ─────────────────────────────────────────────────
+        // ── RigidBody ─────────────────────────────────────────────────
 
   void RigidBody::init(P64::Object *object, float m) {
     assertf(m > 0.0f, "Mass must be greater than zero");
@@ -450,16 +400,34 @@ namespace P64::Coll {
   }
 
   void RigidBody::updateWorldInertia() {
-    Matrix3x3 newRotationMatrix = quatToMatrix3(rotation_);
-    Matrix3x3 newInverseRotationMatrix = quatToMatrix3(quatConjugate(rotation_));
+    // Called twice per body per step (once before integration, once when applying the results), 
+    // and the second call is usually a no-op
+    if(worldInertiaCacheValid_ &&
+       quatIsIdentical(&rotation_, &worldInertiaCacheRotation_) &&
+       position_ == worldInertiaCachePosition_ &&
+       invLocalInertiaTensor_ == worldInertiaCacheLocalInv_ &&
+       localCenterOfMass_ == worldInertiaCacheLocalCom_) {
+      return;
+    }
 
-    const Matrix3x3 localInv = diagonalMatrix(invLocalInertiaTensor_);
-    Matrix3x3 newInvWorldInertiaTensor = matrix3Mul(matrix3Mul(newRotationMatrix, localInv), matrix3Transpose(newRotationMatrix));
+    Matrix3x3 newRotationMatrix = quatToMatrix3(rotation_);
+    Matrix3x3 newInverseRotationMatrix = matrix3Transpose(newRotationMatrix);
+
+    const fm_vec3_t &d = invLocalInertiaTensor_;
+    Matrix3x3 newInvWorldInertiaTensor{};
+    for(int i = 0; i < 3; ++i) {
+      for(int j = i; j < 3; ++j) {
+        const float v = newRotationMatrix.m[i][0] * d.x * newRotationMatrix.m[j][0]
+                      + newRotationMatrix.m[i][1] * d.y * newRotationMatrix.m[j][1]
+                      + newRotationMatrix.m[i][2] * d.z * newRotationMatrix.m[j][2];
+        newInvWorldInertiaTensor.m[i][j] = v;
+        newInvWorldInertiaTensor.m[j][i] = v;
+      }
+    }
 
     const fm_vec3_t worldOffset = matrix3Vec3Mul(newRotationMatrix, localCenterOfMass_);
     const fm_vec3_t newWorldCenterOfMass = position_ + worldOffset;
     const bool transformChanged = !matrix3Equals(rotationMatrix_, newRotationMatrix) ||
-                    !matrix3Equals(inverseRotationMatrix_, newInverseRotationMatrix) ||
                     !matrix3Equals(invWorldInertiaTensor_, newInvWorldInertiaTensor) ||
                                   fm_vec3_distance2(&worldCenterOfMass_, &newWorldCenterOfMass) > FM_EPSILON * FM_EPSILON;
 
@@ -473,6 +441,12 @@ namespace P64::Coll {
     if(transformChanged) {
       ++transformVersion_;
     }
+
+    worldInertiaCacheRotation_ = rotation_;
+    worldInertiaCachePosition_ = position_;
+    worldInertiaCacheLocalInv_ = invLocalInertiaTensor_;
+    worldInertiaCacheLocalCom_ = localCenterOfMass_;
+    worldInertiaCacheValid_ = true;
   }
 
   fm_vec3_t RigidBody::toWorldSpace(const fm_vec3_t &localPoint) const {

--- a/n64/engine/src/collision/shapes.cpp
+++ b/n64/engine/src/collision/shapes.cpp
@@ -15,25 +15,21 @@ namespace {
 
 // ── Box ─────────────────────────────────────────────────────────────
 
+// boundingBox() callers that already hold the rotation matrix use the
+// matrix overload directly and skip rebuilding it.
+
 AABB BoxShape::boundingBox(const fm_quat_t *q) const {
-  float ex, ey, ez;
-
   if(!q) {
-    ex = halfSize.x; ey = halfSize.y; ez = halfSize.z;
-  } else {
-    float x = q->x, y = q->y, z = q->z, w = q->w;
-    float xx = x*x, yy = y*y, zz = z*z;
-    float xy = x*y, xz = x*z, yz = y*z;
-    float wx = w*x, wy = w*y, wz = w*z;
-
-    float r00 = 1 - 2*(yy+zz), r01 = 2*(xy-wz), r02 = 2*(xz+wy);
-    float r10 = 2*(xy+wz), r11 = 1 - 2*(xx+zz), r12 = 2*(yz-wx);
-    float r20 = 2*(xz-wy), r21 = 2*(yz+wx), r22 = 1 - 2*(xx+yy);
-
-    ex = halfSize.x*fabsf(r00) + halfSize.y*fabsf(r01) + halfSize.z*fabsf(r02);
-    ey = halfSize.x*fabsf(r10) + halfSize.y*fabsf(r11) + halfSize.z*fabsf(r12);
-    ez = halfSize.x*fabsf(r20) + halfSize.y*fabsf(r21) + halfSize.z*fabsf(r22);
+    return {fm_vec3_t{{-halfSize.x, -halfSize.y, -halfSize.z}},
+            fm_vec3_t{{ halfSize.x,  halfSize.y,  halfSize.z}}};
   }
+  return boundingBox(quatToMatrix3(*q));
+}
+
+AABB BoxShape::boundingBox(const Matrix3x3 &r) const {
+  const float ex = halfSize.x*fabsf(r.m[0][0]) + halfSize.y*fabsf(r.m[0][1]) + halfSize.z*fabsf(r.m[0][2]);
+  const float ey = halfSize.x*fabsf(r.m[1][0]) + halfSize.y*fabsf(r.m[1][1]) + halfSize.z*fabsf(r.m[1][2]);
+  const float ez = halfSize.x*fabsf(r.m[2][0]) + halfSize.y*fabsf(r.m[2][1]) + halfSize.z*fabsf(r.m[2][2]);
 
   return {fm_vec3_t{{-ex, -ey, -ez}}, fm_vec3_t{{ex, ey, ez}}};
 }
@@ -54,28 +50,21 @@ fm_vec3_t BoxShape::inertiaTensor(float mass) const {
 // ── Capsule ─────────────────────────────────────────────────────────
 
 AABB CapsuleShape::boundingBox(const fm_quat_t *q) const {
-  fm_vec3_t r{};
-
   if(!q) {
-    r = fm_vec3_t{{0.0f, innerHalfHeight, 0.0f}};
-  } else {
-    float x = q->x, y = q->y, z = q->z, w = q->w;
-    float xx = x*x, yy = y*y, zz = z*z;
-    float xy = x*y, xz = x*z, yz = y*z;
-    float wx = w*x, wy = w*y, wz = w*z;
-
-    float r01 = 2*(xy-wz);
-    float r11 = 1 - 2*(xx+zz);
-    float r21 = 2*(yz+wx);
-
-    r.x = r01 * innerHalfHeight;
-    r.y = r11 * innerHalfHeight;
-    r.z = r21 * innerHalfHeight;
+    const float absY = fabsf(innerHalfHeight);
+    return {
+      fm_vec3_t{{-radius, -absY - radius, -radius}},
+      fm_vec3_t{{ radius,  absY + radius,  radius}}
+    };
   }
+  return boundingBox(quatToMatrix3(*q));
+}
 
-  float absX = fabsf(r.x);
-  float absY = fabsf(r.y);
-  float absZ = fabsf(r.z);
+AABB CapsuleShape::boundingBox(const Matrix3x3 &r) const {
+  // Only the rotated local up axis matters, the caps are spherical
+  const float absX = fabsf(r.m[0][1] * innerHalfHeight);
+  const float absY = fabsf(r.m[1][1] * innerHalfHeight);
+  const float absZ = fabsf(r.m[2][1] * innerHalfHeight);
 
   return {
     fm_vec3_t{{-absX - radius, -absY - radius, -absZ - radius}},
@@ -140,30 +129,18 @@ fm_vec3_t CylinderShape::support(const fm_vec3_t &dir) const {
 }
 
 AABB CylinderShape::boundingBox(const fm_quat_t *q) const {
-  float ex = radius, ey = halfHeight, ez = radius;
-
   if(!q) {
-    return {fm_vec3_t{{-ex, -ey, -ez}}, fm_vec3_t{{ex, ey, ez}}};
+    return {fm_vec3_t{{-radius, -halfHeight, -radius}}, fm_vec3_t{{radius, halfHeight, radius}}};
   }
+  return boundingBox(quatToMatrix3(*q));
+}
 
-  float x = q->x, y = q->y, z = q->z, w = q->w;
-  float xx = x*x, yy = y*y, zz = z*z;
-  float xy = x*y, xz = x*z, yz = y*z;
-  float wx = w*x, wy = w*y, wz = w*z;
+AABB CylinderShape::boundingBox(const Matrix3x3 &r) const {
+  const float ex = radius, ey = halfHeight, ez = radius;
 
-  float r00 = 1.0f - 2.0f*(yy+zz);
-  float r01 =        2.0f*(xy-wz);
-  float r02 =        2.0f*(xz+wy);
-  float r10 =        2.0f*(xy+wz);
-  float r11 = 1.0f - 2.0f*(xx+zz);
-  float r12 =        2.0f*(yz-wx);
-  float r20 =        2.0f*(xz-wy);
-  float r21 =        2.0f*(yz+wx);
-  float r22 = 1.0f - 2.0f*(xx+yy);
-
-  float wxe = fabsf(r00)*ex + fabsf(r01)*ey + fabsf(r02)*ez;
-  float wye = fabsf(r10)*ex + fabsf(r11)*ey + fabsf(r12)*ez;
-  float wze = fabsf(r20)*ex + fabsf(r21)*ey + fabsf(r22)*ez;
+  const float wxe = fabsf(r.m[0][0])*ex + fabsf(r.m[0][1])*ey + fabsf(r.m[0][2])*ez;
+  const float wye = fabsf(r.m[1][0])*ex + fabsf(r.m[1][1])*ey + fabsf(r.m[1][2])*ez;
+  const float wze = fabsf(r.m[2][0])*ex + fabsf(r.m[2][1])*ey + fabsf(r.m[2][2])*ez;
 
   return {fm_vec3_t{{-wxe, -wye, -wze}}, fm_vec3_t{{wxe, wye, wze}}};
 }
@@ -208,21 +185,15 @@ AABB ConeShape::boundingBox(const fm_quat_t *q) const {
   if(!q) {
     return {fm_vec3_t{{-radius, -halfHeight, -radius}}, fm_vec3_t{{radius, halfHeight, radius}}};
   }
+  return boundingBox(quatToMatrix3(*q));
+}
 
-  float x = q->x, y = q->y, z = q->z, w = q->w;
-  float xx = x*x, yy = y*y, zz = z*z;
-  float xy = x*y, xz = x*z, yz = y*z;
-  float wx = w*x, wy = w*y, wz = w*z;
-
-  float r00 = 1 - 2*(yy+zz), r01 = 2*(xy-wz), r02 = 2*(xz+wy);
-  float r10 = 2*(xy+wz), r11 = 1 - 2*(xx+zz), r12 = 2*(yz-wx);
-  float r20 = 2*(xz-wy), r21 = 2*(yz+wx), r22 = 1 - 2*(xx+yy);
-
+AABB ConeShape::boundingBox(const Matrix3x3 &r) const {
   auto rotate = [&](float px, float py, float pz) -> fm_vec3_t {
     return fm_vec3_t{{
-      r00*px + r01*py + r02*pz,
-      r10*px + r11*py + r12*pz,
-      r20*px + r21*py + r22*pz
+      r.m[0][0]*px + r.m[0][1]*py + r.m[0][2]*pz,
+      r.m[1][0]*px + r.m[1][1]*py + r.m[1][2]*pz,
+      r.m[2][0]*px + r.m[2][1]*py + r.m[2][2]*pz
     }};
   };
 
@@ -273,24 +244,17 @@ fm_vec3_t PyramidShape::support(const fm_vec3_t &dir) const {
 }
 
 AABB PyramidShape::boundingBox(const fm_quat_t *q) const {
-  float ex, ey, ez;
-
   if(!q) {
-    ex = baseHalfWidthX; ey = halfHeight; ez = baseHalfWidthZ;
-  } else {
-    float x = q->x, y = q->y, z = q->z, w = q->w;
-    float xx = x*x, yy = y*y, zz = z*z;
-    float xy = x*y, xz = x*z, yz = y*z;
-    float wx = w*x, wy = w*y, wz = w*z;
-
-    float r00 = 1 - 2*(yy+zz), r01 = 2*(xy-wz), r02 = 2*(xz+wy);
-    float r10 = 2*(xy+wz), r11 = 1 - 2*(xx+zz), r12 = 2*(yz-wx);
-    float r20 = 2*(xz-wy), r21 = 2*(yz+wx), r22 = 1 - 2*(xx+yy);
-
-    ex = baseHalfWidthX*fabsf(r00) + halfHeight*fabsf(r01) + baseHalfWidthZ*fabsf(r02);
-    ey = baseHalfWidthX*fabsf(r10) + halfHeight*fabsf(r11) + baseHalfWidthZ*fabsf(r12);
-    ez = baseHalfWidthX*fabsf(r20) + halfHeight*fabsf(r21) + baseHalfWidthZ*fabsf(r22);
+    return {fm_vec3_t{{-baseHalfWidthX, -halfHeight, -baseHalfWidthZ}},
+            fm_vec3_t{{ baseHalfWidthX,  halfHeight,  baseHalfWidthZ}}};
   }
+  return boundingBox(quatToMatrix3(*q));
+}
+
+AABB PyramidShape::boundingBox(const Matrix3x3 &r) const {
+  const float ex = baseHalfWidthX*fabsf(r.m[0][0]) + halfHeight*fabsf(r.m[0][1]) + baseHalfWidthZ*fabsf(r.m[0][2]);
+  const float ey = baseHalfWidthX*fabsf(r.m[1][0]) + halfHeight*fabsf(r.m[1][1]) + baseHalfWidthZ*fabsf(r.m[1][2]);
+  const float ez = baseHalfWidthX*fabsf(r.m[2][0]) + halfHeight*fabsf(r.m[2][1]) + baseHalfWidthZ*fabsf(r.m[2][2]);
 
   return {fm_vec3_t{{-ex, -ey, -ez}}, fm_vec3_t{{ex, ey, ez}}};
 }

--- a/n64/examples/char_body/data/scenes/1/scene.json
+++ b/n64/examples/char_body/data/scenes/1/scene.json
@@ -115,6 +115,8 @@
               "near": 1.0,
               "orthoSize": 0.029999999329447746,
               "projection": 0,
+              "targetMode": 0,
+              "targetObjUUID": 0,
               "visMask": 255,
               "vpOffset": [
                 0,
@@ -305,7 +307,7 @@
           },
           {
             "data": {
-              "maskRead": 1,
+              "maskRead": 0,
               "maskWrite": 1,
               "meshFilter": "",
               "modelUUID": 5647511519455702462
@@ -386,7 +388,7 @@
           },
           {
             "data": {
-              "maskRead": 1,
+              "maskRead": 0,
               "maskWrite": 1,
               "meshFilter": "",
               "modelUUID": 4514132608101242667

--- a/n64/examples/jam25/data/scenes/1/scene.json
+++ b/n64/examples/jam25/data/scenes/1/scene.json
@@ -408,7 +408,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 9,
               "meshFilter": "",
               "modelUUID": 67300967874118795
             },
@@ -600,7 +600,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 9,
               "meshFilter": "",
               "modelUUID": 14061694646240479583
             },
@@ -1271,7 +1271,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 9,
                   "meshFilter": "",
                   "modelUUID": 14061694646240479583
                 },
@@ -1630,7 +1630,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 9,
               "meshFilter": "",
               "modelUUID": 14061694646240479583
             },
@@ -2661,7 +2661,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 9,
               "meshFilter": "",
               "modelUUID": 14061694646240479583
             },

--- a/n64/examples/jam25/data/scenes/4/scene.json
+++ b/n64/examples/jam25/data/scenes/4/scene.json
@@ -534,7 +534,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 9,
                   "meshFilter": "",
                   "modelUUID": 6985508143550202785
                 },
@@ -763,7 +763,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 9,
                   "meshFilter": "",
                   "modelUUID": 15813250936274457379
                 },
@@ -795,9 +795,9 @@
             "enabled": true,
             "name": "Planet",
             "pos": [
-              0.6392070055007935,
-              -5.139157772064209,
-              -3.270711660385132
+              0.6000000238418579,
+              -5.099999904632568,
+              -3.299999952316284
             ],
             "propOverrides": {},
             "proportionalScale": false,
@@ -936,7 +936,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 9,
               "meshFilter": "",
               "modelUUID": 18042696417486669443
             },
@@ -1053,8 +1053,8 @@
           },
           {
             "data": {
-              "maskRead": 255,
-              "maskWrite": 255,
+              "maskRead": 240,
+              "maskWrite": 249,
               "meshFilter": "",
               "modelUUID": 18042696417486669443
             },
@@ -1087,8 +1087,8 @@
         "name": "platform",
         "pos": [
           -1.5,
-          4.699999809265137,
-          12.394628524780273
+          4.700000286102295,
+          12.40000057220459
         ],
         "propOverrides": {},
         "proportionalScale": false,
@@ -1154,7 +1154,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 9,
               "meshFilter": "",
               "modelUUID": 18042696417486669443
             },
@@ -1254,7 +1254,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 9,
               "meshFilter": "",
               "modelUUID": 18042696417486669443
             },

--- a/n64/examples/jam25/data/scenes/6/scene.json
+++ b/n64/examples/jam25/data/scenes/6/scene.json
@@ -299,8 +299,8 @@
           },
           {
             "data": {
-              "maskRead": 255,
-              "maskWrite": 255,
+              "maskRead": 240,
+              "maskWrite": 241,
               "meshFilter": "",
               "modelUUID": 1397703482184716120
             },

--- a/n64/examples/jam25/data/scenes/7/scene.json
+++ b/n64/examples/jam25/data/scenes/7/scene.json
@@ -486,7 +486,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 1,
               "meshFilter": "",
               "modelUUID": 9875025468559567941
             },
@@ -1881,7 +1881,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "coll",
                   "modelUUID": 244801699526709921
                 },
@@ -2135,7 +2135,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "block01_coll",
                   "modelUUID": 2790078963282814027
                 },
@@ -2392,7 +2392,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "block01_coll",
                   "modelUUID": 2790078963282814027
                 },
@@ -2729,7 +2729,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "iso00",
                   "modelUUID": 2790078963282814027
                 },
@@ -3388,7 +3388,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "block00_coll",
                   "modelUUID": 2790078963282814027
                 },

--- a/n64/examples/jam25/data/scenes/8/scene.json
+++ b/n64/examples/jam25/data/scenes/8/scene.json
@@ -345,10 +345,10 @@
                   0.0
                 ],
                 "setDepth": false,
-                "setEnv": true,
+                "setEnv": false,
                 "setFresnel": false,
                 "setLighting": false,
-                "setPrim": true
+                "setPrim": false
               },
               "meshFilter": "",
               "model": 2076335883273801836
@@ -361,7 +361,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 1,
               "meshFilter": "",
               "modelUUID": 2076335883273801836
             },
@@ -444,7 +444,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "block00",
                   "modelUUID": 13215419027432979116
                 },
@@ -577,7 +577,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "block01",
                   "modelUUID": 13215419027432979116
                 },
@@ -677,7 +677,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "block02",
                   "modelUUID": 13215419027432979116
                 },
@@ -777,7 +777,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "block00",
                   "modelUUID": 13215419027432979116
                 },
@@ -942,7 +942,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "block01",
                   "modelUUID": 13215419027432979116
                 },
@@ -1190,7 +1190,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "block01",
                   "modelUUID": 13215419027432979116
                 },
@@ -1438,7 +1438,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "block01",
                   "modelUUID": 13215419027432979116
                 },
@@ -2203,8 +2203,8 @@
               },
               {
                 "data": {
-                  "maskRead": 1,
-                  "maskWrite": 8,
+                  "maskRead": 0,
+                  "maskWrite": 1,
                   "meshFilter": "seesaw",
                   "modelUUID": 13215419027432979116
                 },
@@ -2533,7 +2533,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "blockRot00",
                   "modelUUID": 13215419027432979116
                 },
@@ -2895,7 +2895,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 1,
               "meshFilter": "block01",
               "modelUUID": 13215419027432979116
             },
@@ -3791,7 +3791,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 1,
               "meshFilter": "blockRot00",
               "modelUUID": 13215419027432979116
             },
@@ -3906,7 +3906,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "center",
                   "modelUUID": 13215419027432979116
                 },
@@ -4223,7 +4223,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 1,
               "meshFilter": "blockRot00",
               "modelUUID": 13215419027432979116
             },
@@ -4370,7 +4370,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 1,
               "meshFilter": "",
               "modelUUID": 14061694646240479583
             },
@@ -4538,7 +4538,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 1,
               "meshFilter": "",
               "modelUUID": 14061694646240479583
             },
@@ -4896,7 +4896,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 1,
               "meshFilter": "blockRot01",
               "modelUUID": 13215419027432979116
             },
@@ -5199,7 +5199,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 1,
               "meshFilter": "blockRot00",
               "modelUUID": 13215419027432979116
             },
@@ -5314,7 +5314,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "",
                   "modelUUID": 14061694646240479583
                 },
@@ -5429,7 +5429,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "",
                   "modelUUID": 14061694646240479583
                 },
@@ -5769,7 +5769,7 @@
               {
                 "data": {
                   "maskRead": 0,
-                  "maskWrite": 8,
+                  "maskWrite": 1,
                   "meshFilter": "blockRot00",
                   "modelUUID": 13215419027432979116
                 },
@@ -5980,7 +5980,7 @@
           {
             "data": {
               "maskRead": 0,
-              "maskWrite": 8,
+              "maskWrite": 1,
               "meshFilter": "",
               "modelUUID": 14061694646240479583
             },

--- a/n64/examples/jam25/data/scenes/9/scene.json
+++ b/n64/examples/jam25/data/scenes/9/scene.json
@@ -242,8 +242,8 @@
           },
           {
             "data": {
-              "maskRead": 255,
-              "maskWrite": 255,
+              "maskRead": 240,
+              "maskWrite": 241,
               "meshFilter": "",
               "modelUUID": 6985508143550202785
             },
@@ -424,8 +424,8 @@
           },
           {
             "data": {
-              "maskRead": 255,
-              "maskWrite": 255,
+              "maskRead": 240,
+              "maskWrite": 241,
               "meshFilter": "",
               "modelUUID": 15813250936274457379
             },


### PR DESCRIPTION
- move matrix math to header
- inline small hot functions 
- discard mesh collision before querying the tree
- cache mesh collider transform properties 
- add bounding box overload for matrix to save quat conversion 
- reorder tree query so overlap test comes before stack push 
- cache inertia inputs on RBs to early out in repeated update
- optimize moving of nodes in the BVH a bit
- change metric that fattens bounds of moving nodes to reduce expensive moves
