### PR TITLE
chg: Build time Mesh Collider BVHs

### DIFF
--- a/docs/docs/version/breakingChanges.md
+++ b/docs/docs/version/breakingChanges.md
@@ -208,6 +208,17 @@ The fix here is to set the masks accordingly.<br>
 
 Note that it is strongly recommended to only use the mask bits you actually need per collider to avoid unnecessary collision tests.
 
+### Mesh Collision Assets
+
+Mesh Collision BVHs are now statically built during ROM build instead of dynamically during Scene load. This change reduces memory usage a little and marginally improves performance and scene loading speed (depending on the usage of mesh colliders).<br>
+This means that projects using mesh colliders need to be rebuilt so the assets contain the necessary information.
+
+Collision assets also store normals as three floats. Mesh colliders now share the asset's vertices, triangle indices,
+normals and BVH instead of allocating geometry copies for each instance.<br>
+Assets using packed normals must be rebuilt.
+Manually created mesh colliders still take ownership of their supplied arrays and generate their own normals and BVH;
+`destroyData()` frees owned data and only detaches borrowed asset data.
+
 ## v0.7.0
 
 This version completely reworked the material system as well as the collision/physics system.<br>

--- a/n64/engine/include/collision/meshBvh.h
+++ b/n64/engine/include/collision/meshBvh.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <cstdint>
+
+namespace P64::Coll {
+
+  // Collision asset layout, shared with the editor. Offsets are relative to the header;
+  // all fields and BVH nodes are written big-endian. After the header come triangle
+  // indices (3 x uint16_t), normals (3 x float), vertices (3 x float), then BVH nodes.
+  // Each array after the indices starts at a 4-byte boundary. Runtime colliders borrow
+  // these immutable arrays directly from the loaded asset.
+  struct RawCollisionHeader {
+    uint32_t triCount;
+    uint32_t vertCount;
+    float collScale;
+    uint32_t bvhOffset;
+  };
+  static_assert(sizeof(RawCollisionHeader) == 16);
+
+  // Preorder binary tree with exact float bounds. Internal nodes store the number
+  // of nodes in their subtree, so a miss skips it without a traversal stack.
+  // Leaves store the original triangle index; geometry never needs reordering.
+  struct MeshBvhNode {
+    float min[3];
+    float max[3];
+    uint32_t escapeOrTriangle;
+
+    static constexpr uint32_t LEAF = 0x80000000u;
+    bool isLeaf() const { return (escapeOrTriangle & LEAF) != 0; }
+    uint16_t triangleIndex() const { return static_cast<uint16_t>(escapeOrTriangle); }
+  };
+  static_assert(sizeof(MeshBvhNode) == 28);
+
+  constexpr uint32_t meshBvhNodeCount(uint16_t triangleCount) {
+    return triangleCount ? uint32_t(triangleCount) * 2 - 1 : 0;
+  }
+
+  template<typename Intersects>
+  int queryMeshBvh(const MeshBvhNode *nodes, uint32_t nodeCount,
+    uint16_t *results, int maxResults, Intersects intersects)
+  {
+    if(!nodes || !results || maxResults <= 0) return 0;
+    int count = 0;
+    for(uint32_t i = 0; i < nodeCount && count < maxResults;) {
+      const auto &node = nodes[i];
+      if(!intersects(node)) {
+        i += node.isLeaf() ? 1 : node.escapeOrTriangle;
+      } else {
+        if(node.isLeaf()) results[count++] = node.triangleIndex();
+        ++i;
+      }
+    }
+    return count;
+  }
+
+}

--- a/n64/engine/include/collision/meshBvhBuilder.h
+++ b/n64/engine/include/collision/meshBvhBuilder.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "meshBvh.h"
+#include <algorithm>
+#include <memory>
+#include <numeric>
+
+namespace P64::Coll {
+
+  // Used by the Editor during build and by manually created runtime meshes only.
+  // Median splits along the widest centroid axis guarantee logarithmic depth.
+  // triangleBounds(index) returns a MeshBvhNode with its min/max initialized.
+  template<typename TriangleBounds>
+  std::unique_ptr<MeshBvhNode[]> buildMeshBvh(uint16_t triangleCount, TriangleBounds triangleBounds) {
+    if(!triangleCount) return {};
+    auto nodes = std::make_unique<MeshBvhNode[]>(meshBvhNodeCount(triangleCount));
+    auto indices = std::make_unique<uint16_t[]>(triangleCount);
+    std::iota(indices.get(), indices.get() + triangleCount, uint16_t{0});
+
+    auto build = [&](auto &&self, uint32_t nodeIndex, uint32_t begin, uint32_t end) -> void {
+      auto &node = nodes[nodeIndex];
+      node = triangleBounds(indices[begin]);
+      float centroidMin[3], centroidMax[3];
+      for(int axis = 0; axis < 3; ++axis) {
+        centroidMin[axis] = centroidMax[axis] = node.min[axis] * 0.5f + node.max[axis] * 0.5f;
+      }
+      for(uint32_t i = begin + 1; i < end; ++i) {
+        const auto bounds = triangleBounds(indices[i]);
+        for(int axis = 0; axis < 3; ++axis) {
+          node.min[axis] = std::min(node.min[axis], bounds.min[axis]);
+          node.max[axis] = std::max(node.max[axis], bounds.max[axis]);
+          const float centroid = bounds.min[axis] * 0.5f + bounds.max[axis] * 0.5f;
+          centroidMin[axis] = std::min(centroidMin[axis], centroid);
+          centroidMax[axis] = std::max(centroidMax[axis], centroid);
+        }
+      }
+      if(end - begin == 1) {
+        node.escapeOrTriangle = MeshBvhNode::LEAF | indices[begin];
+        return;
+      }
+      int axis = 0;
+      for(int a = 1; a < 3; ++a) {
+        if(centroidMax[a] - centroidMin[a] > centroidMax[axis] - centroidMin[axis]) axis = a;
+      }
+      const uint32_t middle = begin + (end - begin) / 2;
+      std::nth_element(indices.get() + begin, indices.get() + middle, indices.get() + end,
+        [&](uint16_t a, uint16_t b) {
+          const auto boundsA = triangleBounds(a);
+          const auto boundsB = triangleBounds(b);
+          const float ca = boundsA.min[axis] * 0.5f + boundsA.max[axis] * 0.5f;
+          const float cb = boundsB.min[axis] * 0.5f + boundsB.max[axis] * 0.5f;
+          return ca != cb ? ca < cb : a < b;
+        });
+      node.escapeOrTriangle = (end - begin) * 2 - 1;
+      self(self, nodeIndex + 1, begin, middle);
+      self(self, nodeIndex + (middle - begin) * 2, middle, end);
+    };
+    build(build, 0, 0, triangleCount);
+    return nodes;
+  }
+
+}

--- a/n64/engine/include/collision/meshCollider.h
+++ b/n64/engine/include/collision/meshCollider.h
@@ -8,7 +8,9 @@
 #include "vecMath.h"
 #include "matrix3x3.h"
 #include "aabbTree.h"
+#include "meshBvh.h"
 #include <cstdint>
+#include <memory>
 
 namespace P64 { class Object; }
 
@@ -65,12 +67,9 @@ namespace P64::Coll {
     const fm_vec3_t &vertex(uint16_t index) const { return vertices_[index]; }
     const MeshTriangleIndices &triangleIndices(uint16_t index) const { return triangles_[index]; }
     const fm_vec3_t &triangleNormal(uint16_t index) const { return normals_[index]; }
-    int queryTriangleNodes(const AABB &localBounds, NodeProxy *outCandidates, int maxCandidates) const { return aabbTree_.queryBounds(localBounds, outCandidates, maxCandidates); }
-    int queryTriangleNodes(const Raycast &localRay, NodeProxy *outCandidates, int maxCandidates) const { return aabbTree_.queryRay(localRay, outCandidates, maxCandidates); }
-    int triangleIndexForNode(NodeProxy node) const {
-      void *data = aabbTree_.getNodeData(node);
-      return data ? static_cast<int>(reinterpret_cast<intptr_t>(data)) - 1 : -1;
-    }
+    /// Query the static local-space BVH, returning triangle indices directly.
+    int queryTriangles(const AABB &localBounds, uint16_t *outCandidates, int maxCandidates) const;
+    int queryTriangles(const Raycast &localRay, uint16_t *outCandidates, int maxCandidates) const;
 
     const AABB &localRootAabb() const { return localRootAabb_; }
     const AABB &worldAabb() const { return worldAabb_; }
@@ -116,13 +115,14 @@ namespace P64::Coll {
     bool readsMeshCollider(const MeshCollider *other) const;
 
     /// Create a MeshCollider directly from collision asset raw data, binding to the given Object's transform.
-    /// The returned collider owns newly allocated arrays (vertices, triangles, normals).
-    /// Call destroyData() to free them.
-    static MeshCollider *createFromRawData(void *rawData, Object *obj);
+    /// Borrows immutable vertices, triangles, float normals and BVH from the asset.
+    /// rawData must outlive the collider (as scene assets do).
+    static MeshCollider *createFromRawData(const void *rawData, Object *obj);
 
     /// Create a MeshCollider from manually defined geometry. If a non-null owner Object is given, the
     /// MeshCollider's transform will be synced to that of the owner.
     /// Coordinates must use internal physics scale (i.e. 1 unit = 1 meter).
+    /// Builds the immutable triangle BVH once; geometry must not change afterwards.
     /// Ownership of the given arrays (vertices, triangleIndices) is transferred to the returned MeshCollider
     /// object; call destroyData() to free them.
     static MeshCollider* create(fm_vec3_t* vertices, uint16_t vertexCount, MeshTriangleIndices* triangleIndices, uint16_t triangleCount, Object *owner = nullptr);
@@ -136,17 +136,17 @@ namespace P64::Coll {
       return vec3NormalizeOrFallback(normal, VEC3_UP);
     }
 
-    /// Free owned vertex/triangle/normal arrays and destroy the AABB tree.
+    /// Free owned geometry and BVH for manually defined geometry; detach borrowed asset data.
     void destroyData();
 
   private:
     friend class CollisionScene;
 
-    AABBTree aabbTree_{};
-    static void buildAabbTree(MeshCollider* collider);
-    fm_vec3_t *vertices_{nullptr};
-    MeshTriangleIndices *triangles_{nullptr};
-    fm_vec3_t *normals_{nullptr};
+    const MeshBvhNode *triangleBvh_{nullptr};
+    std::unique_ptr<MeshBvhNode[]> ownedTriangleBvh_{};
+    const fm_vec3_t *vertices_{nullptr};
+    const MeshTriangleIndices *triangles_{nullptr};
+    const fm_vec3_t *normals_{nullptr};
     P64::Object *owner_{nullptr};
     AABB localRootAabb_{};
     AABB worldAabb_{};
@@ -168,6 +168,7 @@ namespace P64::Coll {
     bool hasPosition_{false};
     bool hasScale_{false};
     bool hasTransform_{false};
+    bool ownsGeometry_{false};
   };
 
 } // namespace P64::Coll

--- a/n64/engine/src/collision/capsuleSweep.cpp
+++ b/n64/engine/src/collision/capsuleSweep.cpp
@@ -3,8 +3,6 @@
 * @license MIT
 */
 #include "collision/capsuleSweep.h"
-#include "collision/meshCollider.h"
-#include "collision/aabb.h"
 #include "collision/vecMath.h"
 
 #include <cmath>
@@ -75,55 +73,6 @@ static float sphereFaceTest(
   return t;
 }
 
-static float sphereEdgeTest(
-  const fm_vec3_t& S, float r, const fm_vec3_t& dir, float t_max,
-  const fm_vec3_t& E0, const fm_vec3_t& E1,
-  fm_vec3_t& outN, fm_vec3_t& outP, float& outDepth
-) {
-  fm_vec3_t edge   = E1 - E0;
-  float     elen2  = fm_vec3_len2(&edge);
-  if (elen2 < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
-  float     elen   = sqrtf(elen2);
-  fm_vec3_t u_hat  = edge / elen;
-
-  fm_vec3_t ce     = S - E0;
-  float     ce_u   = fm_vec3_dot(&ce, &u_hat);
-  fm_vec3_t c0     = ce - u_hat * ce_u;          // perp component of (S-E0)
-  float     d_u    = fm_vec3_dot(&dir, &u_hat);
-  fm_vec3_t d_perp = dir - u_hat * d_u;          // perp component of dir
-
-  float c0len2 = fm_vec3_len2(&c0);
-  float c_val  = c0len2 - r * r;
-  float a      = fm_vec3_len2(&d_perp);
-  float b      = fm_vec3_dot(&d_perp, &c0);
-
-  float t;
-  if (c_val < 0.0f) {
-    // already within r of the infinite edge line
-    float proj = ce_u;
-    if (proj < 0.0f || proj > elen) return std::numeric_limits<float>::max();
-    t        = 0.0f;
-    outDepth = r - sqrtf(c0len2);
-  } else {
-    if (a < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
-    float disc = b * b - a * c_val;
-    if (disc < 0.0f) return std::numeric_limits<float>::max();
-    t = (-b - sqrtf(disc)) / a;
-    if (t < 0.0f) return std::numeric_limits<float>::max();
-    if (t > t_max) return std::numeric_limits<float>::max();
-    outDepth = 0.0f;
-  }
-
-  fm_vec3_t C_t = S + dir * t;
-  fm_vec3_t C_t_rel = C_t - E0;
-  float proj = fm_vec3_dot(&C_t_rel, &u_hat);
-  if (proj < 0.0f || proj > elen) return std::numeric_limits<float>::max();
-
-  outP = E0 + u_hat * proj;
-  outN = vec3NormalizeOrFallback(C_t - outP, -dir);
-  return t;
-}
-
 static float sphereVertexTest(
   const fm_vec3_t& S, float r, const fm_vec3_t& dir, float t_max,
   const fm_vec3_t& V,
@@ -156,114 +105,6 @@ static float sphereVertexTest(
 // These only fire when the contact is strictly interior to the capsule segment
 // (not at either end cap), so they do not overlap with the sphere tests.
 
-static float cylinderEdgeTest(
-  const fm_vec3_t& P1, const fm_vec3_t& P2, float r,
-  const fm_vec3_t& dir, float t_max,
-  const fm_vec3_t& E0, const fm_vec3_t& E1,
-  fm_vec3_t& outN, fm_vec3_t& outP, float& outDepth
-) {
-  fm_vec3_t d1 = P2 - P1; // capsule axis
-  fm_vec3_t d2 = E1 - E0; // triangle edge
-
-  float a     = fm_vec3_len2(&d1);
-  float e_val = fm_vec3_len2(&d2);
-  float b     = fm_vec3_dot(&d1, &d2);
-  float denom = a * e_val - b * b;
-
-  if (denom < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
-
-  fm_vec3_t n_cross;
-  fm_vec3_cross(&n_cross, &d1, &d2);
-  float n_len = sqrtf(denom);
-  fm_vec3_t n_hat = n_cross / n_len;
-
-  fm_vec3_t r0    = P1 - E0;
-  float r0_dot    = fm_vec3_dot(&r0, &n_hat);
-  float vel_dot   = fm_vec3_dot(&dir, &n_hat); // dir is unit length
-
-  // Helper: verify both segment parameters are interior at a given t
-  auto resolve = [&](float t_phys) -> bool {
-    fm_vec3_t r0_t  = r0 + dir * t_phys;
-    float c_t       = fm_vec3_dot(&d1, &r0_t);
-    float f_t       = fm_vec3_dot(&d2, &r0_t);
-    float s_star    = (b * f_t - c_t * e_val) / denom; // [0,1] for interior
-    float u_star    = (a * f_t - b * c_t) / denom;      // [0,1] for interior
-    if (s_star <= PARAM_EPS || s_star >= 1.0f - PARAM_EPS) return false;
-    if (u_star < 0.0f || u_star > 1.0f) return false;
-    outP = E0 + d2 * u_star;
-    outN = (r0_dot >= 0.0f) ? n_hat : -n_hat;
-    return true;
-  };
-
-  if (fabsf(r0_dot) < r) {
-    if (!resolve(0.0f)) return std::numeric_limits<float>::max();
-    outDepth = r - fabsf(r0_dot);
-    return 0.0f;
-  }
-
-  if (fabsf(vel_dot) < SWEEP_EPS) return std::numeric_limits<float>::max();
-
-  float sign  = (r0_dot > 0.0f) ? 1.0f : -1.0f;
-  float t     = (sign * r - r0_dot) / vel_dot;
-  if (t < 0.0f || t > t_max) return std::numeric_limits<float>::max();
-  if (!resolve(t)) return std::numeric_limits<float>::max();
-  outDepth = 0.0f;
-  return t;
-}
-
-static float cylinderVertexTest(
-  const fm_vec3_t& P1, const fm_vec3_t& P2, float r,
-  const fm_vec3_t& dir, float t_max,
-  const fm_vec3_t& V,
-  fm_vec3_t& outN, fm_vec3_t& outP, float& outDepth
-) {
-  fm_vec3_t d1    = P2 - P1;
-  float d1_len2   = fm_vec3_len2(&d1);
-  if (d1_len2 < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
-  float d1_len    = sqrtf(d1_len2);
-  fm_vec3_t d1hat = d1 / d1_len;
-
-  // Decompose relative to capsule axis
-  fm_vec3_t w        = V - P1; // from P1 to vertex
-  float w_along      = fm_vec3_dot(&w, &d1hat);
-  fm_vec3_t w_perp   = w - d1hat * w_along;
-
-  float dir_along    = fm_vec3_dot(&dir, &d1hat);
-  fm_vec3_t dir_perp = dir - d1hat * dir_along;
-
-  float A      = fm_vec3_len2(&dir_perp);
-  float wperp2 = fm_vec3_len2(&w_perp);
-
-  float t;
-  if (wperp2 < r * r) {
-    // already within r of the capsule axis line
-    t = 0.0f;
-    outDepth = r - sqrtf(wperp2);
-  } else {
-    if (A < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
-    // dist_perp²(t) = |w_perp - t*dir_perp|²
-    float B    = fm_vec3_dot(&w_perp, &dir_perp);
-    float C    = wperp2 - r * r;
-    float disc = B * B - A * C;
-    if (disc < 0.0f) return std::numeric_limits<float>::max();
-    t = (B - sqrtf(disc)) / A; // smallest root
-    if (t < 0.0f) t = (B + sqrtf(disc)) / A;
-    if (t < 0.0f || t > t_max) return std::numeric_limits<float>::max();
-    outDepth = 0.0f;
-  }
-
-  // Verify s is strictly interior (not at end caps)
-  fm_vec3_t w_t = w - dir * t; // V - P1(t)
-  float s       = fm_vec3_dot(&w_t, &d1hat);
-  if (s <= PARAM_EPS || s >= d1_len - PARAM_EPS)
-    return std::numeric_limits<float>::max();
-
-  fm_vec3_t axis_pt = P1 + dir * t + d1hat * s;
-  outP = V;
-  outN = vec3NormalizeOrFallback(axis_pt - V, -dir);
-  return t;
-}
-
 // ── Public: capsule vs. one triangle ─────────────────────────────────────────
 
 bool capsuleSweepTriangle(
@@ -276,12 +117,23 @@ bool capsuleSweepTriangle(
   const fm_vec3_t& triNormal,
   CapsuleSweepHit& hit
 ) {
-  float dist = sqrtf(fm_vec3_len2(&displacement));
+  const float dist = sqrtf(fm_vec3_len2(&displacement));
   if (dist < SWEEP_EPS) return false;
-  fm_vec3_t dir = displacement / dist;
+  const fm_vec3_t dir = displacement / dist;
+  const fm_vec3_t P1 = center - axisUp * innerHalfHeight;
+  const fm_vec3_t P2 = center + axisUp * innerHalfHeight;
 
-  fm_vec3_t P1 = center - axisUp * innerHalfHeight;
-  fm_vec3_t P2 = center + axisUp * innerHalfHeight;
+  // Reuse the capsule-axis projections across all cylinder sub-tests.
+  const fm_vec3_t axis = P2 - P1;
+  const float axisLength2 = fm_vec3_len2(&axis);
+  float axisLength = 0.0f, dirPerpLength2 = 0.0f;
+  fm_vec3_t axisUnit{}, dirPerp{};
+  if (axisLength2 >= SWEEP_EPS * SWEEP_EPS) {
+    axisLength = sqrtf(axisLength2);
+    axisUnit = axis / axisLength;
+    dirPerp = dir - axisUnit * fm_vec3_dot(&dir, &axisUnit);
+    dirPerpLength2 = fm_vec3_len2(&dirPerp);
+  }
 
   float     bestT     = std::numeric_limits<float>::max();
   float     bestDepth = 0.0f;
@@ -302,12 +154,161 @@ bool capsuleSweepTriangle(
   fm_vec3_t n{}, p{};
   float depth = 0.0f;
 
+  // Both sphere caps use the same triangle-edge projections.
+  fm_vec3_t edgeUnits[3]{}, edgeDirPerps[3]{};
+  float edgeLengths[3]{}, edgeDirPerpLength2[3]{};
+  for (int i = 0; i < 3; ++i) {
+    const fm_vec3_t edge = *verts[(i + 1) % 3] - *verts[i];
+    const float length2 = fm_vec3_len2(&edge);
+    if (length2 < SWEEP_EPS * SWEEP_EPS) continue;
+    edgeLengths[i] = sqrtf(length2);
+    edgeUnits[i] = edge / edgeLengths[i];
+    edgeDirPerps[i] = dir - edgeUnits[i] * fm_vec3_dot(&dir, &edgeUnits[i]);
+    edgeDirPerpLength2[i] = fm_vec3_len2(&edgeDirPerps[i]);
+  }
+
+  auto sphereEdgeTest = [&](const fm_vec3_t &S, int i,
+    fm_vec3_t &outN, fm_vec3_t &outP, float &outDepth) -> float {
+    const fm_vec3_t &E0 = *verts[i];
+    if (edgeLengths[i] == 0.0f) return std::numeric_limits<float>::max();
+    float     elen   = edgeLengths[i];
+    const fm_vec3_t &u_hat = edgeUnits[i];
+
+    fm_vec3_t ce     = S - E0;
+    float     ce_u   = fm_vec3_dot(&ce, &u_hat);
+    fm_vec3_t c0     = ce - u_hat * ce_u;          // perp component of (S-E0)
+    const fm_vec3_t &d_perp = edgeDirPerps[i];
+
+    float c0len2 = fm_vec3_len2(&c0);
+    float c_val  = c0len2 - radius * radius;
+    float a      = edgeDirPerpLength2[i];
+    float b      = fm_vec3_dot(&d_perp, &c0);
+
+    float t;
+    if (c_val < 0.0f) {
+      // already within radius of the infinite edge line
+      float proj = ce_u;
+      if (proj < 0.0f || proj > elen) return std::numeric_limits<float>::max();
+      t        = 0.0f;
+      outDepth = radius - sqrtf(c0len2);
+    } else {
+      if (a < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
+      float disc = b * b - a * c_val;
+      if (disc < 0.0f) return std::numeric_limits<float>::max();
+      t = (-b - sqrtf(disc)) / a;
+      if (t < 0.0f) return std::numeric_limits<float>::max();
+      if (t > dist) return std::numeric_limits<float>::max();
+      outDepth = 0.0f;
+    }
+
+    fm_vec3_t C_t = S + dir * t;
+    fm_vec3_t C_t_rel = C_t - E0;
+    float proj = fm_vec3_dot(&C_t_rel, &u_hat);
+    if (proj < 0.0f || proj > elen) return std::numeric_limits<float>::max();
+
+    outP = E0 + u_hat * proj;
+    outN = vec3NormalizeOrFallback(C_t - outP, -dir);
+    return t;
+  };
+
+  auto cylinderEdgeTest = [&](const fm_vec3_t &E0, const fm_vec3_t &E1,
+    fm_vec3_t &outN, fm_vec3_t &outP, float &outDepth) -> float {
+    fm_vec3_t d2 = E1 - E0; // triangle edge
+
+    float a     = axisLength2;
+    float e_val = fm_vec3_len2(&d2);
+    float b     = fm_vec3_dot(&axis, &d2);
+    float denom = a * e_val - b * b;
+
+    if (denom < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
+
+    fm_vec3_t n_cross;
+    fm_vec3_cross(&n_cross, &axis, &d2);
+    float n_len = sqrtf(denom);
+    fm_vec3_t n_hat = n_cross / n_len;
+
+    fm_vec3_t r0    = P1 - E0;
+    float r0_dot    = fm_vec3_dot(&r0, &n_hat);
+    float vel_dot   = fm_vec3_dot(&dir, &n_hat); // dir is unit length
+
+    // Helper: verify both segment parameters are interior at a given t
+    auto resolve = [&](float t_phys) -> bool {
+      fm_vec3_t r0_t  = r0 + dir * t_phys;
+      float c_t       = fm_vec3_dot(&axis, &r0_t);
+      float f_t       = fm_vec3_dot(&d2, &r0_t);
+      float s_star    = (b * f_t - c_t * e_val) / denom; // [0,1] for interior
+      float u_star    = (a * f_t - b * c_t) / denom;      // [0,1] for interior
+      if (s_star <= PARAM_EPS || s_star >= 1.0f - PARAM_EPS) return false;
+      if (u_star < 0.0f || u_star > 1.0f) return false;
+      outP = E0 + d2 * u_star;
+      outN = (r0_dot >= 0.0f) ? n_hat : -n_hat;
+      return true;
+    };
+
+    if (fabsf(r0_dot) < radius) {
+      if (!resolve(0.0f)) return std::numeric_limits<float>::max();
+      outDepth = radius - fabsf(r0_dot);
+      return 0.0f;
+    }
+
+    if (fabsf(vel_dot) < SWEEP_EPS) return std::numeric_limits<float>::max();
+
+    float sign  = (r0_dot > 0.0f) ? 1.0f : -1.0f;
+    float t     = (sign * radius - r0_dot) / vel_dot;
+    if (t < 0.0f || t > dist) return std::numeric_limits<float>::max();
+    if (!resolve(t)) return std::numeric_limits<float>::max();
+    outDepth = 0.0f;
+    return t;
+  };
+
+  auto cylinderVertexTest = [&](const fm_vec3_t &V,
+    fm_vec3_t &outN, fm_vec3_t &outP, float &outDepth) -> float {
+    if (axisLength2 < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
+
+    // Decompose relative to capsule axis
+    fm_vec3_t w        = V - P1; // from P1 to vertex
+    float w_along      = fm_vec3_dot(&w, &axisUnit);
+    fm_vec3_t w_perp   = w - axisUnit * w_along;
+
+    float A      = dirPerpLength2;
+    float wperp2 = fm_vec3_len2(&w_perp);
+
+    float t;
+    if (wperp2 < radius * radius) {
+      // already within radius of the capsule axis line
+      t = 0.0f;
+      outDepth = radius - sqrtf(wperp2);
+    } else {
+      if (A < SWEEP_EPS * SWEEP_EPS) return std::numeric_limits<float>::max();
+      // dist_perp²(t) = |w_perp - t*dirPerp|²
+      float B    = fm_vec3_dot(&w_perp, &dirPerp);
+      float C    = wperp2 - radius * radius;
+      float disc = B * B - A * C;
+      if (disc < 0.0f) return std::numeric_limits<float>::max();
+      t = (B - sqrtf(disc)) / A; // smallest root
+      if (t < 0.0f) t = (B + sqrtf(disc)) / A;
+      if (t < 0.0f || t > dist) return std::numeric_limits<float>::max();
+      outDepth = 0.0f;
+    }
+
+    // Verify s is strictly interior (not at end caps)
+    fm_vec3_t w_t = w - dir * t; // V - P1(t)
+    float s       = fm_vec3_dot(&w_t, &axisUnit);
+    if (s <= PARAM_EPS || s >= axisLength - PARAM_EPS)
+      return std::numeric_limits<float>::max();
+
+    fm_vec3_t axis_pt = P1 + dir * t + axisUnit * s;
+    outP = V;
+    outN = vec3NormalizeOrFallback(axis_pt - V, -dir);
+    return t;
+  };
+
   for (const fm_vec3_t* S : {&P1, &P2}) {
     float t = sphereFaceTest(*S, radius, dir, dist, v0, v1, v2, triNormal, n, p, depth);
     update(t, n, p, depth);
 
     for (int i = 0; i < 3; ++i) {
-      t = sphereEdgeTest(*S, radius, dir, dist, *verts[i], *verts[(i+1)%3], n, p, depth);
+      t = sphereEdgeTest(*S, i, n, p, depth);
       update(t, n, p, depth);
     }
 
@@ -318,12 +319,12 @@ bool capsuleSweepTriangle(
   }
 
   for (int i = 0; i < 3; ++i) {
-    float t = cylinderEdgeTest(P1, P2, radius, dir, dist, *verts[i], *verts[(i+1)%3], n, p, depth);
+    float t = cylinderEdgeTest(*verts[i], *verts[(i+1)%3], n, p, depth);
     update(t, n, p, depth);
   }
 
   for (const fm_vec3_t* V : verts) {
-    float t = cylinderVertexTest(P1, P2, radius, dir, dist, *V, n, p, depth);
+    float t = cylinderVertexTest(*V, n, p, depth);
     update(t, n, p, depth);
   }
 

--- a/n64/engine/src/collision/collide.cpp
+++ b/n64/engine/src/collision/collide.cpp
@@ -1460,8 +1460,8 @@ namespace P64::Coll {
 
     // Query local-space mesh AABB tree for candidate triangles
     constexpr int MAX_CANDIDATES = 20; // arbitrary limit to avoid extreme cases
-    NodeProxy candidates[MAX_CANDIDATES];
-    int count = mesh.queryTriangleNodes(queryAABB, candidates, MAX_CANDIDATES);
+    uint16_t candidates[MAX_CANDIDATES];
+    int count = mesh.queryTriangles(queryAABB, candidates, MAX_CANDIDATES);
 
     if(count <= 0) return false;
 
@@ -1500,8 +1500,7 @@ namespace P64::Coll {
 
     // For every candidate triangle perform precise collision test
     for(int i = 0; i < count; ++i) {
-      int triIndex = mesh.triangleIndexForNode(candidates[i]);
-      if(triIndex < 0) continue;
+      const int triIndex = candidates[i];
 
       // If there is a collision between the collider and the current triangle and the collider is a Trigger
       // we can skip the rest of the candidates since triggers just need to report that a collision happened

--- a/n64/engine/src/collision/collisionScene.cpp
+++ b/n64/engine/src/collision/collisionScene.cpp
@@ -1740,13 +1740,10 @@ namespace P64::Coll {
         }};
 
 
-        NodeProxy triCandidates[RAYCAST_MAX_TRIANGLE_TESTS];
-        int triCount = mesh->aabbTree_.queryRay(localRay, triCandidates, RAYCAST_MAX_TRIANGLE_TESTS);
+        uint16_t triCandidates[RAYCAST_MAX_TRIANGLE_TESTS];
+        int triCount = mesh->queryTriangles(localRay, triCandidates, RAYCAST_MAX_TRIANGLE_TESTS);
         for(int i = 0; i < triCount; ++i) {
-          void *data = mesh->aabbTree_.getNodeData(triCandidates[i]);
-          if(!data) continue;
-          int triIdx = static_cast<int>(reinterpret_cast<intptr_t>(data)) - 1; // stored as index+1
-          if(triIdx < 0 || triIdx >= mesh->triangleCount_) continue;
+          const int triIdx = triCandidates[i];
 
           const MeshTriangleIndices &tri = mesh->triangles_[triIdx];
 
@@ -1875,7 +1872,7 @@ namespace P64::Coll {
     // ── Mesh colliders ──────────────────────────────────────────────────────
     if (doMesh) {
       constexpr int MAX_TRI = 64;
-      NodeProxy triCandidates[MAX_TRI];
+      uint16_t triCandidates[MAX_TRI];
       constexpr int MAX_MESH_CANDIDATES = 32;
       NodeProxy meshCandidates[MAX_MESH_CANDIDATES];
 
@@ -1887,11 +1884,10 @@ namespace P64::Coll {
         if ((mesh->writeMask() & readMask) == 0) continue;
 
         AABB localSweptBox = mesh->worldAabbToLocal(sweptBox);
-        int triCount = mesh->queryTriangleNodes(localSweptBox, triCandidates, MAX_TRI);
+        int triCount = mesh->queryTriangles(localSweptBox, triCandidates, MAX_TRI);
 
         for (int i = 0; i < triCount; ++i) {
-          int triIdx = mesh->triangleIndexForNode(triCandidates[i]);
-          if (triIdx < 0 || triIdx >= static_cast<int>(mesh->triangleCount())) continue;
+          const int triIdx = triCandidates[i];
 
           const MeshTriangleIndices& tri = mesh->triangleIndices(triIdx);
 
@@ -2043,7 +2039,7 @@ namespace P64::Coll {
     // ── Mesh colliders ──────────────────────────────────────────────────────
     if (doMesh) {
       constexpr int MAX_TRI = 64;
-      NodeProxy triCandidates[MAX_TRI];
+      uint16_t triCandidates[MAX_TRI];
       constexpr int MAX_MESH_CANDIDATES = 32;
       NodeProxy meshCandidates[MAX_MESH_CANDIDATES];
 
@@ -2055,11 +2051,10 @@ namespace P64::Coll {
         if ((mesh->writeMask() & readMask) == 0) continue;
 
         AABB localSweptBox = mesh->worldAabbToLocal(sweptBox);
-        int triCount = mesh->queryTriangleNodes(localSweptBox, triCandidates, MAX_TRI);
+        int triCount = mesh->queryTriangles(localSweptBox, triCandidates, MAX_TRI);
 
         for (int i = 0; i < triCount; ++i) {
-          int triIdx = mesh->triangleIndexForNode(triCandidates[i]);
-          if (triIdx < 0 || triIdx >= static_cast<int>(mesh->triangleCount())) continue;
+          const int triIdx = triCandidates[i];
 
           const MeshTriangleIndices& tri = mesh->triangleIndices(triIdx);
 
@@ -2069,8 +2064,7 @@ namespace P64::Coll {
           fm_vec3_t wn  = mesh->hasTransform() ? mesh->localNormalToWorld(mesh->triangleNormal(triIdx)) : mesh->triangleNormal(triIdx);
 
           candidate = SphereSweepHit{};
-          if (!sphereSweepTriangle(center, radius,
-                                    displacement, wv0, wv1, wv2, wn, candidate))
+          if (!sphereSweepTriangle(center, radius, displacement, wv0, wv1, wv2, wn, candidate))
             continue;
 
           if (!hit.didHit || candidate.t < hit.t ||

--- a/n64/engine/src/collision/meshCollider.cpp
+++ b/n64/engine/src/collision/meshCollider.cpp
@@ -7,25 +7,22 @@
 #include "collision/colliderShape.h"
 #include "scene/object.h"
 #include "collision/epa.h"
+#include "collision/meshBvhBuilder.h"
 
 namespace P64::Coll {
 
   namespace {
-    struct RawCollisionHeader {
-      uint32_t triCount;
-      uint32_t vertCount;
-      float collScale;
-      uint32_t vertexPtr;
-      uint32_t normalsPtr;
-      uint32_t bvhPtr;
-    };
+    static_assert(sizeof(fm_vec3_t) == 3 * sizeof(float));
+    static_assert(alignof(fm_vec3_t) <= 4);
+    static_assert(sizeof(MeshTriangleIndices) == 3 * sizeof(uint16_t));
 
-    struct PackedNormal {
-      int16_t v[3];
-    };
+    const char *alignPtr(const char *ptr, size_t alignment) {
+      return reinterpret_cast<const char *>((reinterpret_cast<uintptr_t>(ptr) + alignment - 1) & ~(alignment - 1));
+    }
 
-    char *alignPtr(char *ptr, size_t alignment) {
-      return reinterpret_cast<char *>((reinterpret_cast<uintptr_t>(ptr) + alignment - 1) & ~(alignment - 1));
+    AABB nodeBounds(const MeshBvhNode &node) {
+      return {fm_vec3_t{{node.min[0], node.min[1], node.min[2]}},
+              fm_vec3_t{{node.max[0], node.max[1], node.max[2]}}};
     }
   }
 
@@ -198,12 +195,9 @@ namespace P64::Coll {
   }
 
   void MeshCollider::computeLocalRootAabb() {
-    if(aabbTree_.root != NULL_NODE) {
-      const AABB *rootBounds = aabbTree_.getNodeBounds(aabbTree_.root);
-      if(rootBounds) {
-        localRootAabb_ = *rootBounds;
-        return;
-      }
+    if(triangleBvh_) {
+      localRootAabb_ = nodeBounds(triangleBvh_[0]);
+      return;
     }
     // Fallback: compute from vertices
     if(vertexCount_ == 0) return;
@@ -281,90 +275,61 @@ namespace P64::Coll {
     return {localCenter - localHalf, localCenter + localHalf};
   }
 
-  // ── Load Mesh Collider from Raw Data and build AABB Tree ────────────────────────────────────────
+  int MeshCollider::queryTriangles(const AABB &localBounds, uint16_t *outCandidates, int maxCandidates) const {
+    return queryMeshBvh(triangleBvh_, meshBvhNodeCount(triangleCount_), outCandidates, maxCandidates,
+      [&](const MeshBvhNode &node) { return aabbOverlap(nodeBounds(node), localBounds); });
+  }
 
-  MeshCollider *MeshCollider::createFromRawData(void *rawData, Object *obj) {
+  int MeshCollider::queryTriangles(const Raycast &localRay, uint16_t *outCandidates, int maxCandidates) const {
+    return queryMeshBvh(triangleBvh_, meshBvhNodeCount(triangleCount_), outCandidates, maxCandidates,
+      [&](const MeshBvhNode &node) { return aabbIntersectsRay(nodeBounds(node), localRay); });
+  }
+
+  // ── Load Mesh Collider with the BVH built by the Pyrite Editor ──────────────────────────────────
+
+  MeshCollider *MeshCollider::createFromRawData(const void *rawData, Object *obj) {
     if(!rawData) return nullptr;
     if(!obj) return nullptr;
 
-    auto *header = static_cast<RawCollisionHeader *>(rawData);
+    auto *header = static_cast<const RawCollisionHeader *>(rawData);
     if(header->triCount == 0 || header->vertCount == 0) return nullptr;
     if(header->triCount > 0xFFFFu || header->vertCount > 0xFFFFu) return nullptr;
 
-    char *data = reinterpret_cast<char *>(header + 1);
+    const char *data = reinterpret_cast<const char *>(header + 1);
 
-    auto *indexData = reinterpret_cast<uint16_t *>(data);
-    data += header->triCount * sizeof(uint16_t) * 3;
+    auto *indexData = reinterpret_cast<const MeshTriangleIndices *>(data);
+    data += header->triCount * sizeof(MeshTriangleIndices);
 
     data = alignPtr(data, 4);
-    auto *normalData = reinterpret_cast<PackedNormal *>(data);
+    auto *normalData = reinterpret_cast<const fm_vec3_t *>(data);
 
-    data += header->triCount * sizeof(PackedNormal);
+    data += header->triCount * sizeof(fm_vec3_t);
     data = alignPtr(data, 4);
-    auto *vertexData = reinterpret_cast<fm_vec3_t *>(data);
+    auto *vertexData = reinterpret_cast<const fm_vec3_t *>(data);
+
+    data += header->vertCount * sizeof(fm_vec3_t);
+    data = alignPtr(data, 4);
+    // Reject pre-BVH and packed-normal assets; rebuilding the ROM generates the current layout.
+    if(header->bvhOffset != static_cast<uint32_t>(data - static_cast<const char *>(rawData))) return nullptr;
 
     auto *collider = new MeshCollider();
 
     collider->triangleCount_ = static_cast<uint16_t>(header->triCount);
     collider->vertexCount_ = static_cast<uint16_t>(header->vertCount);
 
-    // Copy vertex data
-    collider->vertices_ = new fm_vec3_t[header->vertCount];
-    for(uint32_t i = 0; i < header->vertCount; ++i) {
-      collider->vertices_[i] = vertexData[i];
-    }
-
-    // Copy triangle indices
-    collider->triangles_ = new MeshTriangleIndices[header->triCount];
-    for(uint32_t t = 0; t < header->triCount; ++t) {
-      collider->triangles_[t].indices[0] = indexData[t * 3 + 0];
-      collider->triangles_[t].indices[1] = indexData[t * 3 + 1];
-      collider->triangles_[t].indices[2] = indexData[t * 3 + 2];
-    }
-
-    // Convert packed normals (int16_t scaled by 32767) to fm_vec3_t
-    constexpr float NORM_SCALE = 1.0f / 32767.0f;
-    collider->normals_ = new fm_vec3_t[header->triCount];
-    for(uint32_t t = 0; t < header->triCount; ++t) {
-      collider->normals_[t] = fm_vec3_t{{
-        static_cast<float>(normalData[t].v[0]) * NORM_SCALE,
-        static_cast<float>(normalData[t].v[1]) * NORM_SCALE,
-        static_cast<float>(normalData[t].v[2]) * NORM_SCALE
-      }};
-    }
+    collider->vertices_ = vertexData;
+    collider->triangles_ = indexData;
+    collider->normals_ = normalData;
 
     // Bind to owner object
     collider->owner_ = obj;
 
-    buildAabbTree(collider);
-    collider->syncOwnerTransform();
-
-    return collider;
-  }
-
-  // Build AABB tree from triangle bounding boxes
-  // Need 2*N-1 internal nodes for N leaves, plus some margin
-  void MeshCollider::buildAabbTree(MeshCollider* collider) {
-    int treeCapacity = static_cast<int>(collider->triangleCount_) * 2 + 1;
-    collider->aabbTree_.init(treeCapacity);
-
-    for(uint32_t t = 0; t < collider->triangleCount_; ++t) {
-      const fm_vec3_t &v0 = collider->vertices_[collider->triangles_[t].indices[0]];
-      const fm_vec3_t &v1 = collider->vertices_[collider->triangles_[t].indices[1]];
-      const fm_vec3_t &v2 = collider->vertices_[collider->triangles_[t].indices[2]];
-
-      AABB triAABB;
-      triAABB.min = vec3Min(vec3Min(v0, v1), v2);
-      triAABB.max = vec3Max(vec3Max(v0, v1), v2);
-
-      // Store triangle index + 1 as data pointer (index 0 would be nullptr and get skipped)
-      collider->aabbTree_.createNode(triAABB, reinterpret_cast<void *>(static_cast<intptr_t>(t + 1)));
-    }
-
+    collider->triangleBvh_ = reinterpret_cast<const MeshBvhNode *>(data);
     collider->computeLocalRootAabb();
-    // syncOwnerTransform() first because recalculateWorldAabb() depends on the cached has*() properties
     collider->syncOwnerTransform();
     collider->recalculateWorldAabb();
+
+    return collider;
   }
 
   MeshCollider* MeshCollider::create(fm_vec3_t* vertices, uint16_t vertexCount, MeshTriangleIndices* triangleIndices, uint16_t triangleCount, Object *owner) {
@@ -376,27 +341,41 @@ namespace P64::Coll {
     collider->triangles_ = triangleIndices;
     collider->triangleCount_ = triangleCount;
     collider->owner_ = owner;
+    collider->ownsGeometry_ = true;
 
-    collider->normals_ = new fm_vec3_t[triangleCount];
+    auto *normals = new fm_vec3_t[triangleCount];
+    collider->normals_ = normals;
     for (uint16_t t = 0; t < triangleCount; ++t) {
       const auto& indices = triangleIndices[t].indices;
       fm_vec3_t v0 = vertices[indices[0]];
       fm_vec3_t v1 = vertices[indices[1]];
       fm_vec3_t v2 = vertices[indices[2]];
-      collider->normals_[t] = triangleNormalFromVertices(v0, v1, v2);
+      normals[t] = triangleNormalFromVertices(v0, v1, v2);
     }
 
-    buildAabbTree(collider);
+    collider->ownedTriangleBvh_ = buildMeshBvh(triangleCount, [&](uint16_t t) {
+      const auto &indices = triangleIndices[t].indices;
+      const auto minV = vec3Min(vec3Min(vertices[indices[0]], vertices[indices[1]]), vertices[indices[2]]);
+      const auto maxV = vec3Max(vec3Max(vertices[indices[0]], vertices[indices[1]]), vertices[indices[2]]);
+      return MeshBvhNode{{minV.x, minV.y, minV.z}, {maxV.x, maxV.y, maxV.z}, 0};
+    });
+    collider->triangleBvh_ = collider->ownedTriangleBvh_.get();
+    collider->computeLocalRootAabb();
     collider->syncOwnerTransform();
+    collider->recalculateWorldAabb();
 
     return collider;
   }
 
   void MeshCollider::destroyData() {
-    aabbTree_.destroy();
-    delete[] vertices_;
-    delete[] triangles_;
-    delete[] normals_;
+    ownedTriangleBvh_.reset();
+    triangleBvh_ = nullptr;
+    if(ownsGeometry_) {
+      delete[] vertices_;
+      delete[] triangles_;
+      delete[] normals_;
+    }
+    ownsGeometry_ = false;
     vertices_ = nullptr;
     triangles_ = nullptr;
     normals_ = nullptr;

--- a/n64/engine/src/collision/sphereSweep.cpp
+++ b/n64/engine/src/collision/sphereSweep.cpp
@@ -3,8 +3,6 @@
 * @license MIT
 */
 #include "collision/sphereSweep.h"
-#include "collision/meshCollider.h"
-#include "collision/aabb.h"
 #include "collision/vecMath.h"
 
 #include <cmath>
@@ -162,9 +160,9 @@ bool sphereSweepTriangle(
   const fm_vec3_t& triNormal,
   SphereSweepHit& hit
 ) {
-  float dist = sqrtf(fm_vec3_len2(&displacement));
+  const float dist = sqrtf(fm_vec3_len2(&displacement));
   if (dist < SWEEP_EPS) return false;
-  fm_vec3_t dir = displacement / dist;
+  const fm_vec3_t dir = displacement / dist;
 
   float     bestT     = std::numeric_limits<float>::max();
   float     bestDepth = 0.0f;

--- a/n64/engine/src/scene/components/collMesh.cpp
+++ b/n64/engine/src/scene/components/collMesh.cpp
@@ -53,8 +53,10 @@ namespace P64::Comp
     void *rawData = AssetManager::getByIndex(initData->assetIdx);
     data->meshCollider = Coll::MeshCollider::createFromRawData(rawData, &obj);
 
+    assertf(data->meshCollider, "Invalid collision asset; rebuild the ROM with the current editor version to ensure the collision asset is up to date.");
+    if(!data->meshCollider) return;
     data->meshCollider->setCollisionMask(initData->maskRead, initData->maskWrite);
-    if(data->meshCollider && obj.isEnabled()) {
+    if(obj.isEnabled()) {
       obj.getScene().getCollision().addMeshCollider(data->meshCollider);
     }
   }

--- a/src/build/collisionBuilder.cpp
+++ b/src/build/collisionBuilder.cpp
@@ -2,25 +2,18 @@
 * @copyright 2025 - Max Bebök
 * @license MIT
 */
-#include "projectBuilder.h"
+#include <vector>
+#include <unordered_set>
 #include "../utils/binaryFile.h"
-#include "../utils/fs.h"
-#include "../project/assets/collision.h"
+#include "tiny3d/tools/gltf_importer/src/math/mat4.h"
 #include "tiny3d/tools/gltf_importer/src/cgltfHelper.h"
-#include "tiny3d/tools/gltf_importer/src/parser.h"
 #include "tiny3d/tools/gltf_importer/src/lib/cgltf.h"
-#include "tiny3d/tools/gltf_importer/src/optimizer/optimizer.h"
+#include "../../n64/engine/include/collision/meshBvhBuilder.h"
+#include <cstddef>
+#include <cmath>
 
 namespace
 {
-  struct CollisionMesh
-  {
-    std::vector<glm::vec3> verticesFloat{};
-    std::vector<glm::i16vec3> vertices{};
-    std::vector<glm::i16vec3> normals{};
-    std::vector<uint16_t> indices{};
-  };
-
   namespace {
     Mat4 parseNodeMatrix(const cgltf_node *node, const Vec3 &posScale)
     {
@@ -74,8 +67,7 @@ namespace
     cgltf_load_buffers(&options, data, gltfPath);
 
     std::vector<Vec3> verticesFloat{};
-    std::vector<glm::i16vec3> vertices{};
-    std::vector<glm::i16vec3> normals{};
+    std::vector<Vec3> normals{};
     std::vector<uint16_t> indices{};
 
     for(size_t i=0; i<data->nodes_count; ++i)
@@ -97,8 +89,7 @@ namespace
 
       for(size_t j = 0; j < mesh->primitives_count; j++)
       {
-        int baseIndex = vertices.size();
-        assert(baseIndex < 0x10000);
+        const size_t baseIndex = verticesFloat.size();
 
         auto prim = &mesh->primitives[j];
 
@@ -110,7 +101,9 @@ namespace
           auto elemSize = Gltf::getDataSize(acc->component_type);
 
           for(size_t k = 0; k < acc->count; k++) {
-            indices.push_back(baseIndex + Gltf::readAsU32(basePtr, acc->component_type));
+            const size_t index = baseIndex + Gltf::readAsU32(basePtr, acc->component_type);
+            if(index >= 0xFFFFu) throw std::runtime_error("Collision mesh exceeds 65535 vertices!");
+            indices.push_back(static_cast<uint16_t>(index));
             basePtr += elemSize;
           }
         }
@@ -129,11 +122,10 @@ namespace
 
               // collision geometry is exported in meters
               verticesFloat.push_back({vert[0], vert[1], vert[2]});
-              vertices.push_back({
-                (int16_t)vert[0],
-                (int16_t)vert[1],
-                (int16_t)vert[2]
-              });
+              if(verticesFloat.size() > 0xFFFFu) throw std::runtime_error("Collision mesh exceeds 65535 vertices!");
+              if(!std::isfinite(vert[0]) || !std::isfinite(vert[1]) || !std::isfinite(vert[2])) {
+                throw std::runtime_error("Collision mesh contains non-finite vertices!");
+              }
               basePtr += Gltf::getDataSize(acc->component_type) * 3;
             }
           }
@@ -141,6 +133,13 @@ namespace
 
       } // primitives
     } // nodes
+
+    if(indices.size() % 3 != 0 || indices.size() / 3 > 0xFFFFu) {
+      throw std::runtime_error("Collision mesh requires complete triangles and at most 65535 triangles!");
+    }
+    for(uint16_t index : indices) {
+      if(index >= verticesFloat.size()) throw std::runtime_error("Collision mesh has an invalid vertex index!");
+    }
 
     // generate normals
     for(size_t v=0; v<indices.size(); v+=3) {
@@ -160,31 +159,33 @@ namespace
 
       Vec3 normal = edge1.cross(edge2);
       normal = normal * (1.0f / normal.length());
-      normals.push_back({
-        (int16_t)(normal[0] * 32767.0f),
-        (int16_t)(normal[1] * 32767.0f),
-        (int16_t)(normal[2] * 32767.0f)
-      });
+      normals.push_back(normal);
     }
 
-    assert(indices.size() % 3 == 0);
+    const auto triangleCount = static_cast<uint16_t>(indices.size() / 3);
+    auto bvh = P64::Coll::buildMeshBvh(triangleCount, [&](uint16_t triangle) {
+      P64::Coll::MeshBvhNode bounds{};
+      for(int axis = 0; axis < 3; ++axis) {
+        const float a = verticesFloat[indices[triangle * 3]][axis];
+        const float b = verticesFloat[indices[triangle * 3 + 1]][axis];
+        const float c = verticesFloat[indices[triangle * 3 + 2]][axis];
+        bounds.min[axis] = std::min({a, b, c});
+        bounds.max[axis] = std::max({a, b, c});
+      }
+      return bounds;
+    });
 
-    // printf("Vert/Index count: %lu %lu\n", vertices.size(), indices.size());
-
+    const uint32_t headerPos = file.getPos();
     file.write<uint32_t>(indices.size() / 3);
-    file.write<uint32_t>(vertices.size());
+    file.write<uint32_t>(verticesFloat.size());
     file.write<float>(1.0f);
-    file.write<uint32_t>(0); // vertex pointer
-    file.write<uint32_t>(0); // normals pointer
-    file.write<uint32_t>(0); // BVH pointer (unused for now)
+    file.write<uint32_t>(0); // patched to the BVH offset below
 
     file.writeArray(indices.data(), indices.size());
     file.align(4);
 
     for(auto& n : normals) {
-      file.write(n.x);
-      file.write(n.y);
-      file.write(n.z);
+      file.writeArray(n.data, 3);
     }
     file.align(4);
 
@@ -192,6 +193,16 @@ namespace
       file.writeArray(v.data, 3);
     }
     file.align(4);
+
+    const uint32_t bvhOffset = file.getPos() - headerPos;
+    file.atPos(headerPos + offsetof(P64::Coll::RawCollisionHeader, bvhOffset), [&] {
+      file.write(bvhOffset);
+    });
+    for(uint32_t i = 0; i < P64::Coll::meshBvhNodeCount(triangleCount); ++i) {
+      file.writeArray(bvh[i].min, 3);
+      file.writeArray(bvh[i].max, 3);
+      file.write(bvh[i].escapeOrTriangle);
+    }
   }
 }
 


### PR DESCRIPTION
Change mesh-local triangle BVHs to build time. The triangle BVHs are always in mesh local space and don't need to be dynamic like the collision scene BVHs that contain moving objects and can thus save space and complexity. 
The results are faster scene loading times, much less RAM used and slight performance gains for the cost of small asset growth in the ROM. 
This commit also contains a small optimization in the Sweep (Capsule & Sphere) functions to avoid repeated work in the checks